### PR TITLE
fix: viewerの生HTML表示とPDFの自己PR重なりを修正＋再発防止テスト

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-syntax-highlighter": "^16.1.0",
         "rehype-pretty-code": "^0.14.1",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "rehype-slug": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
@@ -6395,6 +6396,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -9650,6 +9666,20 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-router-dom": "^7.9.5",
         "react-syntax-highlighter": "^16.1.0",
         "rehype-pretty-code": "^0.14.1",
+        "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
@@ -6357,6 +6358,43 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -6401,6 +6439,25 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9582,6 +9639,21 @@
       },
       "peerDependencies": {
         "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-slug": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-syntax-highlighter": "^16.1.0",
     "rehype-pretty-code": "^0.14.1",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "rehype-slug": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-router-dom": "^7.9.5",
     "react-syntax-highlighter": "^16.1.0",
     "rehype-pretty-code": "^0.14.1",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",

--- a/src/component/pdf/skill-sheet-document.test.tsx
+++ b/src/component/pdf/skill-sheet-document.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SkillSheetDocument } from './skill-sheet-document';
+import { shouldTableWrap } from './table-layout';
+
+describe('shouldTableWrap', () => {
+  // react-pdf の getWrap は wrap が undefined だと折返し不可になるため、
+  // wrap には必ず boolean を渡す必要がある（このバグの回帰防止）。
+  it('常に boolean を返す（undefined を返さない）', () => {
+    for (const n of [0, 1, 4, 5, 10, 40, 100]) {
+      expect(typeof shouldTableWrap(n)).toBe('boolean');
+    }
+  });
+
+  it('小さい表（4行以下）は折り返さない（false）', () => {
+    expect(shouldTableWrap(2)).toBe(false);
+    expect(shouldTableWrap(3)).toBe(false);
+    expect(shouldTableWrap(4)).toBe(false);
+  });
+
+  it('背の高い表（5行以上）は折り返す（true）— ページ高さ超過時のレイアウト崩れを防ぐ', () => {
+    expect(shouldTableWrap(5)).toBe(true);
+    expect(shouldTableWrap(11)).toBe(true);
+    expect(shouldTableWrap(40)).toBe(true);
+  });
+});
+
+describe('SkillSheetDocument', () => {
+  it('ページ高さを超えうる大きなテーブルを含む内容でもスローせず描画できる', () => {
+    const rows = Array.from({ length: 40 }, (_, i) => `| 技術${i} | ${i}年 |`).join('\n');
+    const content = `## スキル\n\n| 技術 | 年数 |\n| :--- | :--- |\n${rows}\n`;
+    const { container } = render(<SkillSheetDocument title="テスト" content={content} />);
+    expect(container).toBeDefined();
+  });
+
+  it('段落内ソフト改行を含む複数行パラグラフを描画できる', () => {
+    const content = ['段落1行目', '段落2行目', '', '次の段落'].join('\n');
+    const { container } = render(<SkillSheetDocument title="テスト" content={content} />);
+    expect(container).toBeDefined();
+  });
+});

--- a/src/component/pdf/skill-sheet-document.tsx
+++ b/src/component/pdf/skill-sheet-document.tsx
@@ -6,6 +6,7 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
 import PDF_FONT_FAMILY from './constants';
+import { shouldTableWrap } from './table-layout';
 
 // ビューア（src/theme/theme.ts のライトテーマ）に合わせたデザイントークン
 const COLOR = {
@@ -29,7 +30,6 @@ const NUM = {
   COL_LABEL_FLEX: 3,
   COL_VALUE_FLEX: 7,
   MIN_PRESENCE_PROJECT: 48,
-  SMALL_TABLE_MAX_ROWS: 4,
 } as const;
 
 const styles = StyleSheet.create({
@@ -285,11 +285,8 @@ function renderTable(node: MdNode, key: number): ReactNode {
   const columnCount = rows[0]?.children?.length ?? 0;
   if (columnCount === 0) return null;
   const align = node.align ?? [];
-  // 小さい表（概要・担当工程）は分割すると見栄えが悪いので 1 ブロックに保つ。
-  // 背の高い表（技術スタック等）は折り返しを許可し、ページ下部の余白を防ぐ。
-  const keepTogether = rows.length <= NUM.SMALL_TABLE_MAX_ROWS;
   return (
-    <View key={key} style={styles.table} wrap={keepTogether ? false : undefined}>
+    <View key={key} style={styles.table} wrap={shouldTableWrap(rows.length)}>
       {rows.map((row, ri) => (
         <View key={ri} style={styles.tableRow}>
           {(row.children ?? []).map((cell, ci) => renderTableCell(cell, ci, columnCount, align, ri === 0))}

--- a/src/component/pdf/table-layout.ts
+++ b/src/component/pdf/table-layout.ts
@@ -1,0 +1,16 @@
+// 1ブロックに保つ「小さい表」の最大行数。これを超える背の高い表はページ間で折り返す。
+export const SMALL_TABLE_MAX_ROWS = 4;
+
+/**
+ * 表をページ間で折り返してよいかを返す（必ず boolean）。
+ *
+ * 小さい表（概要・担当工程など）は分割すると見栄えが悪いので 1 ブロックに保つ（false）。
+ * 背の高い表（スキル表等）は折り返しを許可する（true）。
+ *
+ * 重要: react-pdf の getWrap は `'wrap' in props ? props.wrap : true` のため、
+ * `wrap={undefined}` を渡すと「キーは存在するが falsy」と判定され折返し不可になる。
+ * ページ高さを超える表が折返し不可だとレイアウト全体が崩れるため、必ず明示的な boolean を渡すこと。
+ */
+export function shouldTableWrap(rowCount: number): boolean {
+  return rowCount > SMALL_TABLE_MAX_ROWS;
+}

--- a/src/component/skill-sheet-viewer.test.tsx
+++ b/src/component/skill-sheet-viewer.test.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import SkillSheetViewer from './skill-sheet-viewer';
+
+// framer-motion はアニメーション専用 props を除いた素の要素に置換する
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: () => {
+        const Passthrough = ({ children, ...props }: { children?: ReactNode }) => {
+          const rest = { ...props } as Record<string, unknown>;
+          for (const key of ['initial', 'animate', 'transition', 'whileHover', 'whileTap', 'exit', 'variants']) {
+            delete rest[key];
+          }
+          return <div {...rest}>{children}</div>;
+        };
+        return Passthrough;
+      },
+    },
+  ),
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const DETAILS_CONTENT = `## テストセクション
+
+<details open>
+<summary><h2>スキル・経験年数</h2></summary>
+
+| 技術分類 | 技術名 |
+| :--- | :--- |
+| 言語 | TypeScript |
+
+</details>
+`;
+
+describe('SkillSheetViewer', () => {
+  it('生HTML（<details>/<summary>）を要素として描画し、生HTMLコードを文字列で表示しない', async () => {
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: DETAILS_CONTENT }} />);
+
+    // <summary> 内の見出しテキストが「要素」として描画されている
+    await waitFor(() => {
+      expect(screen.getByText('スキル・経験年数')).toBeInTheDocument();
+    });
+
+    // 生HTMLタグが文字列としてそのまま表示されていないこと（rehype-raw 回帰防止）
+    const root = document.querySelector('.markdown-content');
+    expect(root?.textContent ?? '').not.toContain('<summary');
+    expect(root?.textContent ?? '').not.toContain('<details');
+    expect(root?.textContent ?? '').not.toContain('display: inline');
+
+    // details 要素として描画されている
+    expect(document.querySelector('details')).not.toBeNull();
+    // テーブルも通常どおり描画される
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+  });
+});

--- a/src/component/skill-sheet-viewer.tsx
+++ b/src/component/skill-sheet-viewer.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 
 import { Box, Container, Paper, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { motion } from 'framer-motion';
+import rehypeRaw from 'rehype-raw';
 import rehypeSlug from 'rehype-slug';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
@@ -263,7 +264,7 @@ const SkillSheetViewer = ({ skillSheet }: SkillSheetViewerProps) => {
           >
             <ReactMarkdown
               remarkPlugins={[remarkGfm, remarkBreaks]}
-              rehypePlugins={[rehypeSlug]}
+              rehypePlugins={[rehypeRaw, rehypeSlug]}
               components={{
                 code(props) {
                   const { className, children, ...rest } = props;

--- a/src/component/skill-sheet-viewer.tsx
+++ b/src/component/skill-sheet-viewer.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import { Box, Container, Paper, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { motion } from 'framer-motion';
 import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeSlug from 'rehype-slug';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
@@ -29,6 +30,17 @@ interface SkillSheetViewerProps {
 }
 
 const SIDEBAR_WIDTH = 280;
+
+// rehype-raw が有効化する生HTML描画を details/summary タグに限定する。
+// style属性はデフォルトスキーマで除外済み（XSS防止）。
+const SANITIZE_SCHEMA = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary'],
+  attributes: {
+    ...defaultSchema.attributes,
+    details: ['open'],
+  },
+};
 
 const SkillSheetViewer = ({ skillSheet }: SkillSheetViewerProps) => {
   const [headings, setHeadings] = useState<Heading[]>([]);
@@ -264,7 +276,7 @@ const SkillSheetViewer = ({ skillSheet }: SkillSheetViewerProps) => {
           >
             <ReactMarkdown
               remarkPlugins={[remarkGfm, remarkBreaks]}
-              rehypePlugins={[rehypeRaw, rehypeSlug]}
+              rehypePlugins={[rehypeRaw, [rehypeSanitize, SANITIZE_SCHEMA], rehypeSlug]}
               components={{
                 code(props) {
                   const { className, children, ...rest } = props;


### PR DESCRIPTION
## 概要
本番リリース後に報告された2件の不具合を修正し、再発防止テストを追加しました。

## 1. PDFの自己PRセクションが重なって崩れる問題（根本原因を特定）
- **原因**: 背の高いスキル表（40行・約969pt）が `wrap={undefined}` で描画されていた。react-pdf の `getWrap` は `'wrap' in props ? props.wrap : true` という実装のため、**`wrap={undefined}` を渡すと「キーは存在するが falsy」→ 折返し不可(false)** と判定される。ページ高さ(約749pt)を超える表が折返し不可になり、`Node of type VIEW can't wrap between pages…` を出してページ全体のレイアウトが破綻、上にある自己PRの段落が重畳していた。
- **修正**: 折返し判定を **`shouldTableWrap()`（必ず boolean を返す純粋関数）** に切り出し（`src/component/pdf/table-layout.ts`）、`wrap` に明示的な boolean を渡すよう変更。`bbox` 解析でページ1の重なり 0 件、全39ページの目視で崩れ無しを確認。

## 2. ビューアで生HTML（`<details>/<summary>`）がそのまま表示される問題
- **原因**: `ReactMarkdown`（react-markdown v10）が `rehype-raw` 未使用で生HTMLを描画できていなかった。
- **修正**: `rehypePlugins={[rehypeRaw, rehypeSlug]}` に変更し、`<details open><summary><h2>スキル・経験年数</h2></summary>` を**折りたたみ見出し**として正しく描画。

## 3. 再発防止テスト（ご要望）
- `shouldTableWrap`: 常に boolean を返す / 小さい表は false・大きい表は true（wrap=undefined 回帰を防止）。
- `SkillSheetDocument`: ページ高さを超える大きな表・段落内ソフト改行でもスローせず描画。
- `SkillSheetViewer`: `<details>` を**要素として**描画し、生HTML文字列（`<summary` 等）を表示しない（rehype-raw 回帰を防止）。

## 検証
- `npm run build`（tsc -b && vite build）成功。新規テスト6件含め全通過（既存の `code-block.test.tsx` 5失敗は本PR対象外・無関係）。
- 実 `skillsheet.md` を Node ヘッドレス生成 → `pdftoppm` で自己PR含む複数ページを目視＝重なり解消・他ページ正常を確認。

https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill sheet viewer now supports raw HTML in markdown (enables details/summary and richer formatting, safely sanitized).

* **Improvements**
  * PDF table layout improved to better control table wrapping and pagination for large and small tables.

* **Tests**
  * Added tests covering PDF rendering and the skill sheet viewer to validate table behavior and HTML/markdown rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->