### PR TITLE
feat(builder): D&Dスキルシートビルダー MVP（配置・並替・編集・削除・保存）

### DIFF
--- a/apps/web/app/builder/actions.ts
+++ b/apps/web/app/builder/actions.ts
@@ -1,0 +1,31 @@
+'use server';
+
+import { saveSkillSheetBlocks } from '@skillsheet/db';
+
+import { isEditor } from '@/server/auth-gate';
+
+export interface SaveResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * ビルダーのブロック（順序付き markdown 配列）を DB に保存する。
+ * Server Action 内でも認可を再検証する（多層防御。proxy 任せにしない）。
+ */
+export async function saveBlocksAction(markdowns: string[]): Promise<SaveResult> {
+  if (!(await isEditor())) {
+    return { ok: false, error: 'unauthorized' };
+  }
+  if (!Array.isArray(markdowns) || markdowns.some((m) => typeof m !== 'string')) {
+    return { ok: false, error: 'invalid payload' };
+  }
+
+  try {
+    await saveSkillSheetBlocks(markdowns);
+    return { ok: true };
+  } catch (err) {
+    console.error('saveBlocksAction failed:', err);
+    return { ok: false, error: 'save failed' };
+  }
+}

--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BuilderClient from './builder-client';
+
+// 重いビューア（lightbox/IntersectionObserver 依存）はプレビュー描画を素朴にモック
+vi.mock('@/component/skill-sheet-viewer', () => ({
+  default: ({ skillSheet }: { skillSheet: { content: string } }) => (
+    <div data-testid="preview">{skillSheet.content}</div>
+  ),
+}));
+
+const mockSave = vi.fn().mockResolvedValue({ ok: true });
+vi.mock('./actions', () => ({
+  saveBlocksAction: (markdowns: string[]) => mockSave(markdowns),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+describe('BuilderClient', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('初期ブロックがテキストエリアとして表示される', () => {
+    render(<BuilderClient initialMarkdowns={['## A', '## B']} />);
+    const areas = screen.getAllByPlaceholderText('Markdown を入力...') as HTMLTextAreaElement[];
+    expect(areas).toHaveLength(2);
+    expect(areas[0].value).toBe('## A');
+    expect(areas[1].value).toBe('## B');
+  });
+
+  it('「ブロック追加」で空ブロックが増える', async () => {
+    const user = userEvent.setup();
+    render(<BuilderClient initialMarkdowns={['## A']} />);
+    await user.click(screen.getByRole('button', { name: 'ブロック追加' }));
+    expect(screen.getAllByPlaceholderText('Markdown を入力...')).toHaveLength(2);
+  });
+
+  it('削除ボタンでブロックが減る', async () => {
+    const user = userEvent.setup();
+    render(<BuilderClient initialMarkdowns={['## A', '## B']} />);
+    await user.click(screen.getAllByLabelText('ブロックを削除')[0]);
+    const areas = screen.getAllByPlaceholderText('Markdown を入力...') as HTMLTextAreaElement[];
+    expect(areas).toHaveLength(1);
+    expect(areas[0].value).toBe('## B');
+  });
+
+  it('保存ボタンで現在のブロックが saveBlocksAction に渡る', async () => {
+    const user = userEvent.setup();
+    render(<BuilderClient initialMarkdowns={['## A']} />);
+    await user.click(screen.getByRole('button', { name: /保存/ }));
+    expect(mockSave).toHaveBeenCalledWith(['## A']);
+  });
+
+  it('プレビューに連結 Markdown が反映される', () => {
+    render(<BuilderClient initialMarkdowns={['## A', '## B']} />);
+    expect(screen.getByTestId('preview')).toHaveTextContent('## A ## B');
+  });
+});

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useRef, useState, useTransition } from 'react';
+
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Eye, EyeOff, GripVertical, Plus, Save, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import SkillSheetViewer from '@/component/skill-sheet-viewer';
+import { Button } from '@/components/ui/button';
+
+import { saveBlocksAction } from './actions';
+
+interface BlockItem {
+  id: string;
+  markdown: string;
+}
+
+interface BuilderClientProps {
+  initialMarkdowns: string[];
+}
+
+const newId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `b-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const SortableBlock = ({
+  item,
+  onChange,
+  onDelete,
+}: {
+  item: BlockItem;
+  onChange: (id: string, markdown: string) => void;
+  onDelete: (id: string) => void;
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex gap-2 rounded-lg border border-border bg-card p-3 shadow-sm"
+    >
+      <button
+        type="button"
+        className="mt-1 cursor-grab touch-none text-muted-foreground active:cursor-grabbing"
+        aria-label="ブロックを並べ替え"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-5" />
+      </button>
+      <textarea
+        value={item.markdown}
+        onChange={(e) => onChange(item.id, e.target.value)}
+        rows={Math.min(12, Math.max(3, item.markdown.split('\n').length))}
+        className="min-w-0 flex-1 resize-y rounded-md border border-input bg-background p-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        placeholder="Markdown を入力..."
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onDelete(item.id)}
+        aria-label="ブロックを削除"
+        className="mt-0.5 shrink-0 text-muted-foreground hover:text-destructive"
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </div>
+  );
+};
+
+const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
+  const [items, setItems] = useState<BlockItem[]>(() =>
+    initialMarkdowns.map((markdown) => ({ id: newId(), markdown })),
+  );
+  const [showPreview, setShowPreview] = useState(true);
+  const [isSaving, startSaving] = useTransition();
+  const savedRef = useRef(false);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const previewContent = useMemo(() => items.map((i) => i.markdown).join('\n'), [items]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setItems((prev) => {
+      const oldIndex = prev.findIndex((i) => i.id === active.id);
+      const newIndex = prev.findIndex((i) => i.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(oldIndex, 1);
+      next.splice(newIndex, 0, moved);
+      return next;
+    });
+  };
+
+  const updateBlock = (id: string, markdown: string) =>
+    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, markdown } : i)));
+
+  const deleteBlock = (id: string) => setItems((prev) => prev.filter((i) => i.id !== id));
+
+  const addBlock = () => setItems((prev) => [...prev, { id: newId(), markdown: '' }]);
+
+  const handleSave = () => {
+    startSaving(async () => {
+      const res = await saveBlocksAction(items.map((i) => i.markdown));
+      if (res.ok) {
+        savedRef.current = true;
+        toast.success('保存しました');
+      } else if (res.error === 'unauthorized') {
+        toast.error('セッションが切れました。再度認証してください。');
+      } else {
+        toast.error('保存に失敗しました');
+      }
+    });
+  };
+
+  return (
+    <div className="min-h-screen">
+      <header className="no-print sticky top-0 z-40 border-b border-border bg-card/80 backdrop-blur-md">
+        <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
+          <h1 className="text-lg font-bold">スキルシートビルダー</h1>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setShowPreview((v) => !v)}>
+              {showPreview ? <EyeOff className="mr-1.5 size-4" /> : <Eye className="mr-1.5 size-4" />}
+              プレビュー
+            </Button>
+            <Link href="/view" className="text-sm text-muted-foreground hover:text-foreground">
+              閲覧へ
+            </Link>
+            <Button onClick={handleSave} disabled={isSaving}>
+              <Save className="mr-1.5 size-4" />
+              {isSaving ? '保存中...' : '保存'}
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-2">
+        {/* エディタ */}
+        <div className="space-y-3">
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={items.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+              <div className="space-y-3">
+                {items.map((item) => (
+                  <SortableBlock key={item.id} item={item} onChange={updateBlock} onDelete={deleteBlock} />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+
+          {items.length === 0 && (
+            <p className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+              ブロックがありません。「ブロック追加」で作成してください。
+            </p>
+          )}
+
+          <Button variant="outline" onClick={addBlock} className="w-full">
+            <Plus className="mr-1.5 size-4" />
+            ブロック追加
+          </Button>
+        </div>
+
+        {/* ライブプレビュー */}
+        {showPreview && (
+          <div className="rounded-lg border border-border bg-card">
+            <div className="border-b border-border px-4 py-2 text-sm font-medium text-muted-foreground">
+              プレビュー
+            </div>
+            <SkillSheetViewer skillSheet={{ title: 'プレビュー', content: previewContent }} compareMode />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BuilderClient;

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo, useRef, useState, useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 
 import {
   DndContext,
@@ -94,8 +94,10 @@ const SortableBlock = ({
 };
 
 const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
+  // 初期ブロックの ID は SSR/CSR で一致させるためインデックス基準の安定値にする
+  // （newId() は乱数/時刻依存でハイドレーション不整合を起こす）。追加ブロックのみ newId()。
   const [items, setItems] = useState<BlockItem[]>(() =>
-    initialMarkdowns.map((markdown) => ({ id: newId(), markdown })),
+    initialMarkdowns.map((markdown, index) => ({ id: `block-${index}`, markdown })),
   );
   const [showPreview, setShowPreview] = useState(true);
   const [isSaving, startSaving] = useTransition();
@@ -106,7 +108,16 @@ const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  const previewContent = useMemo(() => items.map((i) => i.markdown).join('\n'), [items]);
+  // プレビューは重い（Markdown パース＋ハイライト）ため、入力のたびではなく
+  // 300ms デバウンスして更新し、タイピングのラグを防ぐ。初期値は即時反映。
+  const [previewContent, setPreviewContent] = useState(() => items.map((i) => i.markdown).join('\n'));
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setPreviewContent(items.map((i) => i.markdown).join('\n'));
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [items]);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;

--- a/apps/web/app/builder/page.tsx
+++ b/apps/web/app/builder/page.tsx
@@ -1,0 +1,30 @@
+import { type Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+import { getSkillSheet } from '@skillsheet/db';
+
+import { isEditor } from '@/server/auth-gate';
+
+import BuilderClient from './builder-client';
+
+export const metadata: Metadata = {
+  title: 'スキルシートビルダー | エンジニアスキルシート',
+};
+
+// cookies() に依存するため動的レンダリング（ビルド時プリレンダ対象外）。
+export default async function BuilderPage() {
+  if (!(await isEditor())) {
+    redirect('/viewer-auth?next=/builder');
+  }
+
+  let initialMarkdowns: string[] = [];
+  try {
+    const sheet = await getSkillSheet();
+    initialMarkdowns = sheet.blocks.map((b) => b.data.markdown);
+  } catch (err) {
+    // DB/GitHub 未設定や疎通失敗時は空のビルダーから開始する（保存で作成できる）。
+    console.error('Failed to load sheet for builder:', err);
+  }
+
+  return <BuilderClient initialMarkdowns={initialMarkdowns} />;
+}

--- a/apps/web/app/viewer-auth/page.tsx
+++ b/apps/web/app/viewer-auth/page.tsx
@@ -30,7 +30,10 @@ const ViewerAuthPage = () => {
       });
 
       if (res.ok) {
-        router.push('/view');
+        // 認証後の遷移先。?next= が内部パスのときのみ許可（オープンリダイレクト防止）。
+        const next = new URLSearchParams(window.location.search).get('next');
+        const dest = next && next.startsWith('/') && !next.startsWith('//') ? next : '/view';
+        router.push(dest);
         return;
       }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/apps/web/src/server/auth-gate.ts
+++ b/apps/web/src/server/auth-gate.ts
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+
+import { SESSION_COOKIE_NAME, verifySessionToken } from './session';
+
+/**
+ * 編集者（オーナー）認可の単一チェックポイント（DAL）。
+ * 公開閲覧は誰でも可だが、ビルダーでの編集・保存はセッション cookie を要求する。
+ * proxy/middleware ではなくサーバー側のこの関数で都度検証する（多層防御・CVE-2025-29927 回避）。
+ *
+ * 当面は閲覧コード（VIEWER_CODE）で発行したセッションを編集ゲートに流用する
+ * （プラン「まず自分専用」）。Phase 3 で Better Auth に置き換える。
+ */
+export async function isEditor(): Promise<boolean> {
+  const store = await cookies();
+  return verifySessionToken(store.get(SESSION_COOKIE_NAME)?.value);
+}

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -7,7 +7,7 @@
  *
  * Server-only. Never import this from a Client Component.
  */
-import { asc, eq } from 'drizzle-orm';
+import { asc, eq, sql } from 'drizzle-orm';
 
 import { type Block, blocksToMarkdown, splitMarkdownIntoBlocks } from './blocks';
 import { type Database, getDb } from './client';
@@ -112,4 +112,27 @@ export async function getSkillSheet(): Promise<SkillSheet> {
   return { title: TITLE, content: blocksToMarkdown(blockList), blocks: blockList };
 }
 
-export { OWNER_ID, TITLE };
+/**
+ * Replace the owner's sheet blocks with the given ordered markdown segments
+ * (D&D builder save path). Empty/whitespace-only segments are dropped.
+ *
+ * neon-http has no interactive transactions, so this does delete-all then
+ * insert; for a single-owner builder the brief window is acceptable and the
+ * (sheet_id, order) unique constraint is never violated because we clear first.
+ */
+export async function saveSkillSheetBlocks(markdowns: string[]): Promise<void> {
+  const db = getDb()
+  const sheetId = await getOrCreateSheetId(db)
+
+  const cleaned = markdowns.map((m) => m.trimEnd()).filter((m) => m.trim().length > 0)
+
+  await db.delete(blocks).where(eq(blocks.sheetId, sheetId))
+  if (cleaned.length > 0) {
+    await db
+      .insert(blocks)
+      .values(cleaned.map((markdown, order) => ({ sheetId, type: 'markdown' as const, order, data: { markdown } })))
+  }
+  await db.update(skillSheets).set({ updatedAt: sql`now()` }).where(eq(skillSheets.id, sheetId))
+}
+
+export { OWNER_ID, TITLE }

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -116,9 +116,10 @@ export async function getSkillSheet(): Promise<SkillSheet> {
  * Replace the owner's sheet blocks with the given ordered markdown segments
  * (D&D builder save path). Empty/whitespace-only segments are dropped.
  *
- * neon-http has no interactive transactions, so this does delete-all then
- * insert; for a single-owner builder the brief window is acceptable and the
- * (sheet_id, order) unique constraint is never violated because we clear first.
+ * delete→insert→update を1つのトランザクションで囲み原子性を保証する
+ * （途中失敗で旧ブロックだけ消える＝データ損失を防ぐ）。neon-http は
+ * 対話的トランザクションは非対応だが、このようなバッチ（中間読み取り無し）の
+ * transaction() はサポートされる。
  */
 export async function saveSkillSheetBlocks(markdowns: string[]): Promise<void> {
   const db = getDb()
@@ -126,13 +127,15 @@ export async function saveSkillSheetBlocks(markdowns: string[]): Promise<void> {
 
   const cleaned = markdowns.map((m) => m.trimEnd()).filter((m) => m.trim().length > 0)
 
-  await db.delete(blocks).where(eq(blocks.sheetId, sheetId))
-  if (cleaned.length > 0) {
-    await db
-      .insert(blocks)
-      .values(cleaned.map((markdown, order) => ({ sheetId, type: 'markdown' as const, order, data: { markdown } })))
-  }
-  await db.update(skillSheets).set({ updatedAt: sql`now()` }).where(eq(skillSheets.id, sheetId))
+  await db.transaction(async (tx) => {
+    await tx.delete(blocks).where(eq(blocks.sheetId, sheetId))
+    if (cleaned.length > 0) {
+      await tx
+        .insert(blocks)
+        .values(cleaned.map((markdown, order) => ({ sheetId, type: 'markdown' as const, order, data: { markdown } })))
+    }
+    await tx.update(skillSheets).set({ updatedAt: sql`now()` }).where(eq(skillSheets.id, sheetId))
+  })
 }
 
 export { OWNER_ID, TITLE }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -321,6 +330,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -4776,6 +4807,31 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
   '@drizzle-team/brocli@0.10.2': {}
 
   '@emnapi/core@1.10.0':
@@ -6825,8 +6881,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -6848,7 +6904,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6859,22 +6915,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6885,7 +6941,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
## 概要

ユーザー要望の核である **D&D スキルシートビルダー（Issue③）の MVP** を実装します。年数表/プロジェクト等のブロックを **ドラッグ＆ドロップで配置・並べ替え・編集・削除し、保存**できます。

> **認可方針（MVP）**
> 既存のセッション機構（`SESSION_SECRET` / `/viewer-auth`）を**編集ゲートに転用**します（新シークレット不要・Phase 2 で温存したコードを実用化）。プラン「まず自分専用」に沿い、当面は閲覧コードで発行したセッションを編集ゲートに使い、後続で **Better Auth** に置き換えます。

## やったこと

- **`app/builder/page.tsx`**（RSC）: `isEditor()` で認可。未認証は `/viewer-auth?next=/builder` へリダイレクト。既存 Neon DB のブロックを `getSkillSheet()` で読み込み（空でも起動可）
- **`app/builder/builder-client.tsx`**（`'use client'`）: `@dnd-kit` でブロック並べ替え（`SortableContext`・キーボード操作対応）、追加・インライン編集（markdown textarea）・削除、**ライブプレビュー**（`SkillSheetViewer` 再利用）
- **`app/builder/actions.ts`**（Server Action）: `saveBlocksAction`。アクション内で `isEditor()` を**再検証**（多層防御・proxy 任せにしない）し、`saveSkillSheetBlocks` で永続化
- **`src/server/auth-gate.ts`**: 編集者認可の単一チェックポイント（DAL）
- **`packages/db`**: `saveSkillSheetBlocks(markdowns)` を追加（オーナーのブロックを置換保存。`(sheet_id, order)` ユニーク制約と整合するよう delete→insert）
- **`viewer-auth`**: `?next=` を**内部パスのみ許可**（オープンリダイレクト防止）しつつ認証後に元のページへ戻す
- 依存追加: `@dnd-kit/core` / `@dnd-kit/sortable` / `@dnd-kit/utilities`

## 挙動確認・テスト

- ✅ `pnpm -r type-check` 全通過
- ✅ `next build` 成功（`/builder` = 動的・cookies 依存）
- ✅ `vitest` 68テスト全グリーン（ビルダー 5件追加：初期表示・追加・削除・保存ペイロード・プレビュー連結）
- ✅ `eslint` 0 errors
- ✅ 実機（`next start`）：未認証 `/builder` → 307 `/viewer-auth?next=/builder` リダイレクトを確認

## 必要な環境変数（既存・追加なし）

`SESSION_SECRET`・`VIEWER_CODE`・`DATABASE_URL`・`GITHUB_*`（いずれも設定済み）。**新規シークレットは不要**です。

## 対応しないこと（後続）

- 公開ビュー（`/view`）の **DB 読取への統一**（保存→公開ビュー反映）。現状 `/view` は GitHub の .md を読むため、ビルダー保存はビルダー内ライブプレビューに反映（DB 永続化は完了）
- **Better Auth** による編集ゲート置換（Phase 3）
- **型付きブロック**（年数表・プロジェクトカードの専用フォーム）。MVP は汎用 markdown ブロック
- tRPC/oRPC 経由の保存 API 化（Phase 4）

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy)_