### PR TITLE
fix: run CI jobs on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   node:
     name: Node (${{ matrix.check-type }})
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 概要

`if: github.event.pull_request.draft == false` の条件が push イベントでは `false` と評価されるため、main へのマージ後の CI が全ジョブスキップ → `failure` になっていたのを修正。

## 変更点

```yaml
# Before
if: github.event.pull_request.draft == false

# After
if: github.event_name == 'push' || github.event.pull_request.draft == false
```

push イベント（main への push）では常に実行、PR イベントではドラフト以外で実行。

https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy)_