### PR TITLE
feat: Better Auth統合 + Biome移行 + Storybook 10 + /login ページ

### DIFF
--- a/apps/web/app/builder/page.tsx
+++ b/apps/web/app/builder/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 export default async function BuilderPage() {
   await connection();
   if (!(await isEditor())) {
-    redirect('/viewer-auth?next=/builder');
+    redirect('/login?next=/builder');
   }
 
   let initialMarkdowns: string[] = [];

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { LogIn } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { signIn } from '@/lib/auth-client';
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const result = await signIn.email({ email, password });
+      if (result.error) {
+        setError('メールアドレスまたはパスワードが正しくありません');
+        return;
+      }
+      const next = searchParams.get('next');
+      const dest = next?.startsWith('/') && !next.startsWith('//') ? next : '/builder';
+      router.push(dest);
+    } catch {
+      setError('ログインに失敗しました。もう一度お試しください。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <motion.form
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: 0.5 }}
+      onSubmit={(e) => {
+        void handleSubmit(e);
+      }}
+      className="space-y-4"
+    >
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+      <div className="space-y-1.5">
+        <label htmlFor="email" className="text-sm font-medium">
+          メールアドレス
+        </label>
+        <Input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+          placeholder="editor@example.com"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <label htmlFor="password" className="text-sm font-medium">
+          パスワード
+        </label>
+        <Input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          autoComplete="current-password"
+        />
+      </div>
+      <Button type="submit" variant="gradient" size="lg" className="w-full" disabled={loading}>
+        {loading ? 'ログイン中...' : 'ログイン'}
+      </Button>
+      <p className="text-center text-sm text-muted-foreground">
+        閲覧のみの場合は{' '}
+        <Link href="/viewer-auth" className="text-primary underline underline-offset-2">
+          閲覧コード認証
+        </Link>
+      </p>
+    </motion.form>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-linear-to-br from-primary to-secondary px-4">
+      <motion.div
+        aria-hidden
+        animate={{ scale: [1, 1.2, 1], rotate: [0, 180, 360] }}
+        transition={{ duration: 20, repeat: Number.POSITIVE_INFINITY, ease: 'linear' }}
+        className="pointer-events-none absolute -right-[10%] -top-[10%] size-[400px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.2)_0%,transparent_70%)]"
+      />
+      <motion.div
+        aria-hidden
+        animate={{ scale: [1, 1.3, 1], rotate: [360, 180, 0] }}
+        transition={{ duration: 25, repeat: Number.POSITIVE_INFINITY, ease: 'linear' }}
+        className="pointer-events-none absolute -bottom-[15%] -left-[10%] size-[360px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.15)_0%,transparent_70%)]"
+      />
+      <motion.div
+        initial={{ opacity: 0, y: 50, scale: 0.9 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.6, ease: [0.43, 0.13, 0.23, 0.96] }}
+        className="relative z-10 w-full max-w-md"
+      >
+        <Card className="border-white/20 bg-card/95 shadow-elevation-8 backdrop-blur-md">
+          <CardContent className="p-8">
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ delay: 0.3, type: 'spring', stiffness: 200 }}
+              className="mb-4 flex justify-center"
+            >
+              <div className="flex size-20 items-center justify-center rounded-full bg-linear-to-br from-primary to-secondary shadow-elevation-4">
+                <LogIn className="size-10 text-white" />
+              </div>
+            </motion.div>
+            <motion.h1
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.4 }}
+              className="text-center text-2xl font-bold"
+            >
+              編集者ログイン
+            </motion.h1>
+            <motion.p
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.45 }}
+              className="mb-6 mt-2 text-center text-sm text-muted-foreground"
+            >
+              スキルシートビルダーへのアクセス
+            </motion.p>
+            <Suspense>
+              <LoginForm />
+            </Suspense>
+          </CardContent>
+        </Card>
+      </motion.div>
+    </div>
+  );
+}

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -55,6 +55,7 @@ const SkillSheetViewer = ({ skillSheet, compareMode = false }: SkillSheetViewerP
   const headingIds = headings.map((h) => h.id);
   const activeId = useActiveHeading(headingIds);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: skillSheet.content はReactMarkdown経由でDOMに反映されるため、DOM再抽出のトリガーとして必要
   useEffect(() => {
     // レンダリング後にDOMから見出しを抽出
     const extractHeadingsFromDOM = () => {
@@ -81,7 +82,7 @@ const SkillSheetViewer = ({ skillSheet, compareMode = false }: SkillSheetViewerP
 
     // 初回とcontent変更時にDOMから見出しを抽出
     extractHeadingsFromDOM();
-  }, []);
+  }, [skillSheet.content]);
 
   const scrollToHeading = (id: string) => {
     // IDにCSS特殊文字が含まれる可能性があるため、querySelector ではなく getElementById を使用
@@ -141,17 +142,13 @@ const SkillSheetViewer = ({ skillSheet, compareMode = false }: SkillSheetViewerP
                 },
                 img({ src, alt, ...props }) {
                   return (
-                    <img
-                      src={src}
-                      alt={alt}
-                      {...props}
+                    <button
+                      type="button"
                       onClick={() => typeof src === 'string' && handleImageClick(src)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && typeof src === 'string') {
-                          handleImageClick(src);
-                        }
-                      }}
-                    />
+                      className="cursor-zoom-in border-0 bg-transparent p-0"
+                    >
+                      <img src={src} alt={alt} {...props} />
+                    </button>
                   );
                 },
               }}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -19,8 +19,10 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 function createAuth() {
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error('DATABASE_URL is not set');
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) throw new Error('BETTER_AUTH_SECRET is not set');
   return betterAuth({
-    secret: process.env.BETTER_AUTH_SECRET,
+    secret,
     baseURL: process.env.BETTER_AUTH_URL,
     database: drizzleAdapter(createDb(url), {
       provider: 'pg',


### PR DESCRIPTION
## 概要

ロードマップの複数項目を一括実装。

## やったこと

### Better Auth 統合
- `better-auth` v1.6.18 を導入し、email/password 認証を実装
- `DATABASE_URL` はランタイム専用のため lazy singleton パターンで初期化（ビルド時の評価を回避）
- `/app/api/auth/[...all]/route.ts` — Better Auth ハンドラをリクエストごとに lazy invoke
- `/app/login/page.tsx` — 編集者向けログインページ（グラデーションデザイン、`?next=` リダイレクト対応）
- `/builder` の認証ゲートを `/login?next=/builder` へ変更
- `await connection()` で `/builder` の静的プリレンダリングを回避

### HMAC フォールバック認証維持
- `/viewer-auth` — 既存の閲覧コード認証は引き続き動作
- `/login` から `/viewer-auth` へのリンクを追加

### Biome 移行（ESLint + Prettier 置き換え）
- Biome 2.5.0 を導入、ESLint + Prettier を削除
- CSS ファイルは除外（Tailwind v4 `@theme` 構文が未対応）
- 既存 lint エラーは warning に格下げ（`noExplicitAny`、`noArrayIndexKey` など）

### Storybook 10
- `@storybook/nextjs` フレームワークで初期化
- `Button`（全バリアント）と `Card` のストーリーを追加

### CI 修正
- `if: github.event.pull_request.draft == false` が push イベントで失敗する問題を修正
- `if: github.event_name == 'push' || github.event.pull_request.draft == false` に変更

## ビルド確認

```
✓ Compiled successfully
/login     ○ (Static)
/builder   ƒ (Dynamic)  ← connection() で動的レンダリング
```

- lint: 0 errors, 4 warnings（既存）
- type-check: clean
- tests: 68 passed
- build: success

## 注意事項

`BETTER_AUTH_SECRET` を Vercel 環境変数に追加してください（サーバー専用）。

https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy)_