### PR TITLE
fix(auth-gate): /builder の本番 500 を修正（Better Auth 未構成時は HMAC へ降格）

### DIFF
--- a/apps/web/src/server/auth-gate.ts
+++ b/apps/web/src/server/auth-gate.ts
@@ -12,8 +12,15 @@ import { SESSION_COOKIE_NAME, verifySessionToken } from './session';
  */
 export async function isEditor(): Promise<boolean> {
   // 1. Better Auth セッション確認
-  const session = await getAuth().api.getSession({ headers: await headers() });
-  if (session?.user) return true;
+  //    BETTER_AUTH_SECRET 未設定など Better Auth が未構成/エラーの場合でも、
+  //    HMAC フォールバックで認可できるよう例外を握りつぶして降格する
+  //    （Better Auth 単体の不調で /builder 全体が 500 になるのを防ぐ）。
+  try {
+    const session = await getAuth().api.getSession({ headers: await headers() });
+    if (session?.user) return true;
+  } catch (err) {
+    console.error('Better Auth session check failed; falling back to HMAC session:', err);
+  }
 
   // 2. フォールバック: 従来の HMAC セッション cookie
   const store = await cookies();

--- a/apps/web/src/server/auth-gate.ts
+++ b/apps/web/src/server/auth-gate.ts
@@ -12,14 +12,17 @@ import { SESSION_COOKIE_NAME, verifySessionToken } from './session';
  */
 export async function isEditor(): Promise<boolean> {
   // 1. Better Auth セッション確認
-  //    BETTER_AUTH_SECRET 未設定など Better Auth が未構成/エラーの場合でも、
-  //    HMAC フォールバックで認可できるよう例外を握りつぶして降格する
-  //    （Better Auth 単体の不調で /builder 全体が 500 になるのを防ぐ）。
-  try {
-    const session = await getAuth().api.getSession({ headers: await headers() });
-    if (session?.user) return true;
-  } catch (err) {
-    console.error('Better Auth session check failed; falling back to HMAC session:', err);
+  //    必要な環境変数が揃っている時のみ実行する。未構成時に毎リクエスト
+  //    getAuth() が throw してログ公害になるのを防ぎ、真のエラー（DB接続
+  //    失敗など）だけを console.error に残す。例外時は HMAC へ降格し、
+  //    Better Auth 単体の不調で /builder 全体が 500 になるのを防ぐ。
+  if (process.env.BETTER_AUTH_SECRET && process.env.DATABASE_URL) {
+    try {
+      const session = await getAuth().api.getSession({ headers: await headers() });
+      if (session?.user) return true;
+    } catch (err) {
+      console.error('Better Auth session check failed; falling back to HMAC session:', err);
+    }
   }
 
   // 2. フォールバック: 従来の HMAC セッション cookie


### PR DESCRIPTION
## 概要

PR #32 マージ後の本番動作確認で `/builder` が **500 Internal Server Error** を返していたため、緊急修正。

## 原因

PR #32 で追加した `BETTER_AUTH_SECRET` のランタイム検証（未設定時 throw）により、本番で同シークレットが未設定のため:

`/builder` → `isEditor()` → `getAuth()` → `createAuth()` が throw → ページ全体が 500

## 修正

`isEditor()` の Better Auth セッション確認を `try/catch` で囲み、Better Auth が未構成/エラーの場合は例外を握りつぶして既存の **HMAC セッション cookie 検証（/viewer-auth・`SESSION_SECRET`）にフォールバック**する。

これにより:
- Better Auth（email/password）未設定でも `/builder` の編集ゲートは従来の HMAC セッションで機能（500 にならない）
- email/password を有効化したい場合は引き続き `BETTER_AUTH_SECRET` の設定が必要（`/api/auth` 本来のフローは secret 必須のまま）
- 多層防御として「Better Auth 単体の不調で /builder 全体が落ちる」を防止

## 本番検証（Vercel 側フェッチで確認）

修正前の本番状態:
- `/login` → ✅ 200 OK（HTML 正常）
- `/viewer-auth` → ✅ 200 OK
- `/builder` → ❌ **500**（digest 3589734969）← 本PRで修正

## ローカル検証

- type-check: clean / lint: 0 errors, 4 warnings（既存）/ test: 68 passed

https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiPxdHy2dU46p38xFe4Fxy)_