### PR TITLE
fix(view): GitHub一覧から設定/AI指示系MDを除外 + auth/builder改善

### DIFF
--- a/apps/web/app/view/[path]/page.tsx
+++ b/apps/web/app/view/[path]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { isValidSheetPath, SheetNotFoundError } from '@/server/github-sheets';
+import { isSheetFileName, isValidSheetPath, SheetNotFoundError } from '@/server/github-sheets';
 import { getCachedSheet } from '@/server/sheets-cache';
 
 import SheetViewClient from './sheet-view-client';
@@ -13,7 +13,7 @@ interface PageProps {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   // App Router の params は既にデコード済み（再 decodeURIComponent は % を含む名前で URIError を招く）。
   const { path } = await params;
-  if (!isValidSheetPath(path)) return {};
+  if (!isValidSheetPath(path) || !isSheetFileName(path)) return {};
   try {
     const sheet = await getCachedSheet(path);
     return {
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function SheetViewPage({ params }: PageProps) {
   const { path } = await params;
-  if (!isValidSheetPath(path)) notFound();
+  if (!isValidSheetPath(path) || !isSheetFileName(path)) notFound();
 
   let sheet: Awaited<ReturnType<typeof getCachedSheet>>;
   try {

--- a/apps/web/src/server/github-sheets.test.ts
+++ b/apps/web/src/server/github-sheets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSheetFileName } from './github-sheets';
+
+describe('isSheetFileName', () => {
+  it('スキルシートの .md は許可する', () => {
+    expect(isSheetFileName('skillsheet.md')).toBe(true);
+    expect(isSheetFileName('技術スキルシート.md')).toBe(true);
+    expect(isSheetFileName('engineer-profile.md')).toBe(true);
+  });
+
+  it('リポジトリ設定 / AI 指示系の .md は除外する', () => {
+    for (const name of [
+      'CLAUDE.md',
+      'AGENTS.md',
+      'README.md',
+      'GEMINI.md',
+      'copilot-instructions.md',
+      'CONTRIBUTING.md',
+      'LICENSE.md',
+      'SECURITY.md',
+      'CHANGELOG.md',
+    ]) {
+      expect(isSheetFileName(name)).toBe(false);
+    }
+  });
+
+  it('大文字小文字を無視して除外する', () => {
+    expect(isSheetFileName('claude.md')).toBe(false);
+    expect(isSheetFileName('Readme.md')).toBe(false);
+  });
+
+  it('.md 以外・ドットファイルは除外する', () => {
+    expect(isSheetFileName('skillsheet.txt')).toBe(false);
+    expect(isSheetFileName('.hidden.md')).toBe(false);
+  });
+});

--- a/apps/web/src/server/github-sheets.ts
+++ b/apps/web/src/server/github-sheets.ts
@@ -65,6 +65,38 @@ export function isValidSheetPath(path: string): boolean {
   return /^[\p{L}\p{N}_.-]+\.md$/u.test(path);
 }
 
+/**
+ * スキルシートとして一覧・表示しない Markdown ファイル名（リポジトリ設定 / AI 指示系）。
+ * データ源リポジトリのルートに混在しても閲覧側には出さない。比較は小文字で行う。
+ */
+const NON_SHEET_MARKDOWN: ReadonlySet<string> = new Set([
+  'readme.md',
+  'claude.md',
+  'agents.md',
+  'gemini.md',
+  'copilot.md',
+  'copilot-instructions.md',
+  'contributing.md',
+  'code_of_conduct.md',
+  'security.md',
+  'changelog.md',
+  'license.md',
+  'support.md',
+  'governance.md',
+  'maintainers.md',
+  'authors.md',
+  'notice.md',
+  'history.md',
+  'todo.md',
+]);
+
+/** ファイル名がスキルシートとして扱える .md か（設定 / AI 指示系・ドットファイルは除外）。 */
+export function isSheetFileName(name: string): boolean {
+  if (!name.endsWith('.md')) return false;
+  if (name.startsWith('.')) return false;
+  return !NON_SHEET_MARKDOWN.has(name.toLowerCase());
+}
+
 export async function listSheets(): Promise<SheetMeta[]> {
   const { token, owner, repo, branch } = getConfig();
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/?ref=${branch}`;
@@ -74,7 +106,7 @@ export async function listSheets(): Promise<SheetMeta[]> {
 
   const items = (await res.json()) as GitHubFileItem[];
   return items
-    .filter((item) => item.type === 'file' && item.name.endsWith('.md'))
+    .filter((item) => item.type === 'file' && isSheetFileName(item.name))
     .map((item) => ({
       path: item.path,
       title: item.name.replace(/\.md$/u, ''),


### PR DESCRIPTION
## Summary

- GitHub一覧から設定/AI指示系MDを除外する github-list-exclude 機能
- auth-gate / viewer-gate / builder 改善
- DB migration 0001_deep_switch.sql 追加
- ドキュメント更新

## Related

- Issue #47

## Note

このPRはBlock Builder MVP(#22 → PR#44 MERGED)の続きの実装を含む。