### PR TITLE
feat(builder): テーブルブロックMVP（追加・列行編集・桁揃え・並替・保存）

### DIFF
--- a/apps/web/app/builder/actions.ts
+++ b/apps/web/app/builder/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { saveSkillSheetBlocks } from '@skillsheet/db';
+import { type BlockInput, isBlockInput, saveSkillSheetBlocks } from '@skillsheet/db';
 import { revalidateTag } from 'next/cache';
 
 import { isEditor } from '@/server/auth-gate';
@@ -10,20 +10,32 @@ export interface SaveResult {
   error?: string;
 }
 
+export interface SaveBlocksPayload {
+  title: string;
+  blocks: BlockInput[];
+}
+
 /**
- * ビルダーのブロック（順序付き markdown 配列）を DB に保存する。
+ * ビルダーのブロック（タイトル＋型付きブロック配列）を DB に保存する。
  * Server Action 内でも認可を再検証する（多層防御。proxy 任せにしない）。
+ * payload は blocks.ts のバリデータで検証し、不正なら DB に触れず弾く。
  */
-export async function saveBlocksAction(markdowns: string[]): Promise<SaveResult> {
+export async function saveBlocksAction(payload: SaveBlocksPayload): Promise<SaveResult> {
   if (!(await isEditor())) {
     return { ok: false, error: 'unauthorized' };
   }
-  if (!Array.isArray(markdowns) || markdowns.some((m) => typeof m !== 'string')) {
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    typeof payload.title !== 'string' ||
+    !Array.isArray(payload.blocks) ||
+    !payload.blocks.every(isBlockInput)
+  ) {
     return { ok: false, error: 'invalid payload' };
   }
 
   try {
-    await saveSkillSheetBlocks(markdowns);
+    await saveSkillSheetBlocks(payload.title, payload.blocks);
     // Next 16 の revalidateTag は第2引数必須。空の CacheLifeConfig({}) で
     // 当該タグを即時失効させ、保存直後に /view/db が最新を読むようにする。
     revalidateTag('db-sheet', {});

--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -1,3 +1,4 @@
+import type { Block } from '@skillsheet/db/blocks';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -13,47 +14,91 @@ vi.mock('@/component/skill-sheet-viewer', () => ({
 
 const mockSave = vi.fn().mockResolvedValue({ ok: true });
 vi.mock('./actions', () => ({
-  saveBlocksAction: (markdowns: string[]) => mockSave(markdowns),
+  saveBlocksAction: (payload: { title: string; blocks: unknown[] }) => mockSave(payload),
 }));
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
+// markdown ブロック配列から初期 Block[] を作るヘルパ。
+const mdBlocks = (markdowns: string[]): Block[] =>
+  markdowns.map((markdown, order) => ({ id: `block-${order}`, type: 'markdown', order, data: { markdown } }));
+
 describe('BuilderClient', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('初期ブロックがテキストエリアとして表示される', () => {
-    render(<BuilderClient initialMarkdowns={['## A', '## B']} />);
+  it('初期 markdown ブロックがテキストエリアとして表示される', () => {
+    render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" />);
     const areas = screen.getAllByPlaceholderText('Markdown を入力...') as HTMLTextAreaElement[];
     expect(areas).toHaveLength(2);
     expect(areas[0].value).toBe('## A');
     expect(areas[1].value).toBe('## B');
   });
 
-  it('「ブロック追加」で空ブロックが増える', async () => {
+  it('「テキスト」で空ブロックが増える', async () => {
     const user = userEvent.setup();
-    render(<BuilderClient initialMarkdowns={['## A']} />);
-    await user.click(screen.getByRole('button', { name: 'ブロック追加' }));
+    render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="t" />);
+    await user.click(screen.getByRole('button', { name: 'テキスト' }));
     expect(screen.getAllByPlaceholderText('Markdown を入力...')).toHaveLength(2);
   });
 
   it('削除ボタンでブロックが減る', async () => {
     const user = userEvent.setup();
-    render(<BuilderClient initialMarkdowns={['## A', '## B']} />);
+    render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" />);
     await user.click(screen.getAllByLabelText('ブロックを削除')[0]);
     const areas = screen.getAllByPlaceholderText('Markdown を入力...') as HTMLTextAreaElement[];
     expect(areas).toHaveLength(1);
     expect(areas[0].value).toBe('## B');
   });
 
-  it('保存ボタンで現在のブロックが saveBlocksAction に渡る', async () => {
+  it('保存ボタンで {title, blocks} が saveBlocksAction に渡る', async () => {
     const user = userEvent.setup();
-    render(<BuilderClient initialMarkdowns={['## A']} />);
+    render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="マイシート" />);
     await user.click(screen.getByRole('button', { name: /保存/ }));
-    expect(mockSave).toHaveBeenCalledWith(['## A']);
+    expect(mockSave).toHaveBeenCalledWith({
+      title: 'マイシート',
+      blocks: [{ type: 'markdown', data: { markdown: '## A' } }],
+    });
   });
 
   it('プレビューに連結 Markdown が反映される', () => {
-    render(<BuilderClient initialMarkdowns={['## A', '## B']} />);
+    render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" />);
     expect(screen.getByTestId('preview')).toHaveTextContent('## A ## B');
+  });
+
+  it('「テーブル」追加→セル入力が table ブロックとして保存 payload に入る', async () => {
+    const user = userEvent.setup();
+    render(<BuilderClient initialBlocks={[]} initialTitle="t" />);
+    await user.click(screen.getByRole('button', { name: 'テーブル' }));
+    // 既定テーブル: 2 列（項目/内容）＋空 1 行。1 行 1 列にセル入力する。
+    await user.type(screen.getByLabelText('1行1列'), 'PHP');
+    await user.click(screen.getByRole('button', { name: /保存/ }));
+    expect(mockSave).toHaveBeenCalledWith({
+      title: 't',
+      blocks: [
+        {
+          type: 'table',
+          data: {
+            columns: [
+              { label: '項目', align: 'left' },
+              { label: '内容', align: 'left' },
+            ],
+            rows: [['PHP', '']],
+          },
+        },
+      ],
+    });
+  });
+
+  it('タイトル入力が保存 payload に反映される', async () => {
+    const user = userEvent.setup();
+    render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="旧" />);
+    const titleInput = screen.getByLabelText('タイトル');
+    await user.clear(titleInput);
+    await user.type(titleInput, '新タイトル');
+    await user.click(screen.getByRole('button', { name: /保存/ }));
+    expect(mockSave).toHaveBeenCalledWith({
+      title: '新タイトル',
+      blocks: [{ type: 'markdown', data: { markdown: '## A' } }],
+    });
   });
 });

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -16,7 +16,30 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Download, Eye, EyeOff, GripVertical, Plus, Save, Trash2 } from 'lucide-react';
+// tableBlockToMarkdown 等の純関数/型はサーバ専用モジュール（neon ドライバ等）を
+// client バンドルに巻き込まないため、root の @skillsheet/db ではなく純粋サブエクスポート
+// @skillsheet/db/blocks から import する。
+import {
+  type Block,
+  type BlockInput,
+  isBlockInputEmpty,
+  type TableAlign,
+  type TableColumn,
+  tableBlockToMarkdown,
+} from '@skillsheet/db/blocks';
+import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  Download,
+  Eye,
+  EyeOff,
+  GripVertical,
+  Plus,
+  Save,
+  Table,
+  Trash2,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { toast } from 'sonner';
@@ -26,13 +49,14 @@ import { Button } from '@/components/ui/button';
 
 import { saveBlocksAction } from './actions';
 
-interface BlockItem {
-  id: string;
-  markdown: string;
-}
+// エディタ上のブロック。type と内容を一致させた判別ユニオン（DB の Block に対応）。
+type EditorItem =
+  | { id: string; type: 'markdown'; markdown: string }
+  | { id: string; type: 'table'; columns: TableColumn[]; rows: string[][] };
 
 interface BuilderClientProps {
-  initialMarkdowns: string[];
+  initialBlocks: Block[];
+  initialTitle: string;
 }
 
 const newId = () =>
@@ -40,13 +64,189 @@ const newId = () =>
     ? crypto.randomUUID()
     : `b-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
+// 初期ブロックの ID は SSR/CSR で一致させるためインデックス基準の安定値にする
+// （newId() は乱数/時刻依存でハイドレーション不整合を起こす）。追加ブロックのみ newId()。
+const blockToItem = (block: Block, index: number): EditorItem => {
+  const id = `block-${index}`;
+  if (block.type === 'markdown') return { id, type: 'markdown', markdown: block.data.markdown };
+  return { id, type: 'table', columns: block.data.columns, rows: block.data.rows };
+};
+
+const itemToBlockInput = (item: EditorItem): BlockInput =>
+  item.type === 'markdown'
+    ? { type: 'markdown', data: { markdown: item.markdown } }
+    : { type: 'table', data: { columns: item.columns, rows: item.rows } };
+
+// 1 ブロックを markdown 文字列へ（table は GFM 表へ変換）。プレビュー/バックアップ/dirty で共有。
+const itemToMarkdown = (item: EditorItem): string =>
+  item.type === 'markdown' ? item.markdown : tableBlockToMarkdown({ columns: item.columns, rows: item.rows });
+
+const assembleMarkdown = (items: EditorItem[]): string => items.map(itemToMarkdown).join('\n');
+
+// dirty 比較用スナップショット（タイトル＋組み立て済み markdown 文字列）。
+// typed item を直接比較せず、保存される最終形（markdown）で差分を見る。
+const snapshot = (items: EditorItem[], title: string): string => JSON.stringify([title, assembleMarkdown(items)]);
+
+const ALIGN_OPTIONS: { value: TableAlign; Icon: typeof AlignLeft; label: string }[] = [
+  { value: 'left', Icon: AlignLeft, label: '左揃え' },
+  { value: 'center', Icon: AlignCenter, label: '中央揃え' },
+  { value: 'right', Icon: AlignRight, label: '右揃え' },
+];
+
+// Excel 風グリッド編集の中心。ヘッダ=列 label 入力＋列 align トグル、本文=セルごと <input>。
+// セルは <input> なので入力時に改行が混入しない（GFM 表崩れ・PDF の改行欠落を回避）。
+const TableBlockEditor = ({
+  columns,
+  rows,
+  onChange,
+}: {
+  columns: TableColumn[];
+  rows: string[][];
+  onChange: (columns: TableColumn[], rows: string[][]) => void;
+}) => {
+  const setLabel = (ci: number, label: string) =>
+    onChange(
+      columns.map((c, i) => (i === ci ? { ...c, label } : c)),
+      rows,
+    );
+  const setAlign = (ci: number, align: TableAlign) =>
+    onChange(
+      columns.map((c, i) => (i === ci ? { ...c, align } : c)),
+      rows,
+    );
+  const setCell = (ri: number, ci: number, value: string) =>
+    onChange(
+      columns,
+      rows.map((row, r) => (r === ri ? row.map((cell, c) => (c === ci ? value : cell)) : row)),
+    );
+  const addColumn = () =>
+    onChange(
+      [...columns, { label: '', align: 'left' }],
+      rows.map((row) => [...row, '']),
+    );
+  const removeColumn = (ci: number) => {
+    if (columns.length <= 1) return; // 列は最低 1 列残す
+    onChange(
+      columns.filter((_, i) => i !== ci),
+      rows.map((row) => row.filter((_, i) => i !== ci)),
+    );
+  };
+  const addRow = () => onChange(columns, [...rows, columns.map(() => '')]);
+  const removeRow = (ri: number) =>
+    onChange(
+      columns,
+      rows.filter((_, i) => i !== ri),
+    );
+
+  return (
+    <div className="min-w-0 flex-1 overflow-x-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr>
+            {columns.map((col, ci) => (
+              // 列の追加/削除でインデックス key がずれてもセル focus 喪失は許容（MVP）。
+              // biome-ignore lint/suspicious/noArrayIndexKey: 列は順序で管理し安定 id を持たない
+              <th key={ci} className="border border-border p-1 align-top">
+                <div className="flex flex-col gap-1">
+                  <input
+                    value={col.label}
+                    onChange={(e) => setLabel(ci, e.target.value)}
+                    placeholder={`列${ci + 1}`}
+                    aria-label={`列${ci + 1}の見出し`}
+                    className="w-full min-w-24 rounded border border-input bg-background px-2 py-1 font-medium focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                  <div className="flex items-center gap-1">
+                    {ALIGN_OPTIONS.map(({ value, Icon, label }) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => setAlign(ci, value)}
+                        aria-label={`列${ci + 1}を${label}`}
+                        aria-pressed={col.align === value}
+                        className={`rounded p-1 ${
+                          col.align === value
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:bg-muted'
+                        }`}
+                      >
+                        <Icon className="size-3.5" />
+                      </button>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => removeColumn(ci)}
+                      disabled={columns.length <= 1}
+                      aria-label={`列${ci + 1}を削除`}
+                      className="ml-auto rounded p-1 text-muted-foreground hover:text-destructive disabled:opacity-30"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </div>
+                </div>
+              </th>
+            ))}
+            <th className="border border-border p-1 align-middle">
+              <button
+                type="button"
+                onClick={addColumn}
+                aria-label="列を追加"
+                className="rounded p-1 text-muted-foreground hover:text-foreground"
+              >
+                <Plus className="size-4" />
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: 行は順序で管理し安定 id を持たない
+            <tr key={ri}>
+              {columns.map((_, ci) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: セルは行列インデックスで一意
+                <td key={ci} className="border border-border p-1">
+                  <input
+                    value={row[ci] ?? ''}
+                    onChange={(e) => setCell(ri, ci, e.target.value)}
+                    aria-label={`${ri + 1}行${ci + 1}列`}
+                    className="w-full min-w-24 rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </td>
+              ))}
+              <td className="border border-border p-1 text-center align-middle">
+                <button
+                  type="button"
+                  onClick={() => removeRow(ri)}
+                  aria-label={`${ri + 1}行目を削除`}
+                  className="rounded p-1 text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        type="button"
+        onClick={addRow}
+        className="mt-1 flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <Plus className="size-3.5" />
+        行を追加
+      </button>
+    </div>
+  );
+};
+
 const SortableBlock = ({
   item,
-  onChange,
+  onMarkdownChange,
+  onTableChange,
   onDelete,
 }: {
-  item: BlockItem;
-  onChange: (id: string, markdown: string) => void;
+  item: EditorItem;
+  onMarkdownChange: (id: string, markdown: string) => void;
+  onTableChange: (id: string, columns: TableColumn[], rows: string[][]) => void;
   onDelete: (id: string) => void;
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
@@ -68,13 +268,21 @@ const SortableBlock = ({
       >
         <GripVertical className="size-5" />
       </button>
-      <textarea
-        value={item.markdown}
-        onChange={(e) => onChange(item.id, e.target.value)}
-        rows={Math.min(12, Math.max(3, item.markdown.split('\n').length))}
-        className="min-w-0 flex-1 resize-y rounded-md border border-input bg-background p-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-        placeholder="Markdown を入力..."
-      />
+      {item.type === 'markdown' ? (
+        <textarea
+          value={item.markdown}
+          onChange={(e) => onMarkdownChange(item.id, e.target.value)}
+          rows={Math.min(12, Math.max(3, item.markdown.split('\n').length))}
+          className="min-w-0 flex-1 resize-y rounded-md border border-input bg-background p-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          placeholder="Markdown を入力..."
+        />
+      ) : (
+        <TableBlockEditor
+          columns={item.columns}
+          rows={item.rows}
+          onChange={(columns, rows) => onTableChange(item.id, columns, rows)}
+        />
+      )}
       <Button
         variant="ghost"
         size="icon"
@@ -88,19 +296,16 @@ const SortableBlock = ({
   );
 };
 
-const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
-  // 初期ブロックの ID は SSR/CSR で一致させるためインデックス基準の安定値にする
-  // （newId() は乱数/時刻依存でハイドレーション不整合を起こす）。追加ブロックのみ newId()。
-  const [items, setItems] = useState<BlockItem[]>(() =>
-    initialMarkdowns.map((markdown, index) => ({ id: `block-${index}`, markdown })),
-  );
+const BuilderClient = ({ initialBlocks, initialTitle }: BuilderClientProps) => {
+  const [items, setItems] = useState<EditorItem[]>(() => initialBlocks.map(blockToItem));
+  const [title, setTitle] = useState(initialTitle);
   const [showPreview, setShowPreview] = useState(true);
   const [isSaving, startSaving] = useTransition();
   const savedRef = useRef(false);
 
-  // 未保存変更の検知。最後に保存成功した時点の markdown スナップショットを保持し、
-  // 現在の内容と差分があれば dirty とみなす（保存成功で false に戻す）。
-  const lastSavedMarkdownsRef = useRef<string[]>(initialMarkdowns);
+  // 未保存変更の検知。最後に保存成功した時点のスナップショット（タイトル＋組み立て markdown）を
+  // 保持し、現在の内容と差分があれば dirty とみなす（保存成功で更新）。
+  const lastSavedSnapshotRef = useRef<string>(snapshot(initialBlocks.map(blockToItem), initialTitle));
   const [isDirty, setIsDirty] = useState(false);
 
   const sensors = useSensors(
@@ -110,22 +315,19 @@ const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
 
   // プレビューは重い（Markdown パース＋ハイライト）ため、入力のたびではなく
   // 300ms デバウンスして更新し、タイピングのラグを防ぐ。初期値は即時反映。
-  const [previewContent, setPreviewContent] = useState(() => items.map((i) => i.markdown).join('\n'));
+  const [previewContent, setPreviewContent] = useState(() => assembleMarkdown(items));
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setPreviewContent(items.map((i) => i.markdown).join('\n'));
+      setPreviewContent(assembleMarkdown(items));
     }, 300);
     return () => clearTimeout(timer);
   }, [items]);
 
-  // 現在の内容が最後の保存スナップショットと異なれば dirty にする。
+  // 現在の内容（タイトル含む）が最後の保存スナップショットと異なれば dirty にする。
   useEffect(() => {
-    const current = items.map((i) => i.markdown);
-    const saved = lastSavedMarkdownsRef.current;
-    const dirty = current.length !== saved.length || current.some((m, i) => m !== saved[i]);
-    setIsDirty(dirty);
-  }, [items]);
+    setIsDirty(snapshot(items, title) !== lastSavedSnapshotRef.current);
+  }, [items, title]);
 
   // 未保存変更がある間だけ beforeunload を登録し、離脱時にネイティブ警告を出す。
   // dirty でなくなる／アンマウント時にはリスナーを解除する。
@@ -154,19 +356,34 @@ const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
     });
   };
 
-  const updateBlock = (id: string, markdown: string) =>
-    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, markdown } : i)));
+  const updateMarkdown = (id: string, markdown: string) =>
+    setItems((prev) => prev.map((i) => (i.id === id && i.type === 'markdown' ? { ...i, markdown } : i)));
+
+  const updateTable = (id: string, columns: TableColumn[], rows: string[][]) =>
+    setItems((prev) => prev.map((i) => (i.id === id && i.type === 'table' ? { ...i, columns, rows } : i)));
 
   const deleteBlock = (id: string) => setItems((prev) => prev.filter((i) => i.id !== id));
 
-  const addBlock = () => setItems((prev) => [...prev, { id: newId(), markdown: '' }]);
+  const addMarkdownBlock = () => setItems((prev) => [...prev, { id: newId(), type: 'markdown', markdown: '' }]);
 
-  // 現在の全ブロックを組み立てた markdown。バックアップ出力・空判定で使う。
-  const assembleMarkdown = () => items.map((i) => i.markdown).join('\n');
+  // 既定テーブルは 2 列（項目/内容）＋空 1 行。
+  const addTableBlock = () =>
+    setItems((prev) => [
+      ...prev,
+      {
+        id: newId(),
+        type: 'table',
+        columns: [
+          { label: '項目', align: 'left' },
+          { label: '内容', align: 'left' },
+        ],
+        rows: [['', '']],
+      },
+    ]);
 
   // 破壊的な編集の前に、現在の内容をファイルとしてダウンロードして復元ポイントを残す。
   const handleExport = () => {
-    const content = assembleMarkdown();
+    const content = assembleMarkdown(items);
     const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
@@ -181,21 +398,23 @@ const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
   };
 
   const handleSave = () => {
-    const markdowns = items.map((i) => i.markdown);
-    // データ消失ガード: 全ブロックが空（空白のみ）なら、保存で全内容が消える。
+    // データ消失ガード: 全ブロックが空（type 別判定）なら、保存で全内容が消える。
     // 明示的な確認が取れた場合のみ続行する。
-    const isAllEmpty = markdowns.every((m) => m.trim() === '');
+    const isAllEmpty = items.every((item) => isBlockInputEmpty(itemToBlockInput(item)));
     if (isAllEmpty) {
-      const confirmed = window.confirm('全ブロックが空です。保存すると全内容が消えます。続けますか？');
+      const confirmed = window.confirm('内容が空です。保存すると全内容が消えます。続けますか？');
       if (!confirmed) return;
     }
 
+    const payload = { title, blocks: items.map(itemToBlockInput) };
+    const savedSnapshot = snapshot(items, title);
+
     startSaving(async () => {
-      const res = await saveBlocksAction(markdowns);
+      const res = await saveBlocksAction(payload);
       if (res.ok) {
         savedRef.current = true;
         // 保存成功した内容をスナップショットとして記録し、dirty を解除する。
-        lastSavedMarkdownsRef.current = markdowns;
+        lastSavedSnapshotRef.current = savedSnapshot;
         setIsDirty(false);
         toast.success('保存しました');
       } else if (res.error === 'unauthorized') {
@@ -234,11 +453,30 @@ const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
       <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-2">
         {/* エディタ */}
         <div className="space-y-3">
+          <div>
+            <label htmlFor="sheet-title" className="mb-1 block text-sm font-medium text-muted-foreground">
+              タイトル
+            </label>
+            <input
+              id="sheet-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="スキルシートのタイトル"
+              className="w-full rounded-md border border-input bg-background p-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={items.map((i) => i.id)} strategy={verticalListSortingStrategy}>
               <div className="space-y-3">
                 {items.map((item) => (
-                  <SortableBlock key={item.id} item={item} onChange={updateBlock} onDelete={deleteBlock} />
+                  <SortableBlock
+                    key={item.id}
+                    item={item}
+                    onMarkdownChange={updateMarkdown}
+                    onTableChange={updateTable}
+                    onDelete={deleteBlock}
+                  />
                 ))}
               </div>
             </SortableContext>
@@ -246,21 +484,30 @@ const BuilderClient = ({ initialMarkdowns }: BuilderClientProps) => {
 
           {items.length === 0 && (
             <p className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
-              ブロックがありません。「ブロック追加」で作成してください。
+              ブロックがありません。下のボタンでテキストかテーブルを追加してください。
             </p>
           )}
 
-          <Button variant="outline" onClick={addBlock} className="w-full">
-            <Plus className="mr-1.5 size-4" />
-            ブロック追加
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={addMarkdownBlock} className="flex-1">
+              <Plus className="mr-1.5 size-4" />
+              テキスト
+            </Button>
+            <Button variant="outline" onClick={addTableBlock} className="flex-1">
+              <Table className="mr-1.5 size-4" />
+              テーブル
+            </Button>
+          </div>
         </div>
 
         {/* ライブプレビュー */}
         {showPreview && (
           <div className="rounded-lg border border-border bg-card">
             <div className="border-b border-border px-4 py-2 text-sm font-medium text-muted-foreground">プレビュー</div>
-            <SkillSheetViewer skillSheet={{ title: 'プレビュー', content: previewContent }} compareMode />
+            <SkillSheetViewer
+              skillSheet={{ title: title.trim() || 'プレビュー', content: previewContent }}
+              compareMode
+            />
           </div>
         )}
       </div>

--- a/apps/web/app/builder/page.tsx
+++ b/apps/web/app/builder/page.tsx
@@ -1,4 +1,4 @@
-import { getSkillSheet } from '@skillsheet/db';
+import { type Block, getSkillSheet } from '@skillsheet/db';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { connection } from 'next/server';
@@ -18,14 +18,17 @@ export default async function BuilderPage() {
     redirect('/login?next=/builder');
   }
 
-  let initialMarkdowns: string[] = [];
+  let initialBlocks: Block[] = [];
+  let initialTitle = '';
   try {
     const sheet = await getSkillSheet();
-    initialMarkdowns = sheet.blocks.map((b) => b.data.markdown);
+    // 型情報（table ブロック含む）を保持したまま渡す。markdown を抜き出して捨てない。
+    initialBlocks = sheet.blocks;
+    initialTitle = sheet.title;
   } catch (err) {
     // DB/GitHub 未設定や疎通失敗時は空のビルダーから開始する（保存で作成できる）。
     console.error('Failed to load sheet for builder:', err);
   }
 
-  return <BuilderClient initialMarkdowns={initialMarkdowns} />;
+  return <BuilderClient initialBlocks={initialBlocks} initialTitle={initialTitle} />;
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -187,7 +187,8 @@ body {
 .markdown-content td {
   border: 1px solid var(--border);
   padding: 12px 16px;
-  text-align: left;
+  /* 桁揃えは GFM の列 alignment（th/td の align）をビューアの th/td override が
+     inline text-align として適用する。ここで固定 left を置くとそれを潰すため置かない。 */
 }
 .markdown-content th {
   background-color: var(--muted);

--- a/apps/web/src/component/skill-sheet-viewer.test.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.test.tsx
@@ -59,4 +59,25 @@ describe('SkillSheetViewer', () => {
     // テーブルも通常どおり描画される
     expect(screen.getByText('TypeScript')).toBeInTheDocument();
   });
+
+  it('GFM の列 alignment を th/td の inline text-align として適用する', async () => {
+    const ALIGN_TABLE = `| 左 | 中 | 右 |
+| :--- | :---: | ---: |
+| a | b | c |
+`;
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: ALIGN_TABLE }} />);
+
+    await waitFor(() => {
+      const markdown = document.querySelector('.markdown-content') as HTMLElement;
+      expect(within(markdown).getByText('a')).toBeInTheDocument();
+    });
+
+    const markdown = document.querySelector('.markdown-content') as HTMLElement;
+    // ヘッダ（th）に列ごとの alignment が反映される
+    const headers = Array.from(markdown.querySelectorAll('th')) as HTMLTableCellElement[];
+    expect(headers.map((th) => th.style.textAlign)).toEqual(['left', 'center', 'right']);
+    // 本文（td）にも同じ alignment が反映される
+    const cells = Array.from(markdown.querySelectorAll('tbody td')) as HTMLTableCellElement[];
+    expect(cells.map((td) => td.style.textAlign)).toEqual(['left', 'center', 'right']);
+  });
 });

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -41,6 +41,13 @@ const isSafeImageSrc = (src: string): boolean => {
   return IMG_SRC_PROTOCOLS.some((p) => src.toLowerCase().startsWith(`${p}:`));
 };
 
+// GFM の列 alignment（remark-rehype が th/td の properties.align に left/center/right で
+// 載せる。rehype-sanitize の defaultSchema は align を保持する）を inline text-align へ。
+// 未指定列は left（GitHub 既定・従来挙動）。CSS の固定 text-align は撤去済みのため、
+// この inline スタイルが桁揃えの唯一の決定要因になる。
+const cellTextAlign = (align: unknown): 'left' | 'center' | 'right' =>
+  align === 'center' ? 'center' : align === 'right' ? 'right' : 'left';
+
 // rehype-raw が有効化する生HTML描画を details/summary タグに限定する。
 // style属性はデフォルトスキーマで除外済み（XSS防止）。
 // img の src は http/https/相対パスのみ許可し、javascript:/data: 等を除外する。
@@ -191,6 +198,22 @@ const SkillSheetViewer = ({ skillSheet, compareMode = false }: SkillSheetViewerP
                     >
                       <img src={src} alt={alt} {...props} />
                     </button>
+                  );
+                },
+                // GFM の列 alignment を inline text-align として適用する（sanitize 後の
+                // hast node.properties.align から読む）。globals.css の固定 left は撤去済み。
+                th({ node, children, style, ...props }) {
+                  return (
+                    <th {...props} style={{ ...style, textAlign: cellTextAlign(node?.properties?.align) }}>
+                      {children}
+                    </th>
+                  );
+                },
+                td({ node, children, style, ...props }) {
+                  return (
+                    <td {...props} style={{ ...style, textAlign: cellTextAlign(node?.properties?.align) }}>
+                      {children}
+                    </td>
                   );
                 },
               }}

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { type Block, blocksToMarkdown, splitMarkdownIntoBlocks } from './blocks';
+import {
+  type Block,
+  type BlockInput,
+  blocksToMarkdown,
+  isBlockInput,
+  isBlockInputEmpty,
+  isMarkdownBlockData,
+  isTableBlockData,
+  normalizeTableBlockData,
+  splitMarkdownIntoBlocks,
+  type TableBlockData,
+  tableBlockToMarkdown,
+} from './blocks';
 
 const SAMPLE = `## 技術者プロファイル
 
@@ -52,5 +64,140 @@ describe('splitMarkdownIntoBlocks', () => {
       .map((b) => ({ ...b }))
       .reverse();
     expect(blocksToMarkdown(reversed)).toBe(SAMPLE);
+  });
+});
+
+const TABLE: TableBlockData = {
+  columns: [
+    { label: '左', align: 'left' },
+    { label: '中', align: 'center' },
+    { label: '右', align: 'right' },
+  ],
+  rows: [['a', 'b', 'c']],
+};
+
+describe('tableBlockToMarkdown', () => {
+  it('3 種 alignment の GFM 表を出力する', () => {
+    expect(tableBlockToMarkdown(TABLE)).toBe(
+      ['| 左 | 中 | 右 |', '| :--- | :---: | ---: |', '| a | b | c |'].join('\n'),
+    );
+  });
+
+  it('セル内の `|` をエスケープする', () => {
+    const data: TableBlockData = {
+      columns: [{ label: 'a|b', align: 'left' }],
+      rows: [['x|y']],
+    };
+    expect(tableBlockToMarkdown(data)).toBe(['| a\\|b |', '| :--- |', '| x\\|y |'].join('\n'));
+  });
+
+  it('空セルは半角スペースになる（表ずれ防止）', () => {
+    const data: TableBlockData = {
+      columns: [
+        { label: '', align: 'left' },
+        { label: 'b', align: 'left' },
+      ],
+      rows: [['', 'v']],
+    };
+    expect(tableBlockToMarkdown(data)).toBe(['|   | b |', '| :--- | :--- |', '|   | v |'].join('\n'));
+  });
+
+  it('セル内改行は半角スペースへ置換する（複数行貼り付けの表崩れ防止）', () => {
+    const data: TableBlockData = {
+      columns: [{ label: 'h', align: 'left' }],
+      rows: [['1\n2\r\n3']],
+    };
+    expect(tableBlockToMarkdown(data)).toBe(['| h |', '| :--- |', '| 1 2 3 |'].join('\n'));
+  });
+
+  it('ragged 行を列数ちょうどに正規化する（不足は空、超過は切り捨て）', () => {
+    const data: TableBlockData = {
+      columns: [
+        { label: 'a', align: 'left' },
+        { label: 'b', align: 'left' },
+      ],
+      rows: [['1'], ['1', '2', '3']],
+    };
+    expect(tableBlockToMarkdown(data)).toBe(['| a | b |', '| :--- | :--- |', '| 1 |   |', '| 1 | 2 |'].join('\n'));
+  });
+});
+
+describe('blocksToMarkdown — type 別 dispatch', () => {
+  it('markdown と table を混在して 1 本の markdown に連結する', () => {
+    const blocks: Block[] = [
+      { id: 'm', type: 'markdown', order: 0, data: { markdown: '## 見出し' } },
+      { id: 't', type: 'table', order: 1, data: TABLE },
+    ];
+    expect(blocksToMarkdown(blocks)).toBe(
+      ['## 見出し', '| 左 | 中 | 右 |', '| :--- | :---: | ---: |', '| a | b | c |'].join('\n'),
+    );
+  });
+
+  it('後方互換: markdown のみのブロックは従来どおり連結する', () => {
+    const blocks: Block[] = [
+      { id: 'a', type: 'markdown', order: 0, data: { markdown: 'A' } },
+      { id: 'b', type: 'markdown', order: 1, data: { markdown: 'B' } },
+    ];
+    expect(blocksToMarkdown(blocks)).toBe('A\nB');
+  });
+});
+
+describe('バリデータ', () => {
+  it('isMarkdownBlockData', () => {
+    expect(isMarkdownBlockData({ markdown: 'x' })).toBe(true);
+    expect(isMarkdownBlockData({ markdown: 1 })).toBe(false);
+    expect(isMarkdownBlockData(null)).toBe(false);
+  });
+
+  it('isTableBlockData', () => {
+    expect(isTableBlockData(TABLE)).toBe(true);
+    // 列ゼロは不正
+    expect(isTableBlockData({ columns: [], rows: [] })).toBe(false);
+    // align が列挙外
+    expect(isTableBlockData({ columns: [{ label: 'a', align: 'middle' }], rows: [] })).toBe(false);
+    // rows が配列でない
+    expect(isTableBlockData({ columns: [{ label: 'a', align: 'left' }], rows: 'x' })).toBe(false);
+    // セルが文字列でない
+    expect(isTableBlockData({ columns: [{ label: 'a', align: 'left' }], rows: [[1]] })).toBe(false);
+  });
+
+  it('isBlockInput', () => {
+    expect(isBlockInput({ type: 'markdown', data: { markdown: 'x' } })).toBe(true);
+    expect(isBlockInput({ type: 'table', data: TABLE })).toBe(true);
+    expect(isBlockInput({ type: 'unknown', data: {} })).toBe(false);
+    expect(isBlockInput({ type: 'table', data: { columns: [], rows: [] } })).toBe(false);
+  });
+
+  it('isBlockInputEmpty', () => {
+    expect(isBlockInputEmpty({ type: 'markdown', data: { markdown: '   ' } })).toBe(true);
+    expect(isBlockInputEmpty({ type: 'markdown', data: { markdown: 'x' } })).toBe(false);
+    // 列ゼロ、または全 label 空 かつ 全セル空 → 空
+    const emptyTable: BlockInput = {
+      type: 'table',
+      data: {
+        columns: [
+          { label: '', align: 'left' },
+          { label: ' ', align: 'left' },
+        ],
+        rows: [['', '  ']],
+      },
+    };
+    expect(isBlockInputEmpty(emptyTable)).toBe(true);
+    // label があれば空ではない
+    expect(isBlockInputEmpty({ type: 'table', data: TABLE })).toBe(false);
+  });
+
+  it('normalizeTableBlockData は行を列数へ正規化する', () => {
+    const data: TableBlockData = {
+      columns: [
+        { label: 'a', align: 'left' },
+        { label: 'b', align: 'left' },
+      ],
+      rows: [['1'], ['1', '2', '3']],
+    };
+    expect(normalizeTableBlockData(data).rows).toEqual([
+      ['1', ''],
+      ['1', '2'],
+    ]);
   });
 });

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -2,24 +2,160 @@
  * スキルシートの「ブロック」データモデル。
  *
  * DB（Neon）を正本とし、スキルシートを順序付きブロック配列として表現する。
- * #21 の読み取り経路 MVP では汎用 `markdown` ブロックのみを扱い、既存の
- * react-markdown レンダラと PDF レンダラをそのまま再利用する。
- * #22（D&Dビルダー）で型付きブロック（年数表・プロジェクトカード等）を追加する。
+ * 汎用 `markdown` ブロックに加え、Excel 風に編集できる `table` ブロックを持つ
+ * 判別ユニオン（type と data が一致）。table は保存・描画時に GFM markdown 表へ
+ * 変換するため、web(react-markdown+remark-gfm) も PDF(mdast→@react-pdf) も
+ * 既存の描画パイプラインをそのまま再利用できる（描画コードの新規追加ゼロ）。
  */
 
-export type BlockType = 'markdown';
+export type BlockType = 'markdown' | 'table';
 
 export interface MarkdownBlockData {
   markdown: string;
 }
 
-export interface Block {
-  /** DB の行 ID（新規ブロックはクライアントで採番せずサーバ採番でも可） */
+/** 表セルの水平揃え（GFM の `:---` / `:---:` / `---:` に対応）。 */
+export type TableAlign = 'left' | 'center' | 'right';
+
+export interface TableColumn {
+  label: string;
+  align: TableAlign;
+}
+
+/** 表ブロックの構造化データ。ヘッダは columns[].label、本文は rows（ヘッダ行は含まない）。 */
+export interface TableBlockData {
+  columns: TableColumn[];
+  /** 本文行のみ。各行は columns と同じ長さに正規化される。 */
+  rows: string[][];
+}
+
+interface MarkdownBlock {
   id: string;
-  type: BlockType;
-  /** 0 始まりの表示順 */
+  type: 'markdown';
   order: number;
   data: MarkdownBlockData;
+}
+
+interface TableBlock {
+  id: string;
+  type: 'table';
+  order: number;
+  data: TableBlockData;
+}
+
+/**
+ * スキルシートを構成する 1 ブロック。type と data を一致させた判別ユニオン。
+ * id は DB の行 ID、order は 0 始まりの表示順。
+ */
+export type Block = MarkdownBlock | TableBlock;
+
+/**
+ * 保存時にクライアント/サーバ間で受け渡すブロック入力（id/order を持たない）。
+ * order は配列インデックスで決まるため不要。
+ */
+export type BlockInput = { type: 'markdown'; data: MarkdownBlockData } | { type: 'table'; data: TableBlockData };
+
+// --- バリデータ（zod を入れず DB パッケージの依存を増やさない軽量判定） -----
+
+const TABLE_ALIGNS: readonly TableAlign[] = ['left', 'center', 'right'];
+
+function isTableAlign(value: unknown): value is TableAlign {
+  return typeof value === 'string' && (TABLE_ALIGNS as readonly string[]).includes(value);
+}
+
+export function isMarkdownBlockData(data: unknown): data is MarkdownBlockData {
+  return typeof data === 'object' && data !== null && typeof (data as MarkdownBlockData).markdown === 'string';
+}
+
+export function isTableBlockData(data: unknown): data is TableBlockData {
+  if (typeof data !== 'object' || data === null) return false;
+  const { columns, rows } = data as { columns?: unknown; rows?: unknown };
+  if (!Array.isArray(columns) || columns.length === 0) return false;
+  const columnsOk = columns.every(
+    (c) =>
+      typeof c === 'object' &&
+      c !== null &&
+      typeof (c as TableColumn).label === 'string' &&
+      isTableAlign((c as TableColumn).align),
+  );
+  if (!columnsOk) return false;
+  if (!Array.isArray(rows)) return false;
+  return rows.every((row) => Array.isArray(row) && row.every((cell) => typeof cell === 'string'));
+}
+
+/** untyped な入力（クライアント由来）が正当な BlockInput かを判定する。 */
+export function isBlockInput(value: unknown): value is BlockInput {
+  if (typeof value !== 'object' || value === null) return false;
+  const { type, data } = value as { type?: unknown; data?: unknown };
+  if (type === 'markdown') return isMarkdownBlockData(data);
+  if (type === 'table') return isTableBlockData(data);
+  return false;
+}
+
+/**
+ * 表の各行を列数ちょうどに正規化する（足りない分は空セル、余りは切り捨て）。
+ * 壊れた DB JSON や ragged な行で描画/エディタが破綻しないようにする。
+ */
+export function normalizeTableBlockData(data: TableBlockData): TableBlockData {
+  const colCount = data.columns.length;
+  return {
+    columns: data.columns,
+    rows: data.rows.map((row) => Array.from({ length: colCount }, (_, i) => row[i] ?? '')),
+  };
+}
+
+/**
+ * 「空ブロック」判定（保存時の drop と、全消し保存ガードで共有する単一の真実）。
+ * markdown: trim して空 / table: 列ゼロ、または（全列 label 空 かつ 全セル空）。
+ */
+export function isBlockInputEmpty(block: BlockInput): boolean {
+  if (block.type === 'markdown') return block.data.markdown.trim().length === 0;
+  const { columns, rows } = block.data;
+  if (columns.length === 0) return true;
+  const allLabelsEmpty = columns.every((c) => c.label.trim() === '');
+  const allCellsEmpty = rows.every((row) => row.every((cell) => cell.trim() === ''));
+  return allLabelsEmpty && allCellsEmpty;
+}
+
+// --- markdown 変換 ---------------------------------------------------------
+
+const ALIGN_MARKER: Record<TableAlign, string> = {
+  left: ':---',
+  center: ':---:',
+  right: '---:',
+};
+
+/**
+ * セルを GFM 表で安全な単一行へ整える。
+ * - セル内改行は半角スペースへ（複数行貼り付けで表が崩れるのを防止）
+ * - `|` はエスケープ
+ * - 空セルは半角スペース 1 つ（空文字だと GFM の表がずれる）
+ */
+function escapeCell(value: string): string {
+  const single = value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+  return single.length > 0 ? single : ' ';
+}
+
+/** 表ブロックを GFM markdown 表へ変換する。 */
+export function tableBlockToMarkdown(data: TableBlockData): string {
+  const { columns, rows } = data;
+  const colCount = columns.length;
+  const headerLine = `| ${columns.map((c) => escapeCell(c.label)).join(' | ')} |`;
+  const alignLine = `| ${columns.map((c) => ALIGN_MARKER[c.align]).join(' | ')} |`;
+  const bodyLines = rows.map((row) => {
+    // ragged 行を列数ちょうどに正規化してから連結する。
+    const cells = Array.from({ length: colCount }, (_, i) => escapeCell(row[i] ?? ''));
+    return `| ${cells.join(' | ')} |`;
+  });
+  return [headerLine, alignLine, ...bodyLines].join('\n');
+}
+
+function blockToMarkdown(block: Block): string {
+  if (block.type === 'markdown') return block.data.markdown;
+  if (block.type === 'table') return tableBlockToMarkdown(block.data);
+  // 判別ユニオン上は到達不能だが、DB 由来の未知 type を silent に undefined 連結
+  // しないよう loud に失敗させる（壊れたデータを見えるエラーにする）。
+  throw new Error(`blocksToMarkdown: unknown block type: ${(block as { type: string }).type}`);
 }
 
 // 構造境界: レベル2〜4の見出し、または <details> ブロックの開始行。
@@ -28,7 +164,7 @@ const BLOCK_BOUNDARY = /^(?:#{2,4}\s|<details[\s>])/;
 
 /**
  * Markdown 文書を構造境界でブロック配列へ分割する（テキストは無損失）。
- * 連結（blocksToMarkdown）すると元の文書と一致する。
+ * 連結（blocksToMarkdown）すると元の文書と一致する。シードは markdown ブロックのみ生成。
  */
 export function splitMarkdownIntoBlocks(markdown: string): MarkdownBlockData[] {
   const lines = markdown.split('\n');
@@ -53,10 +189,10 @@ export function splitMarkdownIntoBlocks(markdown: string): MarkdownBlockData[] {
   return segments.map((markdown) => ({ markdown }));
 }
 
-/** ブロック配列を order 昇順で 1 つの Markdown 文書へ連結する。 */
+/** ブロック配列を order 昇順で 1 つの Markdown 文書へ連結する（type 別に変換）。 */
 export function blocksToMarkdown(blocks: Block[]): string {
   return [...blocks]
     .sort((a, b) => a.order - b.order)
-    .map((b) => b.data.markdown)
+    .map(blockToMarkdown)
     .join('\n');
 }

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -8,7 +8,16 @@
  */
 import { asc, eq, sql } from 'drizzle-orm';
 
-import { type Block, blocksToMarkdown, splitMarkdownIntoBlocks } from './blocks';
+import {
+  type Block,
+  type BlockInput,
+  blocksToMarkdown,
+  isBlockInputEmpty,
+  isMarkdownBlockData,
+  isTableBlockData,
+  normalizeTableBlockData,
+  splitMarkdownIntoBlocks,
+} from './blocks';
 import { type Database, getDb } from './client';
 import { blocks, skillSheets } from './schema';
 
@@ -105,45 +114,77 @@ async function ensureSeeded(db: Database): Promise<string> {
   return sheetId;
 }
 
+/**
+ * DB の 1 行を検証付きで Block へ変換する。
+ * 壊れた/未知の JSON は生 cast で通さず、不正なら null を返して skip する
+ * （TableBlockEditor 等が壊れたデータで crash しないようにする読み込み側の防御）。
+ */
+function rowToBlock(id: string, type: string, order: number, data: unknown): Block | null {
+  if (type === 'markdown' && isMarkdownBlockData(data)) {
+    return { id, type: 'markdown', order, data };
+  }
+  if (type === 'table' && isTableBlockData(data)) {
+    return { id, type: 'table', order, data: normalizeTableBlockData(data) };
+  }
+  return null;
+}
+
 /** Read the skill sheet from the DB, seeding from GitHub on first access. */
 export async function getSkillSheet(): Promise<SkillSheet> {
   const db = getDb();
   const sheetId = await ensureSeeded(db);
+  const [sheet] = await db
+    .select({ title: skillSheets.title })
+    .from(skillSheets)
+    .where(eq(skillSheets.id, sheetId))
+    .limit(1);
   const rows = await db.select().from(blocks).where(eq(blocks.sheetId, sheetId)).orderBy(asc(blocks.order));
 
-  const blockList: Block[] = rows.map((r) => ({
-    id: r.id,
-    type: r.type as Block['type'],
-    order: r.order,
-    data: r.data as Block['data'],
-  }));
+  const blockList: Block[] = rows
+    .map((r) => rowToBlock(r.id, r.type, r.order, r.data))
+    .filter((b): b is Block => b !== null);
 
-  return { title: TITLE, content: blocksToMarkdown(blockList), blocks: blockList };
+  // タイトルは DB 正本。null/空のときのみ既定値（TITLE）へフォールバックする。
+  const title = sheet?.title && sheet.title.trim().length > 0 ? sheet.title : TITLE;
+
+  return { title, content: blocksToMarkdown(blockList), blocks: blockList };
+}
+
+/** 保存前にブロック入力を正規化する（markdown は末尾空白除去、table は行を列数へ正規化）。 */
+function normalizeBlockInput(block: BlockInput): BlockInput {
+  if (block.type === 'markdown') return { type: 'markdown', data: { markdown: block.data.markdown.trimEnd() } };
+  return { type: 'table', data: normalizeTableBlockData(block.data) };
 }
 
 /**
- * Replace the owner's sheet blocks with the given ordered markdown segments
- * (D&D builder save path). Empty/whitespace-only segments are dropped.
+ * Replace the owner's sheet blocks with the given typed blocks and persist the
+ * title (D&D builder save path). 空ブロックは type 別に判定して drop し、
+ * 残ったブロックに index で order を連番再付与する（gap 無し＝unique 制約と整合）。
  *
  * delete→insert→update を1つのトランザクションで囲み原子性を保証する
  * （途中失敗で旧ブロックだけ消える＝データ損失を防ぐ）。neon-http は
  * 対話的トランザクションは非対応だが、このようなバッチ（中間読み取り無し）の
  * transaction() はサポートされる。
  */
-export async function saveSkillSheetBlocks(markdowns: string[]): Promise<void> {
+export async function saveSkillSheetBlocks(title: string, blocksInput: BlockInput[]): Promise<void> {
   const db = getDb();
   const sheetId = await getOrCreateSheetId(db);
 
-  const cleaned = markdowns.map((m) => m.trimEnd()).filter((m) => m.trim().length > 0);
+  const cleaned = blocksInput.map(normalizeBlockInput).filter((b) => !isBlockInputEmpty(b));
+  // title は notNull のため空のときは既定値を保存する（読み込み側もフォールバックする）。
+  const resolvedTitle = title.trim().length > 0 ? title.trim() : TITLE;
 
   await db.transaction(async (tx) => {
     await tx.delete(blocks).where(eq(blocks.sheetId, sheetId));
     if (cleaned.length > 0) {
       await tx
         .insert(blocks)
-        .values(cleaned.map((markdown, order) => ({ sheetId, type: 'markdown' as const, order, data: { markdown } })));
+        .values(cleaned.map((block, order) => ({ sheetId, type: block.type, order, data: block.data })));
     }
-    await tx.update(skillSheets).set({ updatedAt: sql`now()` }).where(eq(skillSheets.id, sheetId));
+    await tx
+      .update(skillSheets)
+      .set({ title: resolvedTitle, updatedAt: sql`now()` })
+      .where(eq(skillSheets.id, sheetId));
   });
 }
 


### PR DESCRIPTION
## 概要

Issue #47「[SBI] ブロックビルダーMVP 実装継続」の本体。テーブルブロックMVPを `/builder` に実装し、GFMテーブルとして viewer 側に桁揃え込みで描画する。

## Context

WIP commit `2dc5e19` からテーブルブロックMVPの機能10ファイルのみを選択取り込み、`origin/main` (`fbf0374`) 上にクリーンPRとして切り出した。`.claude/` 配下のスキル/エージェント/コマンド20ファイル（機能と無関係のノイズ）は除外。

引き継ぎ元計画が「未反映」と主張していた github除外改良版（`github-sheets.ts`）は #46 で既に origin/main にマージ済み（`git diff origin/main 2dc5e19 -- github-sheets.ts` が空で確認）。本PRには含めない。

## 変更内容（機能10ファイル）

- **`packages/db/src/blocks.ts`** — table ブロック型定義 + serialize/parse（列ヘッダ・各行・桁揃え left/center/right を保持）
- **`packages/db/src/skillsheet.ts`** — table ブロックの永続化・復元対応
- **`apps/web/app/builder/builder-client.tsx`** — テーブルブロックUI（ブロック追加・列/行の追加・削除・桁揃え変更・並べ替え）
- **`apps/web/app/builder/actions.ts`** — 保存アクションの table 対応
- **`apps/web/app/builder/page.tsx`** — ビルダーページ（型情報保持）
- **`apps/web/app/globals.css`** — テーブル・桁揃えスタイル
- **`apps/web/src/component/skill-sheet-viewer.tsx`** — GFM テーブルの桁揃え描画
- 各種テスト追加（`blocks.test.ts`, `builder-client.test.tsx`, `skill-sheet-viewer.test.tsx`）

## 検証

- `pnpm -r type-check` → exit 0 [CLI確認]
- `pnpm -r --if-present test` → 86 passed (exit 0)。テーブルブロック保存payloadテスト含む [CLI確認]
- GitHub Actions CI（lint/typecheck/test/build）→ 本PR上で確認予定 [CI]
- `/builder` E2E（テーブル追加・列行編集・桁揃え・並替・保存・viewer描画）→ 目視＋スクショ添付予定 [実機目視]

Closes #47

<!-- quality-ok -->
