### PR TITLE
ci: add devin-slack-trigger workflow

### DIFF
--- a/.github/workflows/devin-slack-trigger.yml
+++ b/.github/workflows/devin-slack-trigger.yml
@@ -1,0 +1,82 @@
+name: Devin Slack Trigger
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  trigger-devin:
+    name: Trigger Devin via Slack
+    runs-on: ${{ vars.RUNNER_LINUX || 'ubuntu-latest' }}
+    if: github.event.label.name == 'devin'
+    concurrency:
+      group: devin-trigger-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check for duplicate trigger
+        id: duplicate-check
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+              }
+            );
+            const alreadyTriggered = comments.some(c =>
+              c.body?.includes('<!-- devin-slack-triggered -->')
+            );
+            if (alreadyTriggered) {
+              core.notice('Devin session already triggered for this issue. Skipping.');
+            }
+            core.setOutput('skip', String(alreadyTriggered));
+
+      - name: Post message to Slack
+        if: steps.duplicate-check.outputs.skip == 'false'
+        id: slack-post
+        uses: actions/github-script@v9
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+          DEVIN_USER_ID: ${{ vars.SLACK_DEVIN_USER_ID }}
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            const message = `[${issue.title}]\n<@${process.env.DEVIN_USER_ID}> Please handle this issue. First, create a plan and share it before implementing. Think in English, respond in Japanese.\n${issue.html_url}`;
+
+            const resp = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                'Content-Type': 'application/json; charset=utf-8',
+              },
+              body: JSON.stringify({
+                channel: process.env.SLACK_CHANNEL_ID,
+                text: message,
+              }),
+            });
+
+            const data = await resp.json();
+            if (!data.ok) {
+              core.setFailed(`Slack API error: ${data.error || 'unknown'}`);
+            }
+
+      - name: Post marker comment
+        if: success() && steps.duplicate-check.outputs.skip == 'false'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: ':robot_face: Devin session triggered via Slack <!-- devin-slack-triggered -->',
+            });


### PR DESCRIPTION
## What

`devin` ラベルを issue に付けると、対象 Slack チャンネルに `@Devin` メンションを送る GitHub Actions ワークフローを追加します。

## Why

Devin AI エージェントへの作業依頼を Slack 経由で自動化するため。getozinc/pink-labo と同じ仕組みを本 repo にも導入します。

## How

- `on: issues: types: [labeled]` でトリガー
- ラベル名が `devin` の場合のみ実行
- 重複送信防止: 既に `<!-- devin-slack-triggered -->` コメントがある issue はスキップ
- Slack `chat.postMessage` で指定チャンネルに issue タイトル + URL + `@Devin` メンションを送信
- 送信後に marker comment を issue に貼付

## Checklist

- [x] 既存 pink-labo 実装との動作一致を確認済み
- [x] `SLACK_BOT_TOKEN` / `SLACK_CHANNEL_ID` / `SLACK_DEVIN_USER_ID` を repo secrets/variables に設定済み
- [x] `devin` ラベルを repo に追加済み
- [x] 動作確認: 各 repo の issue に devin ラベルを付けて Slack 通知が届くことを確認済み