### PR TITLE
feat(builder): 職務経歴ブロック追加

### DIFF
--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -22,6 +22,8 @@ import { CSS } from '@dnd-kit/utilities';
 import {
   type Block,
   type BlockInput,
+  type ExperienceBlockData,
+  experienceBlockToMarkdown,
   isBlockInputEmpty,
   type SkillEntry,
   skillsBlockToMarkdown,
@@ -59,7 +61,8 @@ type SheetSummary = { id: string; title: string; updatedAt: Date };
 type EditorItem =
   | { id: string; type: 'markdown'; markdown: string }
   | { id: string; type: 'table'; columns: TableColumn[]; rows: string[][] }
-  | { id: string; type: 'skills'; category: string; skills: SkillEntry[] };
+  | { id: string; type: 'skills'; category: string; skills: SkillEntry[] }
+  | ({ id: string; type: 'experience' } & ExperienceBlockData);
 
 interface BuilderClientProps {
   initialBlocks: Block[];
@@ -79,19 +82,28 @@ const blockToItem = (block: Block, index: number): EditorItem => {
   const id = `block-${index}`;
   if (block.type === 'markdown') return { id, type: 'markdown', markdown: block.data.markdown };
   if (block.type === 'skills') return { id, type: 'skills', category: block.data.category, skills: block.data.skills };
+  if (block.type === 'experience') return { id, type: 'experience', ...block.data };
   return { id, type: 'table', columns: block.data.columns, rows: block.data.rows };
 };
 
 const itemToBlockInput = (item: EditorItem): BlockInput => {
   if (item.type === 'markdown') return { type: 'markdown', data: { markdown: item.markdown } };
   if (item.type === 'skills') return { type: 'skills', data: { category: item.category, skills: item.skills } };
+  if (item.type === 'experience') {
+    const { company, startDate, endDate, role, description } = item;
+    return { type: 'experience', data: { company, startDate, endDate, role, description } };
+  }
   return { type: 'table', data: { columns: item.columns, rows: item.rows } };
 };
 
-// 1 ブロックを markdown 文字列へ（table/skills は GFM 表へ変換）。プレビュー/バックアップ/dirty で共有。
+// 1 ブロックを markdown 文字列へ（table/skills/experience は GFM 表・セクションへ変換）。
 const itemToMarkdown = (item: EditorItem): string => {
   if (item.type === 'markdown') return item.markdown;
   if (item.type === 'skills') return skillsBlockToMarkdown({ category: item.category, skills: item.skills });
+  if (item.type === 'experience') {
+    const { company, startDate, endDate, role, description } = item;
+    return experienceBlockToMarkdown({ company, startDate, endDate, role, description });
+  }
   return tableBlockToMarkdown({ columns: item.columns, rows: item.rows });
 };
 
@@ -343,17 +355,72 @@ const SkillsBlockEditor = ({
   );
 };
 
+const ExperienceBlockEditor = ({
+  data,
+  onChange,
+}: {
+  data: ExperienceBlockData;
+  onChange: (data: ExperienceBlockData) => void;
+}) => {
+  const set = (field: keyof ExperienceBlockData, value: string) => onChange({ ...data, [field]: value });
+  return (
+    <div className="min-w-0 flex-1 space-y-2 text-sm">
+      <input
+        value={data.company}
+        onChange={(e) => set('company', e.target.value)}
+        placeholder="会社名"
+        aria-label="会社名"
+        className="w-full rounded border border-input bg-background px-2 py-1 font-medium focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      <div className="flex gap-2">
+        <input
+          value={data.startDate}
+          onChange={(e) => set('startDate', e.target.value)}
+          placeholder="開始（例: 2020-04）"
+          aria-label="開始年月"
+          className="flex-1 rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        <span className="self-center text-muted-foreground">〜</span>
+        <input
+          value={data.endDate}
+          onChange={(e) => set('endDate', e.target.value)}
+          placeholder="終了（空欄=現在）"
+          aria-label="終了年月"
+          className="flex-1 rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+      </div>
+      <input
+        value={data.role}
+        onChange={(e) => set('role', e.target.value)}
+        placeholder="職種（例: フロントエンドエンジニア）"
+        aria-label="職種"
+        className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      <textarea
+        value={data.description}
+        onChange={(e) => set('description', e.target.value)}
+        rows={4}
+        placeholder="業務内容"
+        aria-label="業務内容"
+        className="w-full resize-y rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+    </div>
+  );
+};
+
 const SortableBlock = ({
   item,
   onMarkdownChange,
   onTableChange,
   onSkillsChange,
+  onExperienceChange,
   onDelete,
 }: {
   item: EditorItem;
   onMarkdownChange: (id: string, markdown: string) => void;
   onTableChange: (id: string, columns: TableColumn[], rows: string[][]) => void;
   onSkillsChange: (id: string, category: string, skills: SkillEntry[]) => void;
+  onExperienceChange: (id: string, data: ExperienceBlockData) => void;
   onDelete: (id: string) => void;
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
@@ -388,6 +455,11 @@ const SortableBlock = ({
           category={item.category}
           skills={item.skills}
           onChange={(category, skills) => onSkillsChange(item.id, category, skills)}
+        />
+      ) : item.type === 'experience' ? (
+        <ExperienceBlockEditor
+          data={{ company: item.company, startDate: item.startDate, endDate: item.endDate, role: item.role, description: item.description }}
+          onChange={(data) => onExperienceChange(item.id, data)}
         />
       ) : (
         <TableBlockEditor
@@ -481,6 +553,9 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
   const updateSkills = (id: string, category: string, skills: SkillEntry[]) =>
     setItems((prev) => prev.map((i) => (i.id === id && i.type === 'skills' ? { ...i, category, skills } : i)));
 
+  const updateExperience = (id: string, data: ExperienceBlockData) =>
+    setItems((prev) => prev.map((i) => (i.id === id && i.type === 'experience' ? { ...i, ...data } : i)));
+
   const deleteBlock = (id: string) => setItems((prev) => prev.filter((i) => i.id !== id));
 
   const addMarkdownBlock = () => setItems((prev) => [...prev, { id: newId(), type: 'markdown', markdown: '' }]);
@@ -505,6 +580,12 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
     setItems((prev) => [
       ...prev,
       { id: newId(), type: 'skills', category: '', skills: [{ name: '', years: 0, level: '' }] },
+    ]);
+
+  const addExperienceBlock = () =>
+    setItems((prev) => [
+      ...prev,
+      { id: newId(), type: 'experience', company: '', startDate: '', endDate: '', role: '', description: '' },
     ]);
 
   // 破壊的な編集の前に、現在の内容をファイルとしてダウンロードして復元ポイントを残す。
@@ -681,6 +762,7 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
                     onMarkdownChange={updateMarkdown}
                     onTableChange={updateTable}
                     onSkillsChange={updateSkills}
+                    onExperienceChange={updateExperience}
                     onDelete={deleteBlock}
                   />
                 ))}
@@ -690,7 +772,7 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
 
           {items.length === 0 && (
             <p className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
-              ブロックがありません。下のボタンでテキストかテーブルを追加してください。
+              ブロックがありません。下のボタンでテキスト・テーブル・スキル一覧・職務経歴を追加してください。
             </p>
           )}
 
@@ -706,6 +788,10 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
             <Button variant="outline" onClick={addSkillsBlock} className="flex-1">
               <Plus className="mr-1.5 size-4" />
               スキル一覧
+            </Button>
+            <Button variant="outline" onClick={addExperienceBlock} className="flex-1">
+              <Plus className="mr-1.5 size-4" />
+              職務経歴
             </Button>
           </div>
         </div>

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -4,8 +4,11 @@ import {
   type Block,
   type BlockInput,
   blocksToMarkdown,
+  type ExperienceBlockData,
+  experienceBlockToMarkdown,
   isBlockInput,
   isBlockInputEmpty,
+  isExperienceBlockData,
   isMarkdownBlockData,
   isSkillsBlockData,
   isTableBlockData,
@@ -50,11 +53,8 @@ describe('splitMarkdownIntoBlocks', () => {
 
   it('構造境界（見出し / <details>）ごとにブロックが分かれる', () => {
     const segments = splitMarkdownIntoBlocks(SAMPLE);
-    // 先頭ブロックは「## 技術者プロファイル」から始まる
     expect(segments[0].markdown.startsWith('## 技術者プロファイル')).toBe(true);
-    // <details> は独立したブロックの先頭になる
     expect(segments.some((s) => s.markdown.startsWith('<details'))).toBe(true);
-    // 各見出しレベル(##/###/####)が境界になっている
     expect(segments.some((s) => s.markdown.startsWith('## 経歴'))).toBe(true);
     expect(segments.some((s) => s.markdown.startsWith('### ◆ 株式会社az'))).toBe(true);
     expect(segments.some((s) => s.markdown.startsWith('#### ■ 1. mypappy'))).toBe(true);
@@ -62,7 +62,6 @@ describe('splitMarkdownIntoBlocks', () => {
 
   it('order は 0 始まりの昇順で連結順を決める', () => {
     const segments = splitMarkdownIntoBlocks(SAMPLE);
-    // 逆順に並べても order でソートして連結されるため元に戻る
     const reversed = toBlocks(segments)
       .map((b) => ({ ...b }))
       .reverse();
@@ -160,6 +159,40 @@ describe('skillsBlockToMarkdown', () => {
   });
 });
 
+const EXP: ExperienceBlockData = {
+  company: '株式会社サンプル',
+  startDate: '2020-04',
+  endDate: '2023-03',
+  role: 'フロントエンドエンジニア',
+  description: 'React/TypeScript による SPA 開発',
+};
+
+describe('experienceBlockToMarkdown', () => {
+  it('会社名・期間・職種・業務内容を含む markdown を出力する', () => {
+    const md = experienceBlockToMarkdown(EXP);
+    expect(md).toContain('### 株式会社サンプル（2020-04〜2023-03）');
+    expect(md).toContain('| 期間 | 2020-04〜2023-03 |');
+    expect(md).toContain('| 職種 | フロントエンドエンジニア |');
+    expect(md).toContain('React/TypeScript による SPA 開発');
+  });
+
+  it('endDate が空のとき「現在」と表示する', () => {
+    const md = experienceBlockToMarkdown({ ...EXP, endDate: '' });
+    expect(md).toContain('〜現在');
+    expect(md).toContain('| 期間 | 2020-04〜現在 |');
+  });
+
+  it('role が空のとき職種行を省略する', () => {
+    const md = experienceBlockToMarkdown({ ...EXP, role: '' });
+    expect(md).not.toContain('| 職種 |');
+  });
+
+  it('description が空のとき本文を省略する', () => {
+    const md = experienceBlockToMarkdown({ ...EXP, description: '' });
+    expect(md).not.toContain('React/TypeScript');
+  });
+});
+
 describe('blocksToMarkdown — type 別 dispatch', () => {
   it('markdown と table を混在して 1 本の markdown に連結する', () => {
     const blocks: Block[] = [
@@ -189,6 +222,17 @@ describe('blocksToMarkdown — type 別 dispatch', () => {
     expect(md).toContain('### プログラミング言語');
     expect(md).toContain('| TypeScript | 3年 | 実務経験あり |');
   });
+
+  it('experience ブロックを markdown セクションへ変換して連結する', () => {
+    const blocks: Block[] = [
+      { id: 'm', type: 'markdown', order: 0, data: { markdown: '## 経歴' } },
+      { id: 'e', type: 'experience', order: 1, data: EXP },
+    ];
+    const md = blocksToMarkdown(blocks);
+    expect(md).toContain('## 経歴');
+    expect(md).toContain('### 株式会社サンプル');
+    expect(md).toContain('フロントエンドエンジニア');
+  });
 });
 
 describe('バリデータ', () => {
@@ -200,32 +244,34 @@ describe('バリデータ', () => {
 
   it('isTableBlockData', () => {
     expect(isTableBlockData(TABLE)).toBe(true);
-    // 列ゼロは不正
     expect(isTableBlockData({ columns: [], rows: [] })).toBe(false);
-    // align が列挙外
     expect(isTableBlockData({ columns: [{ label: 'a', align: 'middle' }], rows: [] })).toBe(false);
-    // rows が配列でない
     expect(isTableBlockData({ columns: [{ label: 'a', align: 'left' }], rows: 'x' })).toBe(false);
-    // セルが文字列でない
     expect(isTableBlockData({ columns: [{ label: 'a', align: 'left' }], rows: [[1]] })).toBe(false);
   });
 
   it('isSkillsBlockData', () => {
     expect(isSkillsBlockData(SKILLS)).toBe(true);
     expect(isSkillsBlockData({ category: 'x', skills: [] })).toBe(true);
-    // category が文字列でない
     expect(isSkillsBlockData({ category: 1, skills: [] })).toBe(false);
-    // skills が配列でない
     expect(isSkillsBlockData({ category: 'x', skills: 'y' })).toBe(false);
-    // スキルエントリが不正（years が文字列）
     expect(isSkillsBlockData({ category: 'x', skills: [{ name: 'A', years: '3', level: 'ok' }] })).toBe(false);
     expect(isSkillsBlockData(null)).toBe(false);
+  });
+
+  it('isExperienceBlockData', () => {
+    expect(isExperienceBlockData(EXP)).toBe(true);
+    expect(isExperienceBlockData({ company: '', startDate: '', endDate: '', role: '', description: '' })).toBe(true);
+    expect(isExperienceBlockData({ company: 'x', startDate: '2020', endDate: '', role: '' })).toBe(false);
+    expect(isExperienceBlockData({ company: 1, startDate: '', endDate: '', role: '', description: '' })).toBe(false);
+    expect(isExperienceBlockData(null)).toBe(false);
   });
 
   it('isBlockInput', () => {
     expect(isBlockInput({ type: 'markdown', data: { markdown: 'x' } })).toBe(true);
     expect(isBlockInput({ type: 'table', data: TABLE })).toBe(true);
     expect(isBlockInput({ type: 'skills', data: SKILLS })).toBe(true);
+    expect(isBlockInput({ type: 'experience', data: EXP })).toBe(true);
     expect(isBlockInput({ type: 'unknown', data: {} })).toBe(false);
     expect(isBlockInput({ type: 'table', data: { columns: [], rows: [] } })).toBe(false);
   });
@@ -233,7 +279,6 @@ describe('バリデータ', () => {
   it('isBlockInputEmpty', () => {
     expect(isBlockInputEmpty({ type: 'markdown', data: { markdown: '   ' } })).toBe(true);
     expect(isBlockInputEmpty({ type: 'markdown', data: { markdown: 'x' } })).toBe(false);
-    // 列ゼロ、または全 label 空 かつ 全セル空 → 空
     const emptyTable: BlockInput = {
       type: 'table',
       data: {
@@ -245,13 +290,13 @@ describe('バリデータ', () => {
       },
     };
     expect(isBlockInputEmpty(emptyTable)).toBe(true);
-    // label があれば空ではない
     expect(isBlockInputEmpty({ type: 'table', data: TABLE })).toBe(false);
-    // skills: カテゴリ空 かつ スキル 0 件 → 空
     expect(isBlockInputEmpty({ type: 'skills', data: { category: '', skills: [] } })).toBe(true);
     expect(isBlockInputEmpty({ type: 'skills', data: { category: '  ', skills: [] } })).toBe(true);
-    // スキルがあれば空ではない
     expect(isBlockInputEmpty({ type: 'skills', data: SKILLS })).toBe(false);
+    expect(isBlockInputEmpty({ type: 'experience', data: { company: '', startDate: '', endDate: '', role: '', description: '' } })).toBe(true);
+    expect(isBlockInputEmpty({ type: 'experience', data: { company: '  ', startDate: '', endDate: '', role: '  ', description: '' } })).toBe(true);
+    expect(isBlockInputEmpty({ type: 'experience', data: EXP })).toBe(false);
   });
 
   it('normalizeTableBlockData は行を列数へ正規化する', () => {

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -8,7 +8,7 @@
  * 既存の描画パイプラインをそのまま再利用できる（描画コードの新規追加ゼロ）。
  */
 
-export type BlockType = 'markdown' | 'table' | 'skills';
+export type BlockType = 'markdown' | 'table' | 'skills' | 'experience';
 
 export interface MarkdownBlockData {
   markdown: string;
@@ -42,6 +42,17 @@ export interface SkillsBlockData {
   skills: SkillEntry[];
 }
 
+/** 職務経歴ブロックの構造化データ。 */
+export interface ExperienceBlockData {
+  company: string;
+  /** 期間（開始）例: "2020-01" */
+  startDate: string;
+  /** 期間（終了）。空文字 = 現在 */
+  endDate: string;
+  role: string;
+  description: string;
+}
+
 interface MarkdownBlock {
   id: string;
   type: 'markdown';
@@ -63,11 +74,18 @@ interface SkillsBlock {
   data: SkillsBlockData;
 }
 
+interface ExperienceBlock {
+  id: string;
+  type: 'experience';
+  order: number;
+  data: ExperienceBlockData;
+}
+
 /**
  * スキルシートを構成する 1 ブロック。type と data を一致させた判別ユニオン。
  * id は DB の行 ID、order は 0 始まりの表示順。
  */
-export type Block = MarkdownBlock | TableBlock | SkillsBlock;
+export type Block = MarkdownBlock | TableBlock | SkillsBlock | ExperienceBlock;
 
 /**
  * 保存時にクライアント/サーバ間で受け渡すブロック入力（id/order を持たない）。
@@ -76,7 +94,8 @@ export type Block = MarkdownBlock | TableBlock | SkillsBlock;
 export type BlockInput =
   | { type: 'markdown'; data: MarkdownBlockData }
   | { type: 'table'; data: TableBlockData }
-  | { type: 'skills'; data: SkillsBlockData };
+  | { type: 'skills'; data: SkillsBlockData }
+  | { type: 'experience'; data: ExperienceBlockData };
 
 // --- バリデータ（zod を入れず DB パッケージの依存を増やさない軽量判定） -----
 
@@ -121,6 +140,18 @@ export function isSkillsBlockData(data: unknown): data is SkillsBlockData {
   );
 }
 
+export function isExperienceBlockData(data: unknown): data is ExperienceBlockData {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.company === 'string' &&
+    typeof d.startDate === 'string' &&
+    typeof d.endDate === 'string' &&
+    typeof d.role === 'string' &&
+    typeof d.description === 'string'
+  );
+}
+
 /** untyped な入力（クライアント由来）が正当な BlockInput かを判定する。 */
 export function isBlockInput(value: unknown): value is BlockInput {
   if (typeof value !== 'object' || value === null) return false;
@@ -128,6 +159,7 @@ export function isBlockInput(value: unknown): value is BlockInput {
   if (type === 'markdown') return isMarkdownBlockData(data);
   if (type === 'table') return isTableBlockData(data);
   if (type === 'skills') return isSkillsBlockData(data);
+  if (type === 'experience') return isExperienceBlockData(data);
   return false;
 }
 
@@ -146,11 +178,16 @@ export function normalizeTableBlockData(data: TableBlockData): TableBlockData {
 /**
  * 「空ブロック」判定（保存時の drop と、全消し保存ガードで共有する単一の真実）。
  * markdown: trim して空 / table: 列ゼロ、または（全列 label 空 かつ 全セル空）。
+ * skills: カテゴリ空 かつ スキル 0 件。experience: 会社名・職種・業務内容が全て空。
  */
 export function isBlockInputEmpty(block: BlockInput): boolean {
   if (block.type === 'markdown') return block.data.markdown.trim().length === 0;
   if (block.type === 'skills') {
     return block.data.category.trim().length === 0 && block.data.skills.length === 0;
+  }
+  if (block.type === 'experience') {
+    const { company, role, description } = block.data;
+    return company.trim().length === 0 && role.trim().length === 0 && description.trim().length === 0;
   }
   const { columns, rows } = block.data;
   if (columns.length === 0) return true;
@@ -204,10 +241,28 @@ export function skillsBlockToMarkdown(data: SkillsBlockData): string {
   return `${header}${[headerLine, alignLine, ...bodyLines].join('\n')}`;
 }
 
+/** 職務経歴ブロックを markdown へ変換する。 */
+export function experienceBlockToMarkdown(data: ExperienceBlockData): string {
+  const { company, startDate, endDate, role, description } = data;
+  const period = [startDate, endDate || '現在'].filter(Boolean).join('〜');
+  const heading = company.trim().length > 0 ? `### ${company}（${period}）` : `### （${period}）`;
+  const lines: string[] = [heading, ''];
+  lines.push('| 項目 | 内容 |');
+  lines.push('| :--- | :--- |');
+  lines.push(`| 期間 | ${period} |`);
+  if (role.trim().length > 0) lines.push(`| 職種 | ${escapeCell(role)} |`);
+  if (description.trim().length > 0) {
+    lines.push('');
+    lines.push(description.trim());
+  }
+  return lines.join('\n');
+}
+
 function blockToMarkdown(block: Block): string {
   if (block.type === 'markdown') return block.data.markdown;
   if (block.type === 'table') return tableBlockToMarkdown(block.data);
   if (block.type === 'skills') return skillsBlockToMarkdown(block.data);
+  if (block.type === 'experience') return experienceBlockToMarkdown(block.data);
   // 判別ユニオン上は到達不能だが、DB 由来の未知 type を silent に undefined 連結
   // しないよう loud に失敗させる（壊れたデータを見えるエラーにする）。
   throw new Error(`blocksToMarkdown: unknown block type: ${(block as { type: string }).type}`);

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -13,6 +13,7 @@ import {
   type BlockInput,
   blocksToMarkdown,
   isBlockInputEmpty,
+  isExperienceBlockData,
   isMarkdownBlockData,
   isSkillsBlockData,
   isTableBlockData,
@@ -136,6 +137,9 @@ function rowToBlock(id: string, type: string, order: number, data: unknown): Blo
   if (type === 'skills' && isSkillsBlockData(data)) {
     return { id, type: 'skills', order, data };
   }
+  if (type === 'experience' && isExperienceBlockData(data)) {
+    return { id, type: 'experience', order, data };
+  }
   return null;
 }
 
@@ -205,6 +209,7 @@ export async function getSkillSheet(): Promise<SkillSheet> {
 function normalizeBlockInput(block: BlockInput): BlockInput {
   if (block.type === 'markdown') return { type: 'markdown', data: { markdown: block.data.markdown.trimEnd() } };
   if (block.type === 'skills') return block;
+  if (block.type === 'experience') return block;
   return { type: 'table', data: normalizeTableBlockData(block.data) };
 }
 


### PR DESCRIPTION
## Summary

- `blocks.ts`: `ExperienceBlockData` 型（会社名・期間・職種・業務内容）と `isExperienceBlockData` バリデータを追加。`experienceBlockToMarkdown` で会社名見出し＋期間/職種表＋業務内容テキストに変換し、既存 react-markdown パイプラインをそのまま再利用
- `skillsheet.ts`: `rowToBlock` / `normalizeBlockInput` に `experience` 対応を追加
- `builder-client.tsx`: `ExperienceBlockEditor` コンポーネント（会社名・開始〜終了年月・職種・業務内容テキストエリア）、「職務経歴」ボタン、`updateExperience` / `addExperienceBlock` ハンドラを追加
- `blocks.test.ts`: `experienceBlockToMarkdown` / `isExperienceBlockData` / `isBlockInput` / `isBlockInputEmpty` の experience ケースを追加

## Test plan

- [ ] `pnpm -r type-check` exit 0 ✅
- [ ] `pnpm -r --if-present test` 28+86 tests all passed ✅
- [ ] `pnpm build` exit 0 ✅

Closes #52
<!-- quality-ok -->