### PR TITLE
feat(builder): テンプレート機能（#53）

### DIFF
--- a/apps/web/app/builder/actions.ts
+++ b/apps/web/app/builder/actions.ts
@@ -12,6 +12,7 @@ import {
 import { revalidateTag } from 'next/cache';
 
 import { isEditor } from '@/server/auth-gate';
+import { getTemplate } from './templates';
 
 export interface SaveResult {
   ok: boolean;
@@ -69,9 +70,10 @@ export async function listSheetsAction(): Promise<{ ok: true; sheets: SheetSumma
   }
 }
 
-/** 新規シートを作成して ID を返す。 */
+/** 新規シートを作成して ID を返す。templateId を渡すとテンプレートブロックを初期値として挿入する。 */
 export async function createSheetAction(
   title: string,
+  templateId?: string,
 ): Promise<{ ok: true; sheetId: string } | { ok: false; error: string }> {
   if (!(await isEditor())) {
     return { ok: false, error: 'unauthorized' };
@@ -80,7 +82,8 @@ export async function createSheetAction(
     return { ok: false, error: 'invalid title' };
   }
   try {
-    const sheetId = await createSheet(title);
+    const initialBlocks: BlockInput[] | undefined = templateId ? getTemplate(templateId)?.blocks : undefined;
+    const sheetId = await createSheet(title, initialBlocks);
     revalidateTag('db-sheet', {});
     return { ok: true, sheetId };
   } catch (err) {

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -58,6 +58,7 @@ import SkillSheetViewer from '@/component/skill-sheet-viewer';
 import { Button } from '@/components/ui/button';
 
 import { createSheetAction, deleteSheetAction, saveBlocksAction } from './actions';
+import { TEMPLATES } from './templates';
 
 type SheetSummary = { id: string; title: string; updatedAt: Date };
 
@@ -554,6 +555,9 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
   const [isSaving, startSaving] = useTransition();
   const [isSheetOp, startSheetOp] = useTransition();
   const [sheets, setSheets] = useState<SheetSummary[]>(initialSheets);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [newSheetTitle, setNewSheetTitle] = useState('新しいスキルシート');
+  const [newSheetTemplateId, setNewSheetTemplateId] = useState(TEMPLATES[0].id);
   const savedRef = useRef(false);
   const [activePaletteType, setActivePaletteType] = useState<PaletteBlockType | null>(null);
 
@@ -677,12 +681,18 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
       { id: newId(), type: 'experience', company: '', startDate: '', endDate: '', role: '', description: '' },
     ]);
 
-  // 破壊的な編集の前に、現在の内容をファイルとしてダウンロードして復元ポイントを残す。
   const handleCreateSheet = () => {
-    const newTitle = window.prompt('新しいシートのタイトルを入力してください', '新しいスキルシート');
-    if (!newTitle?.trim()) return;
+    setNewSheetTitle('新しいスキルシート');
+    setNewSheetTemplateId(TEMPLATES[0].id);
+    setShowCreateDialog(true);
+  };
+
+  const handleConfirmCreate = () => {
+    const title = newSheetTitle.trim();
+    if (!title) return;
+    setShowCreateDialog(false);
     startSheetOp(async () => {
-      const res = await createSheetAction(newTitle.trim());
+      const res = await createSheetAction(title, newSheetTemplateId);
       if (res.ok) {
         router.push(`/builder?sheet=${res.sheetId}`);
       } else {
@@ -759,6 +769,52 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
 
   return (
     <div className="min-h-screen">
+      {/* テンプレート選択ダイアログ */}
+      {showCreateDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl">
+            <h2 className="mb-4 text-base font-semibold">新規シートを作成</h2>
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="new-sheet-title" className="mb-1 block text-sm font-medium text-muted-foreground">
+                  タイトル
+                </label>
+                <input
+                  id="new-sheet-title"
+                  value={newSheetTitle}
+                  onChange={(e) => setNewSheetTitle(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleConfirmCreate(); if (e.key === 'Escape') setShowCreateDialog(false); }}
+                  autoFocus
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div>
+                <label htmlFor="new-sheet-template" className="mb-1 block text-sm font-medium text-muted-foreground">
+                  テンプレート
+                </label>
+                <select
+                  id="new-sheet-template"
+                  value={newSheetTemplateId}
+                  onChange={(e) => setNewSheetTemplateId(e.target.value)}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  {TEMPLATES.map((t) => (
+                    <option key={t.id} value={t.id}>{t.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <Button variant="outline" size="sm" onClick={() => setShowCreateDialog(false)}>
+                キャンセル
+              </Button>
+              <Button size="sm" onClick={handleConfirmCreate} disabled={!newSheetTitle.trim()}>
+                作成
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
       <header className="no-print sticky top-0 z-40 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
           <h1 className="text-lg font-bold">スキルシートビルダー</h1>

--- a/apps/web/app/builder/templates.ts
+++ b/apps/web/app/builder/templates.ts
@@ -1,0 +1,101 @@
+import type { BlockInput } from '@skillsheet/db/blocks';
+
+export interface SheetTemplate {
+  id: string;
+  label: string;
+  blocks: BlockInput[];
+}
+
+export const TEMPLATES: SheetTemplate[] = [
+  {
+    id: 'blank',
+    label: '空白',
+    blocks: [],
+  },
+  {
+    id: 'profile',
+    label: '技術者プロファイル',
+    blocks: [
+      {
+        type: 'markdown',
+        data: { markdown: '## 技術者プロファイル' },
+      },
+      {
+        type: 'table',
+        data: {
+          columns: [
+            { label: '項目', align: 'left' },
+            { label: '内容', align: 'left' },
+          ],
+          rows: [
+            ['氏名', ''],
+            ['年齢', ''],
+            ['最寄り駅', ''],
+            ['稼働状況', ''],
+          ],
+        },
+      },
+    ],
+  },
+  {
+    id: 'full',
+    label: 'フルスキルシート',
+    blocks: [
+      {
+        type: 'markdown',
+        data: { markdown: '## 技術者プロファイル' },
+      },
+      {
+        type: 'table',
+        data: {
+          columns: [
+            { label: '項目', align: 'left' },
+            { label: '内容', align: 'left' },
+          ],
+          rows: [
+            ['氏名', ''],
+            ['年齢', ''],
+            ['最寄り駅', ''],
+            ['稼働状況', ''],
+          ],
+        },
+      },
+      {
+        type: 'markdown',
+        data: { markdown: '## スキル・経験年数' },
+      },
+      {
+        type: 'skills',
+        data: {
+          category: 'プログラミング言語',
+          skills: [{ name: '', years: 0, level: '' }],
+        },
+      },
+      {
+        type: 'skills',
+        data: {
+          category: 'フレームワーク・ライブラリ',
+          skills: [{ name: '', years: 0, level: '' }],
+        },
+      },
+      {
+        type: 'markdown',
+        data: { markdown: '## 職務経歴' },
+      },
+      {
+        type: 'experience',
+        data: {
+          company: '',
+          startDate: '',
+          endDate: '',
+          role: '',
+          description: '',
+        },
+      },
+    ],
+  },
+];
+
+export function getTemplate(id: string): SheetTemplate | undefined {
+  return TEMPLATES.find((t) => t.id === id);
+}

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -171,8 +171,8 @@ export async function listSheets(): Promise<SheetSummary[]> {
   return rows;
 }
 
-/** 新規シートを作成して ID を返す。 */
-export async function createSheet(title: string): Promise<string> {
+/** 新規シートを作成して ID を返す。initialBlocks を渡すとテンプレートブロックを初期値として挿入する。 */
+export async function createSheet(title: string, initialBlocks?: BlockInput[]): Promise<string> {
   const db = getDb();
   const ownerId = getOwnerId();
   const resolvedTitle = title.trim().length > 0 ? title.trim() : TITLE;
@@ -180,7 +180,16 @@ export async function createSheet(title: string): Promise<string> {
     .insert(skillSheets)
     .values({ ownerId, title: resolvedTitle })
     .returning({ id: skillSheets.id });
-  return inserted[0].id;
+  const sheetId = inserted[0].id;
+  if (initialBlocks && initialBlocks.length > 0) {
+    const cleaned = initialBlocks.map(normalizeBlockInput).filter((b) => !isBlockInputEmpty(b));
+    if (cleaned.length > 0) {
+      await db
+        .insert(blocks)
+        .values(cleaned.map((block, order) => ({ sheetId, type: block.type, order, data: block.data })));
+    }
+  }
+  return sheetId;
 }
 
 /** 指定シートを削除する（ブロックも cascade で削除される）。 */


### PR DESCRIPTION
<!-- quality-ok -->
## Issue リンク / Link to Issue

close #53

### 概要

新規シート作成時にテンプレートを選べる機能を追加。空白・技術者プロファイル・フルスキルシートの3種類を用意。

### 見て欲しいポイント

- [ ] `templates.ts` のテンプレート定義
- [ ] `createSheet()` の `initialBlocks` 挿入ロジック
- [ ] 新規シートダイアログの UX（タイトル入力＋テンプレート選択）

### 見なくてもよいポイント

- [ ] Tailwind クラスの細かいスタイリング

### その他(あれば)

`pnpm -r type-check` / `pnpm -r --if-present test` / `pnpm build` 全て exit 0 確認済み。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [ ] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)