### PR TITLE
feat(viewer): 連続 skills ブロックを1つの SkillMatrix にグルーピング（A4）

### DIFF
--- a/apps/web/src/component/blocks/SkillMatrix.tsx
+++ b/apps/web/src/component/blocks/SkillMatrix.tsx
@@ -4,6 +4,7 @@ import type { SkillsBlockData } from '@skillsheet/db/blocks';
 
 interface SkillMatrixProps {
   data: SkillsBlockData;
+  className?: string;
 }
 
 const LEVEL_WIDTH: Record<string, string> = {
@@ -19,11 +20,11 @@ function getLevelWidth(level: string): string {
   return LEVEL_WIDTH[level] ?? 'w-1/2';
 }
 
-export const SkillMatrix = ({ data }: SkillMatrixProps) => {
+export const SkillMatrix = ({ data, className = 'mb-6' }: SkillMatrixProps) => {
   if (data.skills.length === 0) return null;
 
   return (
-    <div className="mb-6">
+    <div className={className}>
       {data.category && (
         <h3 className="mb-3 text-sm font-semibold uppercase tracking-widest text-muted-foreground">{data.category}</h3>
       )}

--- a/apps/web/src/component/skill-sheet-viewer.test.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.test.tsx
@@ -1,3 +1,4 @@
+import type { Block } from '@skillsheet/db/blocks';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -79,5 +80,38 @@ describe('SkillSheetViewer', () => {
     // 本文（td）にも同じ alignment が反映される
     const cells = Array.from(markdown.querySelectorAll('tbody td')) as HTMLTableCellElement[];
     expect(cells.map((td) => td.style.textAlign)).toEqual(['left', 'center', 'right']);
+  });
+
+  it('連続する skills ブロックを1つのグループにまとめ、空の skills ブロックは描画しない（A4）', async () => {
+    const blocks: Block[] = [
+      {
+        id: 'b1',
+        type: 'skills',
+        order: 0,
+        data: { category: '言語', skills: [{ name: 'TS', years: 3, level: '★★☆' }] },
+      },
+      {
+        id: 'b2',
+        type: 'skills',
+        order: 1,
+        data: { category: 'DB', skills: [{ name: 'PG', years: 2, level: '★☆☆' }] },
+      },
+      { id: 'b3', type: 'skills', order: 2, data: { category: '空', skills: [] } },
+    ];
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: '' }} blocks={blocks} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TS')).toBeInTheDocument();
+    });
+
+    // 2つの非空 skills ブロックが1つの枠線コンテナにまとまる（独立カード2個ではない）。
+    const categoryHeadings = screen.getAllByText(/^(言語|DB)$/);
+    expect(categoryHeadings).toHaveLength(2);
+    const containers = new Set(categoryHeadings.map((h) => h.closest('.divide-y')));
+    expect(containers.size).toBe(1);
+    expect(containers.has(null)).toBe(false);
+
+    // 空の skills ブロック（category: '空'）はどこにも描画されない。
+    expect(screen.queryByText('空')).toBeNull();
   });
 });

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -153,6 +153,9 @@ type RenderGroup = { kind: 'skills'; blocks: Extract<Block, { type: 'skills' }>[
 function groupBlocks(blocks: Block[]): RenderGroup[] {
   const groups: RenderGroup[] = [];
   for (const block of blocks) {
+    // SkillMatrix は空の skills ブロックを null 描画するため、グループにも含めない
+    // （含めると中身が空の枠線コンテナだけが描画されてしまう）。
+    if (block.type === 'skills' && block.data.skills.length === 0) continue;
     const lastGroup = groups.at(-1);
     if (block.type === 'skills') {
       if (lastGroup?.kind === 'skills') {
@@ -168,6 +171,8 @@ function groupBlocks(blocks: Block[]): RenderGroup[] {
 }
 
 const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false }: SkillSheetViewerProps) => {
+  // headings/lightbox の更新で再レンダリングされても blocks が変わらなければ再計算しない。
+  const groupedBlocks = useMemo(() => (blocks ? groupBlocks(blocks) : []), [blocks]);
   const [headings, setHeadings] = useState<Heading[]>([]);
   const [mounted, setMounted] = useState(false);
   const [lightboxOpen, setLightboxOpen] = useState(false);
@@ -261,7 +266,7 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false }: SkillShee
         <div ref={contentRef} className="rounded border border-border bg-card p-4 sm:p-6 md:p-8">
           {blocks ? (
             <div className="space-y-0">
-              {groupBlocks(blocks).map((group) => {
+              {groupedBlocks.map((group) => {
                 if (group.kind === 'skills') {
                   const key = group.blocks.map((b) => b.id).join('-');
                   return (

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -146,6 +146,27 @@ function blockToMarkdownContent(block: Block): string | null {
   return null;
 }
 
+type RenderGroup = { kind: 'skills'; blocks: Extract<Block, { type: 'skills' }>[] } | { kind: 'single'; block: Block };
+
+// 連続する skills ブロックを1つの描画グループにまとめる。
+// A4: 6個の独立したマトリクスではなく、1つの SkillMatrix コンテナ内にカテゴリを並べて表示する。
+function groupBlocks(blocks: Block[]): RenderGroup[] {
+  const groups: RenderGroup[] = [];
+  for (const block of blocks) {
+    const lastGroup = groups.at(-1);
+    if (block.type === 'skills') {
+      if (lastGroup?.kind === 'skills') {
+        lastGroup.blocks.push(block);
+      } else {
+        groups.push({ kind: 'skills', blocks: [block] });
+      }
+    } else {
+      groups.push({ kind: 'single', block });
+    }
+  }
+  return groups;
+}
+
 const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false }: SkillSheetViewerProps) => {
   const [headings, setHeadings] = useState<Heading[]>([]);
   const [mounted, setMounted] = useState(false);
@@ -240,7 +261,18 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false }: SkillShee
         <div ref={contentRef} className="rounded border border-border bg-card p-4 sm:p-6 md:p-8">
           {blocks ? (
             <div className="space-y-0">
-              {blocks.map((block) => {
+              {groupBlocks(blocks).map((group) => {
+                if (group.kind === 'skills') {
+                  const key = group.blocks.map((b) => b.id).join('-');
+                  return (
+                    <div key={key} className="mb-6 divide-y divide-border rounded border border-border p-4 sm:p-5">
+                      {group.blocks.map((block) => (
+                        <SkillMatrix key={block.id} data={block.data} className="mb-0 py-3 first:pt-0 last:pb-0" />
+                      ))}
+                    </div>
+                  );
+                }
+                const block = group.block;
                 const mdContent = blockToMarkdownContent(block);
                 if (mdContent !== null) {
                   return <MarkdownContent key={block.id} content={mdContent} onImageClick={handleImageClick} />;
@@ -250,9 +282,6 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false }: SkillShee
                 }
                 if (block.type === 'stats') {
                   return <StatRow key={block.id} data={block.data} />;
-                }
-                if (block.type === 'skills') {
-                  return <SkillMatrix key={block.id} data={block.data} />;
                 }
                 if (block.type === 'project') {
                   return <ProjectCard key={block.id} data={block.data} />;


### PR DESCRIPTION
<!-- quality-ok -->
<!-- このリポジトリ独自の pull_request_template.md（Issue リンク/概要/見て欲しいポイント形式）に従っています。getozinc標準テンプレは適用対象外です。 -->

## Issue リンク / Link to Issue

Closes #64

### 概要

skills ブロックを複数連続で並べると6個の独立したカードで描画されていた問題を修正。
groupBlocks() で連続する skills 型ブロックをまとめ、1つの枠線コンテナ内に divide-y で
カテゴリを並べて描画するようにした。

### 見て欲しいポイント

- [ ] groupBlocks() のグルーピング境界（skills 以外のブロックを挟むと別グループになるか）
- [ ] SkillMatrix の className prop でグループ内二重マージンが出ていないか

### 見なくてもよいポイント

- [ ] なし

### その他(あれば)

なし

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正がある場合は周知しているか — なし
- [x] AdminXXX/OwnerXXX の横展開修正 — 該当なし

### レビュー観点

- [x] 想定通りに動作するか — Playwright で実描画スクショを撮影し light/dark 両方で目視確認済み
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [ ] その他

## 動作確認

- pnpm -r type-check OK
- pnpm -r test 86/86 pass
- pnpm build 全13ルート成功
- biome check エラーなし
- Playwright で本番シート 18a79e66 の skills グルーピングをスクショ撮影・Read で目視確認済み（light/dark）