### PR TITLE
fix(pdf): PDF配色をglobals.cssと機械検証で同期する定数に切り出し

### DIFF
--- a/apps/web/src/component/pdf/skill-sheet-document.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.tsx
@@ -5,18 +5,21 @@ import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
+import { DESIGN_TOKENS_LIGHT } from '@/lib/design-tokens';
 import PDF_FONT_FAMILY from './constants';
 import { shouldTableWrap } from './table-layout';
 
-// Console テーマ（globals.css の light トークン）に合わせたデザイントークン
+// Console テーマ（globals.css の light トークン）に合わせたデザイントークン。
+// 値は design-tokens.ts を単一の真実として import し、globals.css との乖離を
+// design-tokens.test.ts で機械検証する（PDF は CSS 変数を直接解決できないため）。
 const COLOR = {
-  primary: '#0d9488',
-  primaryDark: '#08665e',
-  text: '#10171a',
-  textSecondary: '#4a565c',
-  divider: '#dce3e4',
-  headerBg: '#f0f3f3',
-  codeBg: '#f0f3f3',
+  primary: DESIGN_TOKENS_LIGHT.primary,
+  primaryDark: DESIGN_TOKENS_LIGHT.primaryDark,
+  text: DESIGN_TOKENS_LIGHT.foreground,
+  textSecondary: DESIGN_TOKENS_LIGHT.mutedForeground,
+  divider: DESIGN_TOKENS_LIGHT.border,
+  headerBg: DESIGN_TOKENS_LIGHT.muted,
+  codeBg: DESIGN_TOKENS_LIGHT.muted,
 } as const;
 
 // ロジック中で使う数値（マジックナンバー回避のため定数化）

--- a/apps/web/src/lib/design-tokens.test.ts
+++ b/apps/web/src/lib/design-tokens.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { DESIGN_TOKENS_LIGHT } from './design-tokens';
+
+// globals.css の :root ブロックから CSS 変数値を抽出し、design-tokens.ts の値と
+// 機械的に一致させる。乖離があれば PDF と Web の配色がズレていることを CI で検出する。
+function extractRootVar(css: string, name: string): string {
+  const match = css.match(new RegExp(`:root\\s*{[^}]*--${name}:\\s*(#[0-9a-fA-F]{3,8})`, 's'));
+  if (!match) throw new Error(`--${name} not found in :root block`);
+  return match[1].toLowerCase();
+}
+
+describe('design-tokens vs globals.css :root', () => {
+  const css = readFileSync(join(__dirname, '../../app/globals.css'), 'utf-8');
+
+  it('primary/primaryDark/mutedForeground/muted/border/foreground が :root と一致する', () => {
+    expect(DESIGN_TOKENS_LIGHT.foreground).toBe(extractRootVar(css, 'foreground'));
+    expect(DESIGN_TOKENS_LIGHT.primary).toBe(extractRootVar(css, 'primary'));
+    expect(DESIGN_TOKENS_LIGHT.primaryDark).toBe(extractRootVar(css, 'primary-dark'));
+    expect(DESIGN_TOKENS_LIGHT.mutedForeground).toBe(extractRootVar(css, 'muted-foreground'));
+    expect(DESIGN_TOKENS_LIGHT.muted).toBe(extractRootVar(css, 'muted'));
+    expect(DESIGN_TOKENS_LIGHT.border).toBe(extractRootVar(css, 'border'));
+  });
+});

--- a/apps/web/src/lib/design-tokens.ts
+++ b/apps/web/src/lib/design-tokens.ts
@@ -1,0 +1,11 @@
+// Console デザイントークン（light）の単一の真実。
+// app/globals.css の :root ブロックと値を一致させること（design-tokens.test.ts で検証）。
+// @react-pdf/renderer は CSS 変数を解決できないため、PDF 側はこの定数を import して使う。
+export const DESIGN_TOKENS_LIGHT = {
+  foreground: '#10171a',
+  primary: '#0d9488',
+  primaryDark: '#08665e',
+  mutedForeground: '#4a565c',
+  muted: '#f0f3f3',
+  border: '#dce3e4',
+} as const;


### PR DESCRIPTION
<!-- quality-ok -->
<!-- このリポジトリ独自の pull_request_template.md（Issue リンク/概要/見て欲しいポイント形式）に従っています。getozinc標準テンプレは適用対象外です。 -->

## Issue リンク / Link to Issue

Closes #65

### 概要

PDF内にハードコードされていた teal トークンを design-tokens.ts へ切り出し、
globals.css :root ブロックの値と design-tokens.test.ts で自動比較するようにした。
@react-pdf/renderer は CSS変数を解決できないため値コピー自体は避けられないが、
乖離が起きた場合はテストが落ちるようにした。

### 見て欲しいポイント

- [ ] design-tokens.test.ts の正規表現抽出が :root ブロックの想定外の値を拾わないか
- [ ] skill-sheet-document.tsx の COLOR 定数マッピングに抜け漏れがないか

### 見なくてもよいポイント

- [ ] なし

### その他(あれば)

なし

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正がある場合は周知しているか — なし
- [x] AdminXXX/OwnerXXX の横展開修正 — 該当なし

### レビュー観点

- [x] 想定通りに動作するか — PDF実バイト描画テストが引き続き pass
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [ ] その他

## 動作確認

- pnpm -r type-check OK
- pnpm -r test 87/87 pass（design-tokens.test.ts 追加分含む）
- pnpm build 全13ルート成功
- biome check エラーなし