### PR TITLE
chore: handoff zip をgitignore対象に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ secret
 .npm
 playground.nnb
 
+# archives / handoff bundles
+*.zip
+
 # seo
 sitemap*.xml
 robots.txt


### PR DESCRIPTION
<!-- no-sbi: 単発chore（.gitignoreへのzip除外追加）、局長からの直接指示でissue紐付けなし -->
<!-- quality-ok -->
## Issue リンク / Link to Issue

close #

### 概要

セッション引き継ぎ用に生成される `*.zip` が未追跡ファイルとしてgit statusに残り続けていた。`.gitignore` に `*.zip` を追加して除外する。対応するissueはなし（局長からの直接指示）。

### 見て欲しいポイント

- [ ] `.gitignore` への `*.zip` 追加が既存の除外ルールと衝突していないか

### 見なくてもよいポイント

- [ ] 特になし

### その他(あれば)

特になし

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）→ 単純なgitignore修正のため対象外
- [x] 複数の変更が 1 つの PR に入り込んでいないか → `.gitignore` 1ファイルのみ
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか → 該当なし
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか → 該当なし

### レビュー観点

- [x] 想定通りに動作するか → `git status` / `git check-ignore -v` で確認済み
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ → 既存の `# temp` セクション近くに追記
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)