### PR TITLE
fix(viewer): スキルマトリクスをカテゴリ横並びグリッドに変更

### DIFF
--- a/apps/web/src/component/blocks/SkillMatrix.tsx
+++ b/apps/web/src/component/blocks/SkillMatrix.tsx
@@ -28,20 +28,19 @@ export const SkillMatrix = ({ data, className = 'mb-6' }: SkillMatrixProps) => {
       {data.category && (
         <h3 className="mb-3 text-sm font-semibold uppercase tracking-widest text-muted-foreground">{data.category}</h3>
       )}
-      <div className="grid gap-2 sm:grid-cols-2">
+      <div className="grid gap-2.5">
         {data.skills.map((skill, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: 静的リスト
-          <div key={i} className="flex items-center gap-3">
-            <span className="w-28 shrink-0 truncate text-sm text-foreground">{skill.name}</span>
-            <div className="flex-1">
-              <div className="h-1.5 w-full rounded-full bg-muted">
-                <div className={`h-1.5 rounded-full bg-primary ${getLevelWidth(skill.level)}`} />
-              </div>
+          <div key={i} className="space-y-1">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate text-sm text-foreground">{skill.name}</span>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {skill.years > 0 ? `${skill.years}年` : '-'} {skill.level}
+              </span>
             </div>
-            <span className="w-12 shrink-0 text-right text-xs text-muted-foreground">
-              {skill.years > 0 ? `${skill.years}年` : '-'}
-            </span>
-            <span className="w-16 shrink-0 text-right text-xs text-muted-foreground">{skill.level}</span>
+            <div className="h-1.5 w-full rounded-full bg-muted">
+              <div className={`h-1.5 rounded-full bg-primary ${getLevelWidth(skill.level)}`} />
+            </div>
           </div>
         ))}
       </div>

--- a/apps/web/src/component/skill-sheet-viewer.test.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.test.tsx
@@ -104,10 +104,10 @@ describe('SkillSheetViewer', () => {
       expect(screen.getByText('TS')).toBeInTheDocument();
     });
 
-    // 2つの非空 skills ブロックが1つの枠線コンテナにまとまる（独立カード2個ではない）。
+    // 2つの非空 skills ブロックが1つのグリッドコンテナにまとまる（独立カード2個ではない）。
     const categoryHeadings = screen.getAllByText(/^(言語|DB)$/);
     expect(categoryHeadings).toHaveLength(2);
-    const containers = new Set(categoryHeadings.map((h) => h.closest('.divide-y')));
+    const containers = new Set(categoryHeadings.map((h) => h.closest('.grid')));
     expect(containers.size).toBe(1);
     expect(containers.has(null)).toBe(false);
 

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -270,9 +270,16 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false }: SkillShee
                 if (group.kind === 'skills') {
                   const key = group.blocks.map((b) => b.id).join('-');
                   return (
-                    <div key={key} className="mb-6 divide-y divide-border rounded border border-border p-4 sm:p-5">
+                    <div
+                      key={key}
+                      className="mb-6 grid grid-cols-1 gap-4 rounded border border-border p-4 sm:p-5 md:grid-cols-2 lg:grid-cols-3"
+                    >
                       {group.blocks.map((block) => (
-                        <SkillMatrix key={block.id} data={block.data} className="mb-0 py-3 first:pt-0 last:pb-0" />
+                        <SkillMatrix
+                          key={block.id}
+                          data={block.data}
+                          className="mb-0 rounded-md border border-border/60 p-3"
+                        />
                       ))}
                     </div>
                   );


### PR DESCRIPTION
<!-- quality-ok -->
<!-- no-sbi: 局長からのチャット指示による作業のため紐づくGitHub issue/SBIなし -->

## Issue リンク / Link to Issue

close #

### 概要

スキルマトリクスを縦積みからモックアップ通りの横並びグリッドに変更した。1440px幅で3カラム、375px幅で1カラムに切り替わる。

### 見て欲しいポイント

- [ ] `skill-sheet-viewer.tsx` のグルーピングコンテナを `divide-y` 縦積みから `grid` （md:2列 / lg:3列）に変更
- [ ] `SkillMatrix.tsx` の各行を「名前+年数/レベル」と「進捗バー」の2段組みに変更（グリッド化で列幅が狭くなり、横一列レイアウトだと文字が隣列に重なる崩れが出たための修正）
- [ ] 1440px幅で言語/フロントエンド/バックエンドが横並び3カラム、データベース以下が2段目になること（Playwright実描画で確認済み）
- [ ] 375px幅で1カラム縦積みになること（同上）

### 見なくてもよいポイント

- [ ] ダークモード配色トークンは既存のまま変更なし

### その他(あれば)

- 調査中、`localhost:3000` を5時間以上占有していた古い `next dev` プロセスを発見。旧コードのまま応答しており、これがローカル差分表示の原因だった。killして再起動し最新コードで確認済み。
- テストの `.divide-y` セレクタを新しい `.grid` に更新。`pnpm -r type-check` / `pnpm -r --if-present test` 全通過。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [x] 想定通りに動作するか
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)