### PR TITLE
ci: add job timeout-minutes to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   node:
     name: Node (${{ matrix.check-type }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false

--- a/.github/workflows/devin-slack-trigger.yml
+++ b/.github/workflows/devin-slack-trigger.yml
@@ -11,6 +11,7 @@ jobs:
   trigger-devin:
     name: Trigger Devin via Slack
     runs-on: ${{ vars.RUNNER_LINUX || 'ubuntu-latest' }}
+    timeout-minutes: 5
     if: github.event.label.name == 'devin'
     concurrency:
       group: devin-trigger-${{ github.event.issue.number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,6 +19,7 @@ jobs:
   label:
     name: Label pull request
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.pull_request.draft == false
     steps:
       - name: Add labels from branch and changed files

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -20,6 +20,7 @@ jobs:
   dependency-audit:
     name: Dependency audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #

### 概要

全 GitHub Actions ワークフローの各ジョブに `timeout-minutes` を追加し、ハング／暴走ジョブが CI 時間を浪費するのを防ぐ。CI ハードニングのスイープの一環で、変更は最小限に留めている。

| ファイル | ジョブ | 追加した timeout |
|---|---|---|
| `.github/workflows/ci.yml` | `node` | 15 分 |
| `.github/workflows/security-scan.yml` | `dependency-audit` | 15 分 |
| `.github/workflows/labeler.yml` | `label` | 5 分 |
| `.github/workflows/devin-slack-trigger.yml` | `trigger-devin` | 5 分 |

### 監査結果（変更しなかった項目とその根拠）

- **labeler.yml**: `pull_request_target` だが checkout ステップが無く、信頼できない PR head を一切チェックアウトしない（github-script による API 操作のみ）。権限は既に最小権限で、`addLabels` に必要な `issues:write` + `pull-requests:write`（#70 のコメントで根拠明記）と `contents:read` ベースラインのみ。使用アクションは `actions/github-script`（first-party `actions/*`）のため SHA ピン留めは行わない（Renovate で @vN 追従）。
- **security-scan.yml**: 実行内容は `pnpm audit` のみ。semgrep / trufflehog は存在しないためピン留め対象なし。`permissions: contents: read` と concurrency は既に適切。
- **ci.yml**: `permissions: contents: read` と concurrency は既存で適切。
- **devin-slack-trigger.yml**: コメント投稿のため `issues:write` が必要（write スコープのため降格しない）。concurrency はジョブレベルで既に宣言済み（`cancel-in-progress: false`）のためワークフローレベルの追加は行わない。

### 見て欲しいポイント

- [ ] 各ジョブの `timeout-minutes` 値が妥当か（lint/type/test/build/audit=15分、小規模スクリプト=5分）

### 見なくてもよいポイント

- [ ] ワークフローロジック自体（未変更）

### その他(あれば)

husky は本リポジトリに存在せず、追加もしていない（pnpm モノレポの ci.yml で lint/type/test を担保済み）。

---

### PR チェックポイント

- [x] 複数の変更が 1 つの PR に入り込んでいないか（timeout 追加のみ）
- [x] 開発環境修正はなし

### レビュー観点

- [ ] `timeout-minutes` の値が各ジョブの実行時間に対して十分か
- [ ] 最小権限・SHA ピン留めの監査判断が妥当か


---
_Generated by [Claude Code](https://claude.ai/code/session_011FLbbgmTJkjve2bRRCBGeF)_