### PR TITLE
fix(builder): シート切替時のエディタ state 未同期を修正

### DIFF
--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -105,6 +105,38 @@ describe('BuilderClient', () => {
     );
   });
 
+  it('シート切替（key={activeSheetId} での再マウント）で内容とタイトルが新シートの値にリセットされる', () => {
+    // page.tsx は router.push('/builder?sheet=X') による同一ルート遷移で
+    // <BuilderClient key={activeSheetId} .../> を再レンダーする。key が
+    // activeSheetId 込みでないと state が前シートの値のまま残り、保存時に
+    // 別シートを誤った内容で上書きするバグが再発する（page.tsx 参照）。
+    const sheetA = { id: 'sheet-a', title: 'シートA', updatedAt: new Date() };
+    const sheetB = { id: 'sheet-b', title: 'シートB', updatedAt: new Date() };
+    const { rerender } = render(
+      <BuilderClient
+        key="sheet-a"
+        initialBlocks={mdBlocks(['## Aの内容'])}
+        initialTitle="シートA"
+        sheets={[sheetA, sheetB]}
+        activeSheetId="sheet-a"
+      />,
+    );
+    expect((screen.getByPlaceholderText('Markdown を入力...') as HTMLTextAreaElement).value).toBe('## Aの内容');
+    expect(screen.getByLabelText('タイトル')).toHaveValue('シートA');
+
+    rerender(
+      <BuilderClient
+        key="sheet-b"
+        initialBlocks={mdBlocks(['## Bの内容'])}
+        initialTitle="シートB"
+        sheets={[sheetA, sheetB]}
+        activeSheetId="sheet-b"
+      />,
+    );
+    expect((screen.getByPlaceholderText('Markdown を入力...') as HTMLTextAreaElement).value).toBe('## Bの内容');
+    expect(screen.getByLabelText('タイトル')).toHaveValue('シートB');
+  });
+
   it('タイトル入力が保存 payload に反映される', async () => {
     const user = userEvent.setup();
     render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="旧" {...defaultProps} />);

--- a/apps/web/app/builder/page.tsx
+++ b/apps/web/app/builder/page.tsx
@@ -51,7 +51,11 @@ export default async function BuilderPage({ searchParams }: { searchParams: Prom
   }
 
   return (
+    // key={activeSheetId}: シート切替は searchParams のみが変わる同一ルート遷移のため、
+    // key が無いと BuilderClient は再マウントされず items/title/savedUpdatedAtRef が
+    // 前のシートの値のまま残り、保存時に別シートを誤った内容で上書きしてしまう。
     <BuilderClient
+      key={activeSheetId}
       initialBlocks={initialBlocks}
       initialTitle={initialTitle}
       sheets={sheets}


### PR DESCRIPTION
<!-- quality-ok -->
<!-- no-sbi: このリポジトリ(kouiso/skillsheet-viewer)は個人プロジェクトでPBI/SBI issue運用をしていません。PR #78 の自己レビュー中に見つけたバグ修正で、特定issueには紐づきません -->

## Issue リンク / Link to Issue

close #

### 概要

PR #78 の自己レビュー中に見つけたバグを修正します。#78 は自己レビュー完了前にマージされたため、修正が間に合わずフォローアップPRとして切り出しました。

### 見て欲しいポイント

- [ ] `apps/web/app/builder/page.tsx` の `<BuilderClient key={activeSheetId} ...>`（シート切替時に確実に再マウントされること）
- [ ] `apps/web/app/builder/builder-client.test.tsx` の追加テスト（再マウントで内容/タイトルがリセットされることの確認）

### 見なくてもよいポイント

- [ ] なし（1ファイル+テストの小さな修正です）

### その他(あれば)

**バグの内容**: `router.push(\x27/builder?sheet=X\x27)` は同一ルートの searchParams 遷移のため、`BuilderClient` に `key` が無いと React は再マウントせず、`items`（編集内容）・`title`・`savedUpdatedAtRef`（楽観ロック基準時刻）が前に開いていたシートの値のまま残ります。この状態で保存すると、`sheetId` は新しいシートを指しているのに `blocks` は前のシートの内容のまま送信され、別シートを誤った内容で上書きしてしまいます。

`<BuilderClient key={activeSheetId} .../>` とすることで、シート切替のたびに確実に再マウント・state リセットされるようにしました。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）（hotfix のため対象外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか（該当なし）
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）（該当なし。単一オーナー運用のため）

### レビュー観点

- [x] 想定通りに動作するか（回帰テストで再マウント時のstateリセットを確認済み）
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [x] その他(具体的に記述をしてください)