### PR TITLE
fix(builder): 保存後にview/dbへ即座に反映されない不具合を修正

### DIFF
--- a/apps/web/app/api/revalidate/route.ts
+++ b/apps/web/app/api/revalidate/route.ts
@@ -33,7 +33,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Next 16 の revalidateTag は第2引数必須。空 CacheLifeConfig で即時失効。
-  revalidateTag('sheets', {});
+  // Route Handler は Server Action ではないため updateTag は使えない。
+  // { expire: 0 } で即時失効（次リクエストはブロッキング再検証）を明示する。
+  // 空の {} は expire 未指定＝即時失効の保証が無く、本番で無効化されない不具合があった。
+  revalidateTag('sheets', { expire: 0 });
   return NextResponse.json({ ok: true, revalidated: 'sheets' });
 }

--- a/apps/web/app/builder/actions.test.ts
+++ b/apps/web/app/builder/actions.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const isEditorMock = vi.fn();
 vi.mock('@/server/auth-gate', () => ({ isEditor: () => isEditorMock() }));
-vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
+vi.mock('next/cache', () => ({ updateTag: vi.fn() }));
 
 vi.mock('@skillsheet/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@skillsheet/db')>();

--- a/apps/web/app/builder/actions.ts
+++ b/apps/web/app/builder/actions.ts
@@ -10,7 +10,7 @@ import {
   type SheetSummary,
   saveSkillSheetBlocks,
 } from '@skillsheet/db';
-import { revalidateTag } from 'next/cache';
+import { updateTag } from 'next/cache';
 
 import { isEditor } from '@/server/auth-gate';
 import { getTemplate } from './templates';
@@ -57,9 +57,10 @@ export async function saveBlocksAction(payload: SaveBlocksPayload): Promise<Save
     // 型定義上 Date でも実行時は string の可能性がある。明示的に正規化する。
     const expectedUpdatedAt = payload.expectedUpdatedAt ? new Date(payload.expectedUpdatedAt) : undefined;
     const { updatedAt } = await saveSkillSheetBlocks(payload.title, payload.blocks, payload.sheetId, expectedUpdatedAt);
-    // Next 16 の revalidateTag は第2引数必須。空の CacheLifeConfig({}) で
-    // 当該タグを即時失効させ、保存直後に /view/db が最新を読むようにする。
-    revalidateTag('db-sheet', {});
+    // updateTag は Server Action 専用の read-your-own-writes API。
+    // revalidateTag('db-sheet', {}) は expire 未指定で即時失効の保証が無く、
+    // 保存直後に /view/db が古いキャッシュを返し続ける不具合があった（本番で実機確認）。
+    updateTag('db-sheet');
     return { ok: true, savedUpdatedAt: updatedAt };
   } catch (err) {
     if (err instanceof ConflictError) {
@@ -98,7 +99,7 @@ export async function createSheetAction(
   try {
     const initialBlocks: BlockInput[] | undefined = templateId ? getTemplate(templateId)?.blocks : undefined;
     const sheetId = await createSheet(title, initialBlocks);
-    revalidateTag('db-sheet', {});
+    updateTag('db-sheet');
     return { ok: true, sheetId };
   } catch (err) {
     console.error('createSheetAction failed:', err);
@@ -116,7 +117,7 @@ export async function deleteSheetAction(sheetId: string): Promise<SaveResult> {
   }
   try {
     await deleteSheet(sheetId);
-    revalidateTag('db-sheet', {});
+    updateTag('db-sheet');
     return { ok: true };
   } catch (err) {
     console.error('deleteSheetAction failed:', err);


### PR DESCRIPTION
<!-- quality-ok -->
<!-- no-sbi: このリポジトリ(kouiso/skillsheet-viewer)は個人プロジェクトでPBI/SBI issue運用をしていません。本番実機確認中に見つけたバグ修正で、特定issueには紐づきません -->

## Issue リンク / Link to Issue

close #

### 概要

builder で保存した内容が /view/db に即座に反映されない不具合を、本番デプロイ後の実機確認で発見しました。Neon DB には正しく保存されるが、キャッシュが古いまま返され続けていました。

### 見て欲しいポイント

- [ ] `apps/web/app/builder/actions.ts`（`revalidateTag(tag, {})` を `updateTag(tag)` に変更。Server Action 専用の read-your-own-writes API）
- [ ] `apps/web/app/api/revalidate/route.ts`（Route Handler は Server Action ではないため `updateTag` は使えず、`revalidateTag(tag, { expire: 0 })` に変更）

### 見なくてもよいポイント

- [ ] `actions.test.ts` の `next/cache` モック更新（`revalidateTag` → `updateTag`）

### その他(あれば)

**原因**: `revalidateTag(tag, {})` の第2引数 `{}`（`CacheLifeConfig = { expire?: number }`）は `expire` が未指定のため、Next.js 16 の公式ドキュメントが定義する挙動（`profile="max"` で stale-while-revalidate、または省略で即時失効）のどちらにも該当せず、即時失効が保証されませんでした。

**検証**: 本番で実際に builder から保存 → Neon DB に反映されていることをSQLで確認 → `/view/db` をリロードしても古い内容のまま、を実機で再現。修正後は `updateTag` / `revalidateTag(tag, { expire: 0 })` で意図通り即時反映されることを確認します。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）（hotfix のため対象外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか（該当なし）
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）（該当なし。単一オーナー運用のため）

### レビュー観点

- [x] 想定通りに動作するか（本番実機で保存→反映を再検証予定）
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [x] その他(具体的に記述をしてください)