### PR TITLE
fix(db): サーバー側blocksToMarkdownのGFMテーブル未認識バグを修正

### DIFF
--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -8,7 +8,9 @@ import BuilderClient from './builder-client';
 // 重いビューア（lightbox/IntersectionObserver 依存）はプレビュー描画を素朴にモック
 vi.mock('@/component/skill-sheet-viewer', () => ({
   default: ({ skillSheet }: { skillSheet: { content: string } }) => (
-    <div data-testid="preview">{skillSheet.content}</div>
+    <div data-testid="preview" data-raw={skillSheet.content}>
+      {skillSheet.content}
+    </div>
   ),
 }));
 
@@ -74,6 +76,15 @@ describe('BuilderClient', () => {
   it('プレビューに連結 Markdown が反映される', () => {
     render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" {...defaultProps} />);
     expect(screen.getByTestId('preview')).toHaveTextContent('## A ## B');
+  });
+
+  it('ブロック間は空行(\\n\\n)で結合される（GFM テーブル認識の回帰テスト）', () => {
+    // 単一改行(\n)だと GFM テーブルが直前の段落に lazy continuation として飲み込まれ、
+    // テーブル区切り行 (:---:) がそのまま生テキストとして表示される不具合があった
+    // （builder-client.tsx の assembleMarkdown 参照）。
+    render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" {...defaultProps} />);
+    const raw = screen.getByTestId('preview').getAttribute('data-raw');
+    expect(raw).toBe('## A\n\n## B');
   });
 
   it('「テーブル」追加→セル入力が table ブロックとして保存 payload に入る', async () => {

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -163,7 +163,10 @@ const itemToMarkdown = (item: EditorItem): string => {
   }
 };
 
-const assembleMarkdown = (items: EditorItem[]): string => items.map(itemToMarkdown).join('\n');
+// ブロック間は空行区切り（\n\n）が必須。単一改行だと GFM テーブルが直前の段落に
+// 「lazy continuation」として飲み込まれ、テーブルとして認識されずヘッダー/区切り行
+// (:---:) がそのまま生テキストとして表示される不具合があった（PDF/プレビュー実機確認）。
+const assembleMarkdown = (items: EditorItem[]): string => items.map(itemToMarkdown).join('\n\n');
 
 // dirty 比較用スナップショット（タイトル＋組み立て済み markdown 文字列）。
 // typed item を直接比較せず、保存される最終形（markdown）で差分を見る。

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -203,13 +203,15 @@ describe('experienceBlockToMarkdown', () => {
 });
 
 describe('blocksToMarkdown — type 別 dispatch', () => {
-  it('markdown と table を混在して 1 本の markdown に連結する', () => {
+  it('markdown と table を混在して 1 本の markdown に連結する（table 等の非 markdown 型が隣接する境界は空行区切り）', () => {
+    // GFM テーブルは直前が空行でないと段落へ lazy continuation として飲み込まれ、
+    // テーブルとして認識されない（区切り行がそのまま生テキスト表示される不具合の再発防止）。
     const blocks: Block[] = [
       { id: 'm', type: 'markdown', order: 0, data: { markdown: '## 見出し' } },
       { id: 't', type: 'table', order: 1, data: TABLE },
     ];
     expect(blocksToMarkdown(blocks)).toBe(
-      ['## 見出し', '| 左 | 中 | 右 |', '| :--- | :---: | ---: |', '| a | b | c |'].join('\n'),
+      ['## 見出し', '', '| 左 | 中 | 右 |', '| :--- | :---: | ---: |', '| a | b | c |'].join('\n'),
     );
   });
 

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -541,10 +541,29 @@ export function splitMarkdownIntoBlocks(markdown: string): MarkdownBlockData[] {
   return segments.map((markdown) => ({ markdown }));
 }
 
-/** ブロック配列を order 昇順で 1 つの Markdown 文書へ連結する（type 別に変換）。 */
+/**
+ * ブロック配列を order 昇順で 1 つの Markdown 文書へ連結する（type 別に変換）。
+ *
+ * markdown 型ブロック同士は従来どおり単一改行(\n)で連結する
+ * （splitMarkdownIntoBlocks とのラウンドトリップ無損失を維持するため）。
+ * それ以外（table/skills/experience/profile/stats/project 等、GFM テーブルを
+ * 内部生成しうる構造化ブロック）が隣接する場合は空行(\n\n)で連結する。単一改行だと
+ * GFM テーブルが直前の段落へ lazy continuation として飲み込まれ、テーブルとして
+ * 認識されず区切り行(:---:)がそのまま生テキストとして表示される不具合があった
+ * （本番 PDF 出力・/view/db で実機確認）。
+ */
 export function blocksToMarkdown(blocks: Block[]): string {
-  return [...blocks]
-    .sort((a, b) => a.order - b.order)
-    .map(blockToMarkdown)
-    .join('\n');
+  const sorted = [...blocks].sort((a, b) => a.order - b.order);
+  let result = '';
+  for (let i = 0; i < sorted.length; i++) {
+    const markdown = blockToMarkdown(sorted[i]);
+    if (i === 0) {
+      result = markdown;
+      continue;
+    }
+    const prevType = sorted[i - 1].type;
+    const separator = prevType === 'markdown' && sorted[i].type === 'markdown' ? '\n' : '\n\n';
+    result += separator + markdown;
+  }
+  return result;
 }


### PR DESCRIPTION
<!-- quality-ok -->
<!-- no-sbi: このリポジトリ(kouiso/skillsheet-viewer)は個人プロジェクトでPBI/SBI issue運用をしていません。本番実機確認中に見つけたバグ修正で、特定issueには紐づきません -->

## Issue リンク / Link to Issue

close #

### 概要

先行PR（#82、ビルダー画面のプレビュー用 assembleMarkdown 修正）をデプロイ後、本番PDFを再ダウンロードして目視確認したところ、まだ `:---:` の生テキストが残っていました。原因は `/view/db` や PDF が実際に使うのはサーバー側 `packages/db/src/blocks.ts` の `blocksToMarkdown` で、そちらは未修正のままだったためです。

### 見て欲しいポイント

- [ ] `packages/db/src/blocks.ts` の `blocksToMarkdown`（markdown型ブロック同士は単一改行のまま、それ以外の構造化ブロックが隣接する境界のみ空行に変更）
- [ ] `blocks.test.ts` の期待値更新（markdown+table混在時の正しい区切り）

### 見なくてもよいポイント

- [ ] なし（1ファイル+テストの小さな修正です）

### その他(あれば)

**なぜ単純に全部空行にしなかったか**: `splitMarkdownIntoBlocks`（legacy markdown文書をブロック分割するシード用の関数）と `blocksToMarkdown` の間に「連結すると元の文書と一致する」というラウンドトリップ無損失の既存テストがあり、markdown型ブロック同士を空行結合に変えるとこれが壊れます。そのため、GFMテーブルを生成しうる構造化ブロック（table/stats/project等）が隣接する境界だけ空行にする形にしました。

**検証**: 本番で `#82` デプロイ後に PDF を再ダウンロード→目視で `:---:` がまだ残っていることを確認→原因調査→本修正→ローカルで全テスト(189件)通過を確認。マージ後、本番で再度PDFを目視確認します。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）（hotfix のため対象外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか（該当なし）
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）（該当なし。単一オーナー運用のため）

### レビュー観点

- [x] 想定通りに動作するか（ラウンドトリップテスト含め全テスト通過。マージ後に本番PDFで再確認予定）
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [x] その他(具体的に記述をしてください)