### PR TITLE
fix(builder): スキルブロックのテーブルが375pxで横スクロールする不具合を修正

### DIFF
--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -148,6 +148,22 @@ describe('BuilderClient', () => {
     expect(screen.getByLabelText('タイトル')).toHaveValue('シートB');
   });
 
+  it('スキルブロックのテーブルは overflow-x-auto でラップされる（375px モバイル横スクロール回帰テスト）', () => {
+    // ラッパー無しだとテーブルがページ全体を横に押し広げ、/builder が 375px 幅で
+    // 横スクロールしてしまう不具合があった（本番実機で scrollWidth 548px > 375px を確認）。
+    const skillsBlock: Block[] = [
+      {
+        id: 'skills-1',
+        type: 'skills',
+        order: 0,
+        data: { category: '言語', skills: [{ name: 'TypeScript', years: 5, level: '実務経験あり' }] },
+      },
+    ];
+    render(<BuilderClient initialBlocks={skillsBlock} initialTitle="t" {...defaultProps} />);
+    const table = screen.getByRole('table');
+    expect(table.parentElement).toHaveClass('overflow-x-auto');
+  });
+
   it('タイトル入力が保存 payload に反映される', async () => {
     const user = userEvent.setup();
     render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="旧" {...defaultProps} />);

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -353,62 +353,66 @@ const SkillsBlockEditor = ({
         placeholder="カテゴリ（例: プログラミング言語）"
         className="w-full rounded border border-input bg-background px-2 py-1 text-sm font-medium focus:outline-none focus:ring-1 focus:ring-ring"
       />
-      <table className="w-full border-collapse text-sm">
-        <thead>
-          <tr>
-            <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">スキル</th>
-            <th className="border border-border px-2 py-1 text-center text-xs text-muted-foreground w-20">経験年数</th>
-            <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">習熟度</th>
-            <th className="border border-border px-1 py-1 w-8" />
-          </tr>
-        </thead>
-        <tbody>
-          {skills.map((s, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: スキル行は順序で管理
-            <tr key={i}>
-              <td className="border border-border p-1">
-                <input
-                  value={s.name}
-                  onChange={(e) => setSkill(i, 'name', e.target.value)}
-                  placeholder="TypeScript"
-                  aria-label={`スキル${i + 1}の名称`}
-                  className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </td>
-              <td className="border border-border p-1">
-                <input
-                  type="number"
-                  min={0}
-                  max={50}
-                  value={s.years}
-                  onChange={(e) => setSkill(i, 'years', Math.max(0, Number(e.target.value)))}
-                  aria-label={`スキル${i + 1}の経験年数`}
-                  className="w-full rounded border border-input bg-background px-2 py-1 text-center focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </td>
-              <td className="border border-border p-1">
-                <input
-                  value={s.level}
-                  onChange={(e) => setSkill(i, 'level', e.target.value)}
-                  placeholder="実務経験あり"
-                  aria-label={`スキル${i + 1}の習熟度`}
-                  className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </td>
-              <td className="border border-border p-1 text-center">
-                <button
-                  type="button"
-                  onClick={() => removeSkill(i)}
-                  aria-label={`スキル${i + 1}を削除`}
-                  className="rounded p-1 text-muted-foreground hover:text-destructive"
-                >
-                  <Trash2 className="size-3.5" />
-                </button>
-              </td>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">スキル</th>
+              <th className="border border-border px-2 py-1 text-center text-xs text-muted-foreground w-20">
+                経験年数
+              </th>
+              <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">習熟度</th>
+              <th className="border border-border px-1 py-1 w-8" />
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {skills.map((s, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: スキル行は順序で管理
+              <tr key={i}>
+                <td className="border border-border p-1">
+                  <input
+                    value={s.name}
+                    onChange={(e) => setSkill(i, 'name', e.target.value)}
+                    placeholder="TypeScript"
+                    aria-label={`スキル${i + 1}の名称`}
+                    className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </td>
+                <td className="border border-border p-1">
+                  <input
+                    type="number"
+                    min={0}
+                    max={50}
+                    value={s.years}
+                    onChange={(e) => setSkill(i, 'years', Math.max(0, Number(e.target.value)))}
+                    aria-label={`スキル${i + 1}の経験年数`}
+                    className="w-full rounded border border-input bg-background px-2 py-1 text-center focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </td>
+                <td className="border border-border p-1">
+                  <input
+                    value={s.level}
+                    onChange={(e) => setSkill(i, 'level', e.target.value)}
+                    placeholder="実務経験あり"
+                    aria-label={`スキル${i + 1}の習熟度`}
+                    className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </td>
+                <td className="border border-border p-1 text-center">
+                  <button
+                    type="button"
+                    onClick={() => removeSkill(i)}
+                    aria-label={`スキル${i + 1}を削除`}
+                    className="rounded p-1 text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       <button
         type="button"
         onClick={addSkill}


### PR DESCRIPTION
<!-- quality-ok -->
<!-- no-sbi: このリポジトリ(kouiso/skillsheet-viewer)は個人プロジェクトでPBI/SBI issue運用をしていません。真の完成の定義の再検証中に発見したバグ修正で、特定issueには紐づきません -->

## Issue リンク / Link to Issue

close #

### 概要

「真の完成の定義」チェックリストを局長からの質問をきっかけに再検証したところ、`/builder` 自体の375pxモバイル確認が未実施だったことに気づき、実際に確認したところ横スクロールが発生する不具合を見つけました。

### 見て欲しいポイント

- [ ] `apps/web/app/builder/builder-client.tsx` の `SkillsBlockEditor`（`<table>` を `overflow-x-auto` の div でラップ）
- [ ] `builder-client.test.tsx` の回帰テスト

### 見なくてもよいポイント

- [ ] biome フォーマッタによるインデント調整（内容の変更なし）

### その他(あれば)

**原因**: `SkillsBlockEditor` の `<table>` に `overflow-x-auto` ラッパーが無く、同じファイル内の `TableBlockEditor`（案件エディタのテーブル）とは異なる実装になっていました。テーブルの内容（スキル名/経験年数/習熟度/削除ボタン）がページ全体を横に押し広げていました。

**検証**: 本番の `/builder` を Playwright で 375px 幅に設定し、`document.documentElement.scrollWidth`（548px）が `clientWidth`（375px）を超えていることを確認 → 修正後は同じ幅でテーブル単体がスクロールし、ページ全体は横スクロールしないことを確認します。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）（hotfix のため対象外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか（該当なし）
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）（該当なし。単一オーナー運用のため）

### レビュー観点

- [x] 想定通りに動作するか（回帰テストで確認済み。マージ後に本番375pxで再検証予定）
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [x] その他(具体的に記述をしてください)