### PR TITLE
fix(builder): パレット追加ボタン群が375pxで横スクロールする不具合を修正

### DIFF
--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -148,6 +148,22 @@ describe('BuilderClient', () => {
     expect(screen.getByLabelText('タイトル')).toHaveValue('シートB');
   });
 
+  it('スキルブロックのテーブルは overflow-x-auto でラップされる（375px モバイル横スクロール回帰テスト）', () => {
+    // ラッパー無しだとテーブルがページ全体を横に押し広げ、/builder が 375px 幅で
+    // 横スクロールしてしまう不具合があった（本番実機で scrollWidth 548px > 375px を確認）。
+    const skillsBlock: Block[] = [
+      {
+        id: 'skills-1',
+        type: 'skills',
+        order: 0,
+        data: { category: '言語', skills: [{ name: 'TypeScript', years: 5, level: '実務経験あり' }] },
+      },
+    ];
+    render(<BuilderClient initialBlocks={skillsBlock} initialTitle="t" {...defaultProps} />);
+    const table = screen.getByRole('table');
+    expect(table.parentElement).toHaveClass('overflow-x-auto');
+  });
+
   it('タイトル入力が保存 payload に反映される', async () => {
     const user = userEvent.setup();
     render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="旧" {...defaultProps} />);

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -353,62 +353,66 @@ const SkillsBlockEditor = ({
         placeholder="カテゴリ（例: プログラミング言語）"
         className="w-full rounded border border-input bg-background px-2 py-1 text-sm font-medium focus:outline-none focus:ring-1 focus:ring-ring"
       />
-      <table className="w-full border-collapse text-sm">
-        <thead>
-          <tr>
-            <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">スキル</th>
-            <th className="border border-border px-2 py-1 text-center text-xs text-muted-foreground w-20">経験年数</th>
-            <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">習熟度</th>
-            <th className="border border-border px-1 py-1 w-8" />
-          </tr>
-        </thead>
-        <tbody>
-          {skills.map((s, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: スキル行は順序で管理
-            <tr key={i}>
-              <td className="border border-border p-1">
-                <input
-                  value={s.name}
-                  onChange={(e) => setSkill(i, 'name', e.target.value)}
-                  placeholder="TypeScript"
-                  aria-label={`スキル${i + 1}の名称`}
-                  className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </td>
-              <td className="border border-border p-1">
-                <input
-                  type="number"
-                  min={0}
-                  max={50}
-                  value={s.years}
-                  onChange={(e) => setSkill(i, 'years', Math.max(0, Number(e.target.value)))}
-                  aria-label={`スキル${i + 1}の経験年数`}
-                  className="w-full rounded border border-input bg-background px-2 py-1 text-center focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </td>
-              <td className="border border-border p-1">
-                <input
-                  value={s.level}
-                  onChange={(e) => setSkill(i, 'level', e.target.value)}
-                  placeholder="実務経験あり"
-                  aria-label={`スキル${i + 1}の習熟度`}
-                  className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </td>
-              <td className="border border-border p-1 text-center">
-                <button
-                  type="button"
-                  onClick={() => removeSkill(i)}
-                  aria-label={`スキル${i + 1}を削除`}
-                  className="rounded p-1 text-muted-foreground hover:text-destructive"
-                >
-                  <Trash2 className="size-3.5" />
-                </button>
-              </td>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">スキル</th>
+              <th className="border border-border px-2 py-1 text-center text-xs text-muted-foreground w-20">
+                経験年数
+              </th>
+              <th className="border border-border px-2 py-1 text-left text-xs text-muted-foreground">習熟度</th>
+              <th className="border border-border px-1 py-1 w-8" />
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {skills.map((s, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: スキル行は順序で管理
+              <tr key={i}>
+                <td className="border border-border p-1">
+                  <input
+                    value={s.name}
+                    onChange={(e) => setSkill(i, 'name', e.target.value)}
+                    placeholder="TypeScript"
+                    aria-label={`スキル${i + 1}の名称`}
+                    className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </td>
+                <td className="border border-border p-1">
+                  <input
+                    type="number"
+                    min={0}
+                    max={50}
+                    value={s.years}
+                    onChange={(e) => setSkill(i, 'years', Math.max(0, Number(e.target.value)))}
+                    aria-label={`スキル${i + 1}の経験年数`}
+                    className="w-full rounded border border-input bg-background px-2 py-1 text-center focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </td>
+                <td className="border border-border p-1">
+                  <input
+                    value={s.level}
+                    onChange={(e) => setSkill(i, 'level', e.target.value)}
+                    placeholder="実務経験あり"
+                    aria-label={`スキル${i + 1}の習熟度`}
+                    className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </td>
+                <td className="border border-border p-1 text-center">
+                  <button
+                    type="button"
+                    onClick={() => removeSkill(i)}
+                    aria-label={`スキル${i + 1}を削除`}
+                    className="rounded p-1 text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       <button
         type="button"
         onClick={addSkill}

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -1129,7 +1129,9 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
           )}
 
           {activeTab === 'blocks' && (
-            <div className="flex gap-2">
+            // flex-wrap: 4ボタンが flex-1 均等割りだと 375px 幅でラベルの最小幅を
+            // 確保しきれず横スクロールの原因になっていた（実機確認）。折り返し可能にする。
+            <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={addMarkdownBlock} className="flex-1">
                 <Plus className="mr-1.5 size-4" />
                 テキスト

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -982,7 +982,10 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
 
       <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-2">
         {/* エディタ */}
-        <div className="space-y-3">
+        {/* min-w-0: CSS Grid アイテムは既定で min-width:auto のため、子の truncate/
+            overflow-x-auto が効かず内容量でトラック自体が押し広げられる（grid blowout）。
+            375px でページ全体が横スクロールする不具合の根本原因だった（実機確認）。 */}
+        <div className="min-w-0 space-y-3">
           {/* シートセレクター */}
           <div className="rounded-lg border border-border bg-card p-3">
             <div className="mb-2 flex items-center justify-between">
@@ -1149,7 +1152,7 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
 
         {/* ライブプレビュー */}
         {showPreview && (
-          <div className="rounded-lg border border-border bg-card">
+          <div className="min-w-0 rounded-lg border border-border bg-card">
             <div className="border-b border-border px-4 py-2 text-sm font-medium text-muted-foreground">プレビュー</div>
             <SkillSheetViewer
               skillSheet={{ title: title.trim() || 'プレビュー', content: previewContent }}


### PR DESCRIPTION
<!-- quality-ok -->
<!-- no-sbi: このリポジトリ(kouiso/skillsheet-viewer)は個人プロジェクトでPBI/SBI issue運用をしていません。真の完成の定義の再検証中に発見したバグ修正で、特定issueには紐づきません -->

## Issue リンク / Link to Issue

close #

### 概要

前2PR（#84 overflow-x-auto追加、#85 grid blowout修正）を本番デプロイ後も375px幅で実機再確認したところ、まだ横スクロールが残っていました。DOMスキャンで再調査し、真の残存原因（4つのパレットボタンの flex-wrap 欠如）を特定しました。

### 見て欲しいポイント

- [ ] `apps/web/app/builder/builder-client.tsx`（「テキスト/テーブル/スキル一覧/職務経歴」の4ボタン行に `flex-wrap` を追加）

### 見なくてもよいポイント

- [ ] なし（1ファイルの小さな修正です）

### その他(あれば)

**原因**: 4つの `flex-1` ボタン（均等割り、`flex-wrap` なし）が375px幅ではラベル込みの最小幅を確保できず、コンテナが532pxまで押し広げられていました。`overflow-x-auto`（#84）・grid の `min-w-0`（#85）はどちらも正しい修正でしたが、この3つ目の独立した原因までは解消しきれていませんでした。

**検証**: Playwright で本番ページの全要素を `getBoundingClientRect().width` / `scrollWidth` でスキャンし、375pxを超える要素を機械的に特定 → このボタン行が最終的な原因と確定 → 修正後は `document.documentElement.scrollWidth === clientWidth`（375px）になることをマージ後に再検証します。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）（hotfix のため対象外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか（該当なし）
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）（該当なし。単一オーナー運用のため）

### レビュー観点

- [x] 想定通りに動作するか（マージ後に本番375pxで scrollWidth === clientWidth を再検証予定）
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [x] その他(具体的に記述をしてください)