### PR TITLE
fix(a11y): --faintトークンのコントラスト比不足とTechFilterのaria-pressed欠落を修正

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -51,7 +51,7 @@
 
   /* ハンドオフ redesign2（console.light）のトークン語彙。既存トークンとは別名で追加し非破壊。 */
   --surface2: #f0f3f3;
-  --faint: #8a969c;
+  --faint: #647079; /* 元 #8a969c は白背景 3.0:1 で WCAG AA(4.5:1) 未達だったため修正（2026-07-08 自己レビュー） */
   --track: #e6ecec;
   --chip-bg: #eef3f3;
   --chip-text: #34424a;
@@ -88,7 +88,7 @@
 
   /* ハンドオフ redesign2（console.dark）のトークン語彙。 */
   --surface2: #141a1e;
-  --faint: #5a656c;
+  --faint: #818c94; /* 元 #5a656c は card 背景 3.1:1 で WCAG AA(4.5:1) 未達だったため修正（2026-07-08 自己レビュー） */
   --track: #192227;
   --chip-bg: #141b1f;
   --chip-text: #aeb9bf;

--- a/apps/web/src/component/blocks/TechFilter.test.tsx
+++ b/apps/web/src/component/blocks/TechFilter.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TechFilter } from './TechFilter';
+
+describe('TechFilter', () => {
+  it('トグル状態を aria-pressed で通知する（スクリーンリーダー a11y 回帰防止）', () => {
+    render(
+      <TechFilter
+        all={['TypeScript', 'React']}
+        active={['TypeScript']}
+        query=""
+        onQueryChange={vi.fn()}
+        onToggle={vi.fn()}
+        onClear={vi.fn()}
+        count={1}
+        total={2}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'TypeScript' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'React' })).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/apps/web/src/component/blocks/TechFilter.tsx
+++ b/apps/web/src/component/blocks/TechFilter.tsx
@@ -40,6 +40,7 @@ export function TechFilter({ all, active, query, onQueryChange, onToggle, onClea
             key={tech}
             type="button"
             onClick={() => onToggle(tech)}
+            aria-pressed={active.includes(tech)}
             className={`chip ${active.includes(tech) ? 'on' : ''}`}
           >
             {tech}


### PR DESCRIPTION
## 関連Issue
Closes #87
Closes #88

## 概要
自己レビューの敵対レビューで見つかったアクセシビリティ不具合2件を修正した。

## やったこと
- `--faint` トークンをWCAG AA(4.5:1)を満たす値に変更（light `#647079` / dark `#818c94`）
- `TechFilter` のトグルチップに `aria-pressed` を追加

## 影響範囲
Consoleダッシュボードで `--faint` を使う箇所の文字色が変わる。TechFilterの技術チップにARIA属性が追加される（見た目の変化なし）。

## 挙動確認・テスト等
- 独立agentがWCAG相対輝度式で再計算し、コントラスト比不足を確認済み
- `pnpm -r test` 全121件green、`pnpm -r type-check` green
- TechFilter.test.tsx を新規追加

## 相談・共有したいこと
色調整のみのためレイアウト崩れの心配はないが、マージ後に本番で色味を確認したい。

## 対応しないこと
他の色トークンのコントラスト再監査は今回のスコープ外。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ライト/ダークテーマで一部の配色を調整し、見た目の一貫性を改善しました。
  * フィルターチップの選択状態がアクセシビリティ属性で正しく表現されるようになりました。

* **Tests**
  * フィルター表示のレンダリングテストを追加し、各ボタンの選択状態が期待どおりに表示されることを確認しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->