### PR TITLE
fix(viewer): SkillMatrixグリッドの320px幅はみ出しとProcessStepperラベル重なりを修正

### DIFF
--- a/apps/web/src/component/blocks/ProcessStepper.test.tsx
+++ b/apps/web/src/component/blocks/ProcessStepper.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ProcessStepper } from './ProcessStepper';
+
+describe('ProcessStepper', () => {
+  it('ラベルに whitespace-nowrap を使わない（320px 幅での隣接ラベル重なり回帰防止）', () => {
+    render(<ProcessStepper done={[false, false, false, false, false, false, false]} uncertain={[]} />);
+
+    const labels = screen.getAllByText(/要件定義|基本設計|詳細設計|実装・単体|結合テスト|総合テスト|保守・運用/);
+    for (const label of labels) {
+      expect(label.className).not.toContain('whitespace-nowrap');
+      expect(label.className).toContain('text-center');
+    }
+  });
+
+  it('compact=true のときラベルを描画しない', () => {
+    render(<ProcessStepper done={[true, false, false, false, false, false, false]} uncertain={[]} compact />);
+    expect(screen.queryByText('要件定義')).toBeNull();
+  });
+});

--- a/apps/web/src/component/blocks/ProcessStepper.tsx
+++ b/apps/web/src/component/blocks/ProcessStepper.tsx
@@ -27,7 +27,7 @@ export function ProcessStepper({ done, uncertain, compact = false }: ProcessStep
           <div key={label} className="flex min-w-0 flex-1 flex-col items-center gap-1">
             {!compact && (
               <span
-                className={`whitespace-nowrap font-mono text-[10px] ${isDone || isUncertain ? 'text-accent-text' : 'text-faint'}`}
+                className={`text-center font-mono text-[10px] leading-tight ${isDone || isUncertain ? 'text-accent-text' : 'text-faint'}`}
               >
                 {label}
               </span>

--- a/apps/web/src/component/skill-sheet-viewer.test.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.test.tsx
@@ -114,4 +114,26 @@ describe('SkillSheetViewer', () => {
     // 空の skills ブロック（category: '空'）はどこにも描画されない。
     expect(screen.queryByText('空')).toBeNull();
   });
+
+  it('SkillMatrix グリッドの列最小幅が min(240px,100%) でコンテナ幅を超えない（320px 幅での横スクロール回帰防止）', async () => {
+    const blocks: Block[] = [
+      {
+        id: 'b1',
+        type: 'skills',
+        order: 0,
+        data: { category: '言語', skills: [{ name: 'TS', years: 3, level: '★★☆' }] },
+      },
+    ];
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: '' }} blocks={blocks} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TS')).toBeInTheDocument();
+    });
+
+    const grid = document.querySelector('[class*="grid-template-columns"]') as HTMLElement;
+    expect(grid).not.toBeNull();
+    // 固定 240px の minmax だけだと 320px 幅で列自体がコンテナよりはみ出す
+    // （実機/Playwright 計測で確認済み）。min() でコンテナ幅を上限にキャップする。
+    expect(grid.className).toContain('minmax(min(240px,100%),1fr)');
+  });
 });

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -279,7 +279,7 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false }: SkillShee
                   return (
                     <section key={key}>
                       <SectionHead kicker="Skill Matrix" title="スキルマトリクス" />
-                      <div className="grid gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-4 sm:p-5 [grid-template-columns:repeat(auto-fit,minmax(240px,1fr))]">
+                      <div className="grid gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-4 sm:p-5 [grid-template-columns:repeat(auto-fit,minmax(min(240px,100%),1fr))]">
                         {group.blocks.map((block) => (
                           <SkillMatrix key={block.id} data={block.data} className="mb-0" />
                         ))}


### PR DESCRIPTION
## 関連Issue
Closes #90
Closes #91

## 概要
自己レビューの敵対レビュー（Playwright実測）で見つかった320px幅のレイアウト不具合2件を修正した。

## やったこと
- SkillMatrixグリッドの `minmax(240px,1fr)` を `minmax(min(240px,100%),1fr)` に変更し、コンテナ幅を上限にキャップ
- ProcessStepperの工程ラベルから `whitespace-nowrap` を外し `text-center` を追加、320px幅で重ならず折り返すように

## 影響範囲
Console閲覧ページのSkillMatrixと案件カードのProcessStepper表示。

## 挙動確認・テスト等
- 独立agentがPlaywrightで320px/375px幅を実測し、修正前の不具合を再現・修正方針を検証済み
- `pnpm -r test` 全121件green、`pnpm -r type-check` green
- 回帰テストを2件追加（グリッドのCSS値、ラベルのクラス）

## 相談・共有したいこと
このリポジトリにはPlaywright等のビューポート実測テストが存在せず、320px/375px系の不具合が過去に3回連続で再発した（#84/#85/#86）。今回のテストもクラス名アサーションに留まり、実測回帰は防げない。ビューポートベースの自動テスト導入は別issueとして提案したい。

## 対応しないこと
Playwright導入自体は本PRのスコープ外。