### PR TITLE
test(coverage): revalidate routeとblocksユーティリティのエッジケーステストを追加

### DIFF
--- a/apps/web/app/api/revalidate/route.test.ts
+++ b/apps/web/app/api/revalidate/route.test.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from 'next/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const revalidateTag = vi.fn();
+vi.mock('next/cache', () => ({ revalidateTag: (...args: unknown[]) => revalidateTag(...args) }));
+
+describe('POST /api/revalidate', () => {
+  afterEach(() => {
+    revalidateTag.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it('revalidateTag を { expire: 0 } 付きで呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）', async () => {
+    vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
+    const { POST } = await import('./route');
+
+    const req = new NextRequest('https://example.com/api/revalidate', {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-secret' },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(revalidateTag).toHaveBeenCalledWith('sheets', { expire: 0 });
+  });
+
+  it('secret が不一致なら 401 を返し revalidateTag を呼ばない', async () => {
+    vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
+    const { POST } = await import('./route');
+
+    const req = new NextRequest('https://example.com/api/revalidate', {
+      method: 'POST',
+      headers: { authorization: 'Bearer wrong-secret' },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -76,6 +76,16 @@ describe('splitMarkdownIntoBlocks', () => {
       .reverse();
     expect(blocksToMarkdown(reversed)).toBe(SAMPLE);
   });
+
+  it('空文字列は空文字の1セグメントを返す（例外を投げない）', () => {
+    expect(splitMarkdownIntoBlocks('')).toEqual([{ markdown: '' }]);
+  });
+
+  it('空白のみの文字列は1つのセグメントとして返す', () => {
+    const segments = splitMarkdownIntoBlocks('   \n\n  ');
+    expect(segments).toHaveLength(1);
+    expect(segments[0].markdown).toBe('   \n\n  ');
+  });
 });
 
 const TABLE: TableBlockData = {
@@ -487,6 +497,11 @@ describe('blocksToMarkdown — 新型ブロック dispatch', () => {
     const blks = [{ id: 'x', type: 'unknown', order: 0, data: {} }] as unknown as Block[];
     expect(() => blocksToMarkdown(blks)).not.toThrow();
     expect(blocksToMarkdown(blks)).toBe('');
+  });
+
+  it('空配列は空文字を返してエラーを throw しない', () => {
+    expect(() => blocksToMarkdown([])).not.toThrow();
+    expect(blocksToMarkdown([])).toBe('');
   });
 });
 


### PR DESCRIPTION
## 関連Issue
Closes #93
Closes #94

## 概要
自己レビューのテスト網羅性レビューで見つかったテスト不足2件を追加した。

## やったこと
- /api/revalidate の `revalidateTag('sheets', { expire: 0 })` 呼び出しをアサートするテストを追加（空の`{}`だと即時失効せず本番反映されない#81の再発を検知できるように）
- `blocksToMarkdown([])` / `splitMarkdownIntoBlocks('')` の空入力挙動をテストで固定

## 影響範囲
テスト追加のみ、プロダクションコードの変更なし。

## 挙動確認・テスト等
- `pnpm -r test` 全123件green（新規4件含む）
- `pnpm -r type-check` green

## 相談・共有したいこと
テスト網羅性レビューでは他に「#85/#86(375px修正)に自動テストが1件もない」「PDF多列テーブルの未検証」も見つかったが、いずれも既存コードへの変更を要する/優先度が低いためこのPRには含めていない。前者はビューポート実測テストの仕組み自体が必要（fix/skill-matrix-grid-and-process-stepper-overflow のPRで別issue提案予定）。

## 対応しないこと
PDF多列テーブルの検証・Playwright導入は別issue。