### PR TITLE
fix(pdf): 多列テーブルの長いURLトークンがセル境界を越える不具合を修正

### DIFF
--- a/apps/web/src/component/pdf/skill-sheet-document.render.test.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.render.test.tsx
@@ -98,4 +98,20 @@ describe('SkillSheetDocument（実バイト描画）', () => {
       expect(buffer.subarray(0, PDF_HEADER.length).toString('latin1')).toBe(PDF_HEADER);
     }
   });
+
+  it('多列テーブル＋長い未分割トークン(URL)を含む内容でもスローせず描画できる（セルの overflow:hidden 回帰防止）', async () => {
+    // 8列テーブル＋URLのような区切り文字のない長いトークンは、修正前は
+    // 折返し後の最終行がセル境界を超えて隣列へ視覚的にはみ出していた
+    // （PDFをラスタライズして実際に確認済み）。tableCell に overflow: 'hidden'
+    // を追加し、セル幅内にクリップされるよう修正した。
+    const header = '| 列A | 列B | 列C | 列D | 列E | 列F | 列G | 列H |';
+    const sep = '| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |';
+    const row =
+      '| https://example.com/very/long/unbroken/url/path/xxxxxxxxxxxxxxxxxxxxxxxxxx | b | c | d | e | f | g | h |';
+    const content = ['## 多列テーブル', '', header, sep, row, ''].join('\n');
+
+    const buffer = await renderToBuffer(<SkillSheetDocument title="テスト" content={content} />);
+    expect(buffer.length).toBeGreaterThan(0);
+    expect(buffer.subarray(0, PDF_HEADER.length).toString('latin1')).toBe(PDF_HEADER);
+  });
 });

--- a/apps/web/src/component/pdf/skill-sheet-document.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.tsx
@@ -117,6 +117,7 @@ const styles = StyleSheet.create({
     flexBasis: 0,
     flexShrink: 1,
     minWidth: 0,
+    overflow: 'hidden',
     borderRightWidth: 1,
     borderRightColor: COLOR.divider,
     borderBottomWidth: 1,


### PR DESCRIPTION
## 関連Issue
Closes #97

## 概要
自己レビュー（局長承認の追加検証）で、PDF多列テーブルの長いURLトークンがセル境界を越えて隣列にはみ出す不具合を発見・修正した。

## やったこと
- react-pdfのPDFをレンダリング→ラスタライズ（pdftoppm）して実際に確認したところ、8列テーブルで長いURLを含むセルの最終折返し行が隣列に視覚的に侵入していた
- `tableCell` に `overflow: 'hidden'` を追加し、Yogaレイアウトエンジンでセル幅内にクリップされるよう修正
- 修正後、再ラスタライズして隣列への侵入が消えたことを目視確認

## 影響範囲
PDF出力の全テーブル（skills/stats/project由来のGFMテーブル含む）。通常の短いテキストでは見た目の変化なし。

## 挙動確認・テスト等
- 修正前後でPDFを実際にレンダリング→PNG変換→目視比較（scratchpadに一時ファイル、リポジトリには含めていない）
- 回帰テストを追加（8列+長いURLトークンでスローせず描画できることを確認）
- `pnpm -r test` 全122件green、`pnpm -r type-check` green

## 相談・共有したいこと
セル幅を超えるコンテンツはクリップされる（末尾が見えなくなる）仕様になる。真に長いURL等を含むスキルシートを想定するなら、ツールチップやリンクとしての遷移可能性を別途検討してもよいかもしれない（本PRのスコープ外）。

## 対応しないこと
クリップされた内容を別UIで補完表示する仕組みは作っていない。