### PR TITLE
fix(builder): プレビューと保存後表示のmarkdown連結を統一

### DIFF
--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -78,13 +78,29 @@ describe('BuilderClient', () => {
     expect(screen.getByTestId('preview')).toHaveTextContent('## A ## B');
   });
 
-  it('ブロック間は空行(\\n\\n)で結合される（GFM テーブル認識の回帰テスト）', () => {
+  it('隣接 markdown ブロック同士は単一改行(\\n)で結合される', () => {
+    // サーバ側 blocksToMarkdown と同じく markdown 分割のラウンドトリップ無損失性を保つ。
+    render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" {...defaultProps} />);
+    const raw = screen.getByTestId('preview').getAttribute('data-raw');
+    expect(raw).toBe('## A\n## B');
+  });
+
+  it('markdown と非 markdown の隣接は空行(\\n\\n)で結合される（GFM テーブル認識の回帰テスト）', () => {
     // 単一改行(\n)だと GFM テーブルが直前の段落に lazy continuation として飲み込まれ、
     // テーブル区切り行 (:---:) がそのまま生テキストとして表示される不具合があった
     // （builder-client.tsx の assembleMarkdown 参照）。
-    render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" {...defaultProps} />);
+    const blocks: Block[] = [
+      { id: 'markdown-1', type: 'markdown', order: 0, data: { markdown: '## A' } },
+      {
+        id: 'table-1',
+        type: 'table',
+        order: 1,
+        data: { columns: [{ label: '項目', align: 'left' }], rows: [['内容']] },
+      },
+    ];
+    render(<BuilderClient initialBlocks={blocks} initialTitle="t" {...defaultProps} />);
     const raw = screen.getByTestId('preview').getAttribute('data-raw');
-    expect(raw).toBe('## A\n\n## B');
+    expect(raw).toBe('## A\n\n| 項目 |\n| :--- |\n| 内容 |');
   });
 
   it('「テーブル」追加→セル入力が table ブロックとして保存 payload に入る', async () => {

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -163,10 +163,23 @@ const itemToMarkdown = (item: EditorItem): string => {
   }
 };
 
-// ブロック間は空行区切り（\n\n）が必須。単一改行だと GFM テーブルが直前の段落に
-// 「lazy continuation」として飲み込まれ、テーブルとして認識されずヘッダー/区切り行
-// (:---:) がそのまま生テキストとして表示される不具合があった（PDF/プレビュー実機確認）。
-const assembleMarkdown = (items: EditorItem[]): string => items.map(itemToMarkdown).join('\n\n');
+// markdown 同士は単一改行、それ以外の隣接は空行区切り（\n\n）にする。
+// サーバ側 blocksToMarkdown と同じ連結規則に揃え、markdown 分割の無損失性と
+// GFM テーブルが直前段落へ lazy continuation として飲み込まれない区切りを両立する。
+const assembleMarkdown = (items: EditorItem[]): string => {
+  let result = '';
+  for (let i = 0; i < items.length; i++) {
+    const markdown = itemToMarkdown(items[i]);
+    if (i === 0) {
+      result = markdown;
+      continue;
+    }
+    const prevType = items[i - 1].type;
+    const separator = prevType === 'markdown' && items[i].type === 'markdown' ? '\n' : '\n\n';
+    result += separator + markdown;
+  }
+  return result;
+};
 
 // dirty 比較用スナップショット（タイトル＋組み立て済み markdown 文字列）。
 // typed item を直接比較せず、保存される最終形（markdown）で差分を見る。


### PR DESCRIPTION
## Issue リンク / Link to Issue

<!-- quality-ok -->

### 概要

編集中プレビュー（クライアント側 `assembleMarkdown`）と保存後の `/view/db` 表示（サーバー側 `blocksToMarkdown`）でmarkdown型ブロック間の連結ルールが食い違っていた問題を修正。

`remarkBreaks` プラグインは段落内の単一改行を `<br>` に変換するため、連結ロジックの差異がWYSIWYG不一致として現れていた。`assembleMarkdown` を `blocksToMarkdown` と同じ隣接判定ロジックに揃えた。

### 見て欲しいポイント

- [ ] `apps/web/app/builder/builder-client.tsx` の `assembleMarkdown` 関数（markdown+markdown は `\n`、それ以外は `\n\n`）
- [ ] `apps/web/app/builder/builder-client.test.tsx` の隣接判定テスト2件

### 見なくてもよいポイント

- [ ] 特になし

### その他(あれば)

gemini-code-assistのPR #82/#83 レビュースレッド（client/server間のmarkdown連結ロジック不整合）に対応。

---

### PR チェックポイント

- [ ] タイトルにタスク管理ツールのチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [ ] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdownブロックの結合方法を改善し、見た目どおりのプレビューがより正確になるようになりました。
  * 連続するMarkdownブロックは自然な1行区切りでつながり、表などの非Markdown要素が隣接する場合は空行で分離されるようになりました。
  * 一部の表が前後のテキストに誤って吸収される問題を防ぎました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->