### PR TITLE
fix(builder,test): gemini-code-assist未対応指摘4件を修正

### DIFF
--- a/apps/web/app/api/revalidate/route.test.ts
+++ b/apps/web/app/api/revalidate/route.test.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { POST } from './route';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const revalidateTag = vi.fn();
@@ -12,8 +13,6 @@ describe('POST /api/revalidate', () => {
 
   it('revalidateTag を { expire: 0 } 付きで呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）', async () => {
     vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
-    const { POST } = await import('./route');
-
     const req = new NextRequest('https://example.com/api/revalidate', {
       method: 'POST',
       headers: { authorization: 'Bearer test-secret' },
@@ -26,8 +25,6 @@ describe('POST /api/revalidate', () => {
 
   it('secret が不一致なら 401 を返し revalidateTag を呼ばない', async () => {
     vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
-    const { POST } = await import('./route');
-
     const req = new NextRequest('https://example.com/api/revalidate', {
       method: 'POST',
       headers: { authorization: 'Bearer wrong-secret' },

--- a/apps/web/app/api/revalidate/route.test.ts
+++ b/apps/web/app/api/revalidate/route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
-import { POST } from './route';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { POST } from './route';
 
 const revalidateTag = vi.fn();
 vi.mock('next/cache', () => ({ revalidateTag: (...args: unknown[]) => revalidateTag(...args) }));

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -388,7 +388,7 @@ const SkillsBlockEditor = ({
                     onChange={(e) => setSkill(i, 'name', e.target.value)}
                     placeholder="TypeScript"
                     aria-label={`スキル${i + 1}の名称`}
-                    className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                    className="w-full min-w-24 rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
                   />
                 </td>
                 <td className="border border-border p-1">
@@ -408,7 +408,7 @@ const SkillsBlockEditor = ({
                     onChange={(e) => setSkill(i, 'level', e.target.value)}
                     placeholder="実務経験あり"
                     aria-label={`スキル${i + 1}の習熟度`}
-                    className="w-full rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                    className="w-full min-w-24 rounded border border-input bg-background px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
                   />
                 </td>
                 <td className="border border-border p-1 text-center">

--- a/apps/web/src/component/blocks/ProcessStepper.test.tsx
+++ b/apps/web/src/component/blocks/ProcessStepper.test.tsx
@@ -7,8 +7,9 @@ describe('ProcessStepper', () => {
   it('ラベルに whitespace-nowrap を使わない（320px 幅での隣接ラベル重なり回帰防止）', () => {
     render(<ProcessStepper done={[false, false, false, false, false, false, false]} uncertain={[]} />);
 
-    const labels = screen.getAllByText(/要件定義|基本設計|詳細設計|実装・単体|結合テスト|総合テスト|保守・運用/);
-    for (const label of labels) {
+    const expectedLabels = ['要件定義', '基本設計', '詳細設計', '実装・単体', '結合テスト', '総合テスト', '保守・運用'];
+    for (const expectedLabel of expectedLabels) {
+      const label = screen.getByText(expectedLabel);
       expect(label.className).not.toContain('whitespace-nowrap');
       expect(label.className).toContain('text-center');
     }

--- a/apps/web/src/component/skill-sheet-viewer.test.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.test.tsx
@@ -124,13 +124,13 @@ describe('SkillSheetViewer', () => {
         data: { category: '言語', skills: [{ name: 'TS', years: 3, level: '★★☆' }] },
       },
     ];
-    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: '' }} blocks={blocks} />);
+    const { container } = render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: '' }} blocks={blocks} />);
 
     await waitFor(() => {
       expect(screen.getByText('TS')).toBeInTheDocument();
     });
 
-    const grid = document.querySelector('[class*="grid-template-columns"]') as HTMLElement;
+    const grid = container.querySelector('[class*="grid-template-columns"]') as HTMLElement;
     expect(grid).not.toBeNull();
     // 固定 240px の minmax だけだと 320px 幅で列自体がコンテナよりはみ出す
     // （実機/Playwright 計測で確認済み）。min() でコンテナ幅を上限にキャップする。


### PR DESCRIPTION
## Issue リンク / Link to Issue

<!-- quality-ok -->

### 概要

gemini-code-assist が過去PRで指摘した未対応事項4件をまとめて修正。

1. スキルテーブルの name/level 入力欄に `min-w-24` を追加（375px幅での縮小防止）
2. ProcessStepper.test: 正規表現 `getAllByText` を `getByText` 個別検証に変更
3. skill-sheet-viewer.test: `document.querySelector` グローバル参照をコンポーネントスコープに変更
4. revalidate/route.test: テストごとの `await import` をトップレベル import に変更

### 見て欲しいポイント

- [ ] `apps/web/app/builder/builder-client.tsx` のスキル入力欄 `min-w-24`
- [ ] `apps/web/src/component/blocks/ProcessStepper.test.tsx` の検証ロジック
- [ ] `apps/web/src/component/skill-sheet-viewer.test.tsx` のスコープ修正
- [ ] `apps/web/app/api/revalidate/route.test.ts` の import 変更

### 見なくてもよいポイント

- [ ] 特になし

### その他(あれば)

gemini-code-assist の PR #84、#92（2件）、#95 レビュースレッドに対応。

---

### PR チェックポイント

- [ ] タイトルにタスク管理ツールのチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [ ] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)