### PR TITLE
fix(builder,pdf): blockJoinSeparatorを共通化し結合ロジックを統一

### DIFF
--- a/apps/web/app/api/revalidate/route.test.ts
+++ b/apps/web/app/api/revalidate/route.test.ts
@@ -1,35 +1,35 @@
-import { NextRequest } from "next/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { POST } from "./route";
+import { NextRequest } from 'next/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { POST } from './route';
 
 const revalidateTag = vi.fn();
-vi.mock("next/cache", () => ({
+vi.mock('next/cache', () => ({
   revalidateTag: (...args: unknown[]) => revalidateTag(...args),
 }));
 
-describe("POST /api/revalidate", () => {
+describe('POST /api/revalidate', () => {
   afterEach(() => {
     revalidateTag.mockClear();
     vi.unstubAllEnvs();
   });
 
-  it("revalidateTag を { expire: 0 } 付きで呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）", async () => {
-    vi.stubEnv("REVALIDATE_SECRET", "test-secret");
-    const req = new NextRequest("https://example.com/api/revalidate", {
-      method: "POST",
-      headers: { authorization: "Bearer test-secret" },
+  it('revalidateTag を { expire: 0 } 付きで呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）', async () => {
+    vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
+    const req = new NextRequest('https://example.com/api/revalidate', {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-secret' },
     });
     const res = await POST(req);
 
     expect(res.status).toBe(200);
-    expect(revalidateTag).toHaveBeenCalledWith("sheets", { expire: 0 });
+    expect(revalidateTag).toHaveBeenCalledWith('sheets', { expire: 0 });
   });
 
-  it("secret が不一致なら 401 を返し revalidateTag を呼ばない", async () => {
-    vi.stubEnv("REVALIDATE_SECRET", "test-secret");
-    const req = new NextRequest("https://example.com/api/revalidate", {
-      method: "POST",
-      headers: { authorization: "Bearer wrong-secret" },
+  it('secret が不一致なら 401 を返し revalidateTag を呼ばない', async () => {
+    vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
+    const req = new NextRequest('https://example.com/api/revalidate', {
+      method: 'POST',
+      headers: { authorization: 'Bearer wrong-secret' },
     });
     const res = await POST(req);
 

--- a/apps/web/app/api/revalidate/route.test.ts
+++ b/apps/web/app/api/revalidate/route.test.ts
@@ -1,33 +1,35 @@
-import { NextRequest } from 'next/server';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { POST } from './route';
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
 
 const revalidateTag = vi.fn();
-vi.mock('next/cache', () => ({ revalidateTag: (...args: unknown[]) => revalidateTag(...args) }));
+vi.mock("next/cache", () => ({
+  revalidateTag: (...args: unknown[]) => revalidateTag(...args),
+}));
 
-describe('POST /api/revalidate', () => {
+describe("POST /api/revalidate", () => {
   afterEach(() => {
     revalidateTag.mockClear();
     vi.unstubAllEnvs();
   });
 
-  it('revalidateTag を { expire: 0 } 付きで呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）', async () => {
-    vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
-    const req = new NextRequest('https://example.com/api/revalidate', {
-      method: 'POST',
-      headers: { authorization: 'Bearer test-secret' },
+  it("revalidateTag を { expire: 0 } 付きで呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）", async () => {
+    vi.stubEnv("REVALIDATE_SECRET", "test-secret");
+    const req = new NextRequest("https://example.com/api/revalidate", {
+      method: "POST",
+      headers: { authorization: "Bearer test-secret" },
     });
     const res = await POST(req);
 
     expect(res.status).toBe(200);
-    expect(revalidateTag).toHaveBeenCalledWith('sheets', { expire: 0 });
+    expect(revalidateTag).toHaveBeenCalledWith("sheets", { expire: 0 });
   });
 
-  it('secret が不一致なら 401 を返し revalidateTag を呼ばない', async () => {
-    vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
-    const req = new NextRequest('https://example.com/api/revalidate', {
-      method: 'POST',
-      headers: { authorization: 'Bearer wrong-secret' },
+  it("secret が不一致なら 401 を返し revalidateTag を呼ばない", async () => {
+    vi.stubEnv("REVALIDATE_SECRET", "test-secret");
+    const req = new NextRequest("https://example.com/api/revalidate", {
+      method: "POST",
+      headers: { authorization: "Bearer wrong-secret" },
     });
     const res = await POST(req);
 

--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -103,6 +103,24 @@ describe('BuilderClient', () => {
     expect(raw).toBe('## A\n\n| 項目 |\n| :--- |\n| 内容 |');
   });
 
+  it('markdown ブロック同士でも 2 本目が GFM テーブルで始まる場合は空行(\\n\\n)で結合される', () => {
+    // 生 markdown ブロックとして貼られたテーブル（type=markdown だが先頭がテーブル行）は、
+    // 単一改行だと直前段落へ lazy continuation として飲み込まれる。共有 blockJoinSeparator
+    // で先頭テーブル行を検出し \n\n 区切りにする（サーバ blocksToMarkdown と対称）。
+    const blocks: Block[] = [
+      { id: 'markdown-0', type: 'markdown', order: 0, data: { markdown: '経歴の概要テキスト。' } },
+      {
+        id: 'markdown-1',
+        type: 'markdown',
+        order: 1,
+        data: { markdown: '| 言語 | 経験 |\n| :--- | :--- |\n| TS | 3年 |' },
+      },
+    ];
+    render(<BuilderClient initialBlocks={blocks} initialTitle="t" {...defaultProps} />);
+    const raw = screen.getByTestId('preview').getAttribute('data-raw');
+    expect(raw).toBe('経歴の概要テキスト。\n\n| 言語 | 経験 |\n| :--- | :--- |\n| TS | 3年 |');
+  });
+
   it('「テーブル」追加→セル入力が table ブロックとして保存 payload に入る', async () => {
     const user = userEvent.setup();
     render(<BuilderClient initialBlocks={[]} initialTitle="t" {...defaultProps} />);

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -26,6 +26,7 @@ import { CSS } from '@dnd-kit/utilities';
 import {
   type Block,
   type BlockInput,
+  blockJoinSeparator,
   type ExperienceBlockData,
   experienceBlockToMarkdown,
   isBlockInputEmpty,
@@ -163,20 +164,22 @@ const itemToMarkdown = (item: EditorItem): string => {
   }
 };
 
-// markdown 同士は単一改行、それ以外の隣接は空行区切り（\n\n）にする。
-// サーバ側 blocksToMarkdown と同じ連結規則に揃え、markdown 分割の無損失性と
+// 連結規則はサーバ側 blocksToMarkdown と共有の blockJoinSeparator に一元化する。
+// 手コピーで 2 箇所に規則が重複していたのを解消し、markdown 分割の無損失性と
 // GFM テーブルが直前段落へ lazy continuation として飲み込まれない区切りを両立する。
 const assembleMarkdown = (items: EditorItem[]): string => {
   let result = '';
   for (let i = 0; i < items.length; i++) {
-    const markdown = itemToMarkdown(items[i]);
+    const item = items[i];
+    if (!item) continue;
+    const markdown = itemToMarkdown(item);
     if (i === 0) {
       result = markdown;
       continue;
     }
-    const prevType = items[i - 1].type;
-    const separator = prevType === 'markdown' && items[i].type === 'markdown' ? '\n' : '\n\n';
-    result += separator + markdown;
+    const prev = items[i - 1];
+    // prev は i>=1 なので通常存在するが、sparse 配列など不正入力でも落ちないよう防御する。
+    result += (prev ? blockJoinSeparator(prev.type, item.type, markdown) : '\n\n') + markdown;
   }
   return result;
 };

--- a/apps/web/src/component/pdf/skill-sheet-document.render.test.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.render.test.tsx
@@ -114,4 +114,32 @@ describe('SkillSheetDocument（実バイト描画）', () => {
     expect(buffer.length).toBeGreaterThan(0);
     expect(buffer.subarray(0, PDF_HEADER.length).toString('latin1')).toBe(PDF_HEADER);
   });
+
+  it('表セル内のリンクはクリック注釈(/URI)を生成しない（隣セルへの不可視クリック領域漏れ防止）', async () => {
+    // 表セル内の <Link> はセル幅で clip されず、クリック注釈が隣セル上に不可視のまま漏れる。
+    // セル内リンクは注釈なしの Text として描画するため、PDF バイト列にセル内 URL の
+    // /URI 注釈が現れないことを固定する。対照として段落内リンクは注釈が現れる。
+    // 注釈オブジェクトは非圧縮でバイト列に平文で出るため URL 部分文字列で判定できる。
+    const CELL_URL = 'https://example.com/annot-in-cell-marker';
+    const PARA_URL = 'https://example.com/annot-in-para-marker';
+    const content = [
+      '## リンク注釈テスト',
+      '',
+      `段落内のリンク: [サイト](${PARA_URL})`,
+      '',
+      '| 参照 | 備考 |',
+      '| :--- | :--- |',
+      `| [ドキュメント](${CELL_URL}) | 補足 |`,
+      '',
+    ].join('\n');
+
+    const buffer = await renderToBuffer(<SkillSheetDocument title="テスト" content={content} />);
+    const bytes = buffer.toString('latin1');
+
+    expect(buffer.subarray(0, PDF_HEADER.length).toString('latin1')).toBe(PDF_HEADER);
+    // 段落内リンクは <Link> のまま → /URI 注釈に URL が平文で出る。
+    expect(bytes).toContain('annot-in-para-marker');
+    // セル内リンクは Text 描画 → 注釈が出ないため URL はバイト列に現れない。
+    expect(bytes).not.toContain('annot-in-cell-marker');
+  });
 });

--- a/apps/web/src/component/pdf/skill-sheet-document.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.tsx
@@ -177,12 +177,18 @@ const INLINE_LEAF = new Map<string, (node: MdNode) => ReactNode>([
   ['html', () => null],
 ]);
 
-function renderInline(nodes: MdNode[] | undefined): ReactNode {
-  if (!nodes) return null;
-  return nodes.map((node, i) => renderInlineNode(node, i));
+// インライン描画の文脈オプション。inTableCell=true のときはリンクの
+// クリック注釈（<Link>）を抑制する（下記 link 分岐を参照）。
+interface InlineContext {
+  inTableCell?: boolean;
 }
 
-function renderInlineNode(node: MdNode, key: number): ReactNode {
+function renderInline(nodes: MdNode[] | undefined, ctx?: InlineContext): ReactNode {
+  if (!nodes) return null;
+  return nodes.map((node, i) => renderInlineNode(node, i, ctx));
+}
+
+function renderInlineNode(node: MdNode, key: number, ctx?: InlineContext): ReactNode {
   const leaf = INLINE_LEAF.get(node.type);
   if (leaf) return leaf(node);
   if (node.type === 'inlineCode') {
@@ -193,9 +199,20 @@ function renderInlineNode(node: MdNode, key: number): ReactNode {
     );
   }
   if (node.type === 'link') {
+    // 表セル内はセル幅で内容を clip するが、<Link> が生成するクリック注釈は
+    // clip の対象外で、隣のセル上に不可視のクリック領域として漏れる。セル内では
+    // 注釈を出さない styled Text として描画し、注釈自体を発生させない
+    // （見た目は従来どおり色付き下線を維持）。段落等の通常文脈は <Link> のまま。
+    if (ctx?.inTableCell) {
+      return (
+        <Text key={key} style={styles.link}>
+          {renderInline(node.children, ctx)}
+        </Text>
+      );
+    }
     return (
       <Link key={key} src={node.url ?? ''} style={styles.link}>
-        {renderInline(node.children)}
+        {renderInline(node.children, ctx)}
       </Link>
     );
   }
@@ -203,11 +220,11 @@ function renderInlineNode(node: MdNode, key: number): ReactNode {
   if (style) {
     return (
       <Text key={key} style={style}>
-        {renderInline(node.children)}
+        {renderInline(node.children, ctx)}
       </Text>
     );
   }
-  return node.children ? renderInline(node.children) : (node.value ?? null);
+  return node.children ? renderInline(node.children, ctx) : (node.value ?? null);
 }
 
 // --- ブロック描画 ---------------------------------------------------------
@@ -270,7 +287,8 @@ function renderTableCell(
   const textAlign = a === 'center' ? 'center' : a === 'right' ? 'right' : 'left';
   // 空セル（担当工程の未経験欄など）は空文字だとレイアウト計算が破綻するため、
   // 高さを保つノーブレークスペースを入れる。
-  const inline = renderInline(cell.children);
+  // セル内リンクは注釈が隣セルへ漏れるため inTableCell フラグで <Link> を抑制する。
+  const inline = renderInline(cell.children, { inTableCell: true });
   const isEmpty = inline == null || (Array.isArray(inline) && inline.length === 0);
   return (
     <View

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   type Block,
   type BlockInput,
+  blockJoinSeparator,
   blocksToMarkdown,
   type ExperienceBlockData,
   experienceBlockToMarkdown,
@@ -253,6 +254,59 @@ describe('blocksToMarkdown — type 別 dispatch', () => {
     expect(md).toContain('## 経歴');
     expect(md).toContain('### 株式会社サンプル');
     expect(md).toContain('フロントエンドエンジニア');
+  });
+});
+
+describe('blockJoinSeparator — 連結セパレータの単一の真実', () => {
+  const TABLE_MD = ['| a | b |', '| :--- | :--- |', '| 1 | 2 |'].join('\n');
+
+  it('markdown 同士は原則 \\n（ラウンドトリップ無損失を維持）', () => {
+    expect(blockJoinSeparator('markdown', 'markdown', '本文段落')).toBe('\n');
+  });
+
+  it('後続 markdown が GFM テーブル行で始まる場合は \\n\\n（飲み込み防止）', () => {
+    expect(blockJoinSeparator('markdown', 'markdown', TABLE_MD)).toBe('\n\n');
+  });
+
+  it('先頭に空行があってもテーブル始まりを検出する', () => {
+    expect(blockJoinSeparator('markdown', 'markdown', `\n\n${TABLE_MD}`)).toBe('\n\n');
+  });
+
+  it('先頭がインデント付きテーブル行でも検出する', () => {
+    expect(blockJoinSeparator('markdown', 'markdown', '  | a |\n  | :--- |')).toBe('\n\n');
+  });
+
+  it('非 markdown 型が絡む隣接は常に \\n\\n', () => {
+    expect(blockJoinSeparator('markdown', 'table', TABLE_MD)).toBe('\n\n');
+    expect(blockJoinSeparator('table', 'markdown', '本文')).toBe('\n\n');
+    expect(blockJoinSeparator('skills', 'stats', '')).toBe('\n\n');
+  });
+});
+
+describe('blocksToMarkdown — markdown ブロック同士でも 2 本目がテーブル始まりなら空行区切り', () => {
+  const TABLE_MD = ['| 言語 | 経験 |', '| :--- | :--- |', '| TS | 3年 |'].join('\n');
+
+  it('段落 + テーブル始まりの markdown ブロックは空行で区切られテーブルが飲み込まれない', () => {
+    const blocks: Block[] = [
+      { id: 'p', type: 'markdown', order: 0, data: { markdown: '経歴の概要テキスト。' } },
+      { id: 't', type: 'markdown', order: 1, data: { markdown: TABLE_MD } },
+    ];
+    const md = blocksToMarkdown(blocks);
+    // テーブル直前が空行（\n\n）であることを確認する。
+    expect(md).toBe(`経歴の概要テキスト。\n\n${TABLE_MD}`);
+    // split→join のラウンドトリップで文字列が保存される（破壊されない）。
+    const reassembled = blocksToMarkdown(
+      splitMarkdownIntoBlocks(md).map((data, order) => ({ id: String(order), type: 'markdown' as const, order, data })),
+    );
+    expect(reassembled).toBe(md);
+  });
+
+  it('テーブルで始まらない markdown ブロック同士は従来どおり \\n 連結（無損失維持）', () => {
+    const blocks: Block[] = [
+      { id: 'a', type: 'markdown', order: 0, data: { markdown: '段落A' } },
+      { id: 'b', type: 'markdown', order: 1, data: { markdown: '段落B' } },
+    ];
+    expect(blocksToMarkdown(blocks)).toBe('段落A\n段落B');
   });
 });
 

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -542,15 +542,39 @@ export function splitMarkdownIntoBlocks(markdown: string): MarkdownBlockData[] {
 }
 
 /**
- * ブロック配列を order 昇順で 1 つの Markdown 文書へ連結する（type 別に変換）。
+ * 与えられた markdown の先頭「非空行」が GFM テーブル行（`|` 始まり）かを判定する。
+ * lazy continuation でテーブルが直前段落へ飲み込まれるのは、後続ブロックの先頭が
+ * テーブル行のときだけなので、この 1 点で連結セパレータを切り替える。
+ */
+function startsWithTableRow(markdown: string): boolean {
+  for (const line of markdown.split('\n')) {
+    if (line.trim().length === 0) continue;
+    return /^\s*\|/.test(line);
+  }
+  return false;
+}
+
+/**
+ * 2 ブロックを連結する際のセパレータ（`\n` か `\n\n`）を決める単一の真実。
+ * サーバ（blocksToMarkdown）とクライアント（builder の assembleMarkdown）の両方が
+ * この関数を経由することで、連結規則が 2 箇所に手コピー重複してドリフトするのを防ぐ。
  *
- * markdown 型ブロック同士は従来どおり単一改行(\n)で連結する
- * （splitMarkdownIntoBlocks とのラウンドトリップ無損失を維持するため）。
- * それ以外（table/skills/experience/profile/stats/project 等、GFM テーブルを
- * 内部生成しうる構造化ブロック）が隣接する場合は空行(\n\n)で連結する。単一改行だと
- * GFM テーブルが直前の段落へ lazy continuation として飲み込まれ、テーブルとして
- * 認識されず区切り行(:---:)がそのまま生テキストとして表示される不具合があった
- * （本番 PDF 出力・/view/db で実機確認）。
+ * - markdown 型ブロック同士は原則 `\n`（splitMarkdownIntoBlocks とのラウンドトリップ
+ *   無損失を維持。split が生成するブロックの先頭は必ず見出し/<details> なので `\n` になる）。
+ * - ただし後続 markdown の先頭非空行が GFM テーブル行で始まる場合のみ `\n\n`。単一改行だと
+ *   テーブルが直前段落へ lazy continuation として飲み込まれ、区切り行(:---:)が生テキストで
+ *   表示される不具合があった（本番 PDF 出力・/view/db で実機確認）。
+ * - それ以外（table/skills/experience/profile/stats/project 等、テーブルを内部生成しうる
+ *   構造化ブロック）が隣接する場合は常に `\n\n`。
+ */
+export function blockJoinSeparator(prevType: BlockType, curType: BlockType, curMarkdown: string): '\n' | '\n\n' {
+  if (prevType !== 'markdown' || curType !== 'markdown') return '\n\n';
+  return startsWithTableRow(curMarkdown) ? '\n\n' : '\n';
+}
+
+/**
+ * ブロック配列を order 昇順で 1 つの Markdown 文書へ連結する（type 別に変換）。
+ * 連結規則は blockJoinSeparator に一元化している（クライアントの assembleMarkdown と共有）。
  */
 export function blocksToMarkdown(blocks: Block[]): string {
   const sorted = [...blocks].sort((a, b) => a.order - b.order);
@@ -561,9 +585,7 @@ export function blocksToMarkdown(blocks: Block[]): string {
       result = markdown;
       continue;
     }
-    const prevType = sorted[i - 1].type;
-    const separator = prevType === 'markdown' && sorted[i].type === 'markdown' ? '\n' : '\n\n';
-    result += separator + markdown;
+    result += blockJoinSeparator(sorted[i - 1].type, sorted[i].type, markdown) + markdown;
   }
   return result;
 }


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #

### 概要

プレビュー・保存後表示・PDF出力でMarkdownブロック結合の挙動が異なる問題を修正。
`packages/db/src/blocks.ts` に `blockJoinSeparator` を実装し、builder-clientとPDFレンダラーで共有する形に統一した。

### 見て欲しいポイント

- [ ] `blockJoinSeparator` のロジック（同一ブロックタイプ間は `\n`、異ブロック間は `\n\n`）
- [ ] builder-client.tsx のセパレータ差し替え箇所
- [ ] skill-sheet-document.tsx の PDF レンダリング側の対応

### 見なくてもよいポイント

- [ ] テストの細かいアサーション内容（カバレッジ追加が主目的）

### その他(あれば)

特になし

---

### PR チェックポイント

- [ ] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [ ] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [x] 想定通りに動作するか
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - Markdownブロック間の改行処理を改善し、GFMテーブルが正しく表示されるようになりました。
  - PDFの表セル内リンクが誤ってクリック可能な注釈として出力される問題を修正しました。通常の段落内リンクは引き続き利用できます。

- **テスト**
  - Markdownプレビュー、PDFリンク、再検証処理に関するテストを拡充し、表示と動作の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->