### PR TITLE
fix(builder,db): PR#102未解決のボット指摘3件を修正

### DIFF
--- a/apps/web/app/api/revalidate/route.test.ts
+++ b/apps/web/app/api/revalidate/route.test.ts
@@ -2,9 +2,9 @@ import { NextRequest } from 'next/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { POST } from './route';
 
-const revalidateTag = vi.fn();
+const revalidateTag = vi.hoisted(() => vi.fn());
 vi.mock('next/cache', () => ({
-  revalidateTag: (...args: unknown[]) => revalidateTag(...args),
+  revalidateTag,
 }));
 
 describe('POST /api/revalidate', () => {

--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import BuilderClient from './builder-client';
+import BuilderClient, { assembleMarkdown, type EditorItem } from './builder-client';
 
 // 重いビューア（lightbox/IntersectionObserver 依存）はプレビュー描画を素朴にモック
 vi.mock('@/component/skill-sheet-viewer', () => ({
@@ -83,6 +83,17 @@ describe('BuilderClient', () => {
     render(<BuilderClient initialBlocks={mdBlocks(['## A', '## B'])} initialTitle="t" {...defaultProps} />);
     const raw = screen.getByTestId('preview').getAttribute('data-raw');
     expect(raw).toBe('## A\n## B');
+  });
+
+  it('sparse 配列（途中に undefined 要素）でも実際の直前ブロック基準で結合される', () => {
+    // items[i - 1] の位置参照だと sparse 配列で直前の undefined 穴を挟んだ際に
+    // 実際にレンダリングされた直前ブロックを見失う不具合があった（レビュー指摘）。
+    const items = [
+      { id: 'markdown-0', type: 'markdown', markdown: '前のブロック。' },
+      undefined,
+      { id: 'markdown-1', type: 'markdown', markdown: '次のブロック。' },
+    ] as unknown as EditorItem[];
+    expect(assembleMarkdown(items)).toBe('前のブロック。\n次のブロック。');
   });
 
   it('markdown と非 markdown の隣接は空行(\\n\\n)で結合される（GFM テーブル認識の回帰テスト）', () => {

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -74,7 +74,7 @@ const REVOKE_DELAY_MS = 100;
 const PREVIEW_DEBOUNCE_MS = 300;
 
 // エディタ上のブロック。type と内容を一致させた判別ユニオン（DB の Block に対応）。
-type EditorItem =
+export type EditorItem =
   | { id: string; type: 'markdown'; markdown: string }
   | { id: string; type: 'table'; columns: TableColumn[]; rows: string[][] }
   | { id: string; type: 'skills'; category: string; skills: SkillEntry[] }
@@ -167,7 +167,7 @@ const itemToMarkdown = (item: EditorItem): string => {
 // 連結規則はサーバ側 blocksToMarkdown と共有の blockJoinSeparator に一元化する。
 // 手コピーで 2 箇所に規則が重複していたのを解消し、markdown 分割の無損失性と
 // GFM テーブルが直前段落へ lazy continuation として飲み込まれない区切りを両立する。
-const assembleMarkdown = (items: EditorItem[]): string => {
+export const assembleMarkdown = (items: EditorItem[]): string => {
   let result = '';
   let prev: EditorItem | undefined;
   for (let i = 0; i < items.length; i++) {

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -169,17 +169,16 @@ const itemToMarkdown = (item: EditorItem): string => {
 // GFM テーブルが直前段落へ lazy continuation として飲み込まれない区切りを両立する。
 const assembleMarkdown = (items: EditorItem[]): string => {
   let result = '';
+  let prev: EditorItem | undefined;
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (!item) continue;
     const markdown = itemToMarkdown(item);
-    if (i === 0) {
-      result = markdown;
-      continue;
-    }
-    const prev = items[i - 1];
-    // prev は i>=1 なので通常存在するが、sparse 配列など不正入力でも落ちないよう防御する。
-    result += (prev ? blockJoinSeparator(prev.type, item.type, markdown) : '\n\n') + markdown;
+    // items[i - 1] を位置で参照すると sparse 配列（途中の undefined 要素）で
+    // 実際に直前にレンダリングされたブロックを見失う。実際にレンダリングした
+    // 直前アイテムを prev で追跡し、先頭要素の判定も prev の有無で行う。
+    result += prev === undefined ? markdown : blockJoinSeparator(prev.type, item.type, markdown) + markdown;
+    prev = item;
   }
   return result;
 };

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -281,6 +281,14 @@ describe('blockJoinSeparator — 連結セパレータの単一の真実', () =>
     expect(blockJoinSeparator('table', 'markdown', '本文')).toBe('\n\n');
     expect(blockJoinSeparator('skills', 'stats', '')).toBe('\n\n');
   });
+
+  it('先頭が `|` 始まりでも区切り行を伴わない非テーブルなら \\n のまま（誤検出防止）', () => {
+    // GFM テーブルは見出し行の直後に `| --- |` 形式の区切り行が必須。区切り行を伴わない
+    // `|` 始まりの地の文（レビュー指摘: ASCII 表現やエスケープされたテーブルサンプル等）を
+    // テーブルと誤認して \n\n に切り替えると、無損失ラウンドトリップの前提が崩れる。
+    expect(blockJoinSeparator('markdown', 'markdown', '| これはテーブルではない普通の文章です')).toBe('\n');
+    expect(blockJoinSeparator('markdown', 'markdown', '|not a table|\n次の行も普通の文章')).toBe('\n');
+  });
 });
 
 describe('blocksToMarkdown — markdown ブロック同士でも 2 本目がテーブル始まりなら空行区切り', () => {

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -552,11 +552,13 @@ function isTableDelimiterRow(line: string): boolean {
 
 /**
  * 与えられた markdown が GFM テーブルで始まるかを判定する（先頭「非空行」が `|` 始まり、
- * かつその次の非空行がテーブル区切り行であることまで確認する）。
+ * かつヘッダ行の直後の行がテーブル区切り行であることまで確認する）。
  * lazy continuation でテーブルが直前段落へ飲み込まれるのは、後続ブロックの先頭が
  * テーブル行のときだけなので、この 1 点で連結セパレータを切り替える。
  * `|` 始まりだけを見ると、区切り行を伴わない通常の markdown（先頭が `|` の地の文や
  * コードサンプル等）まで誤って GFM テーブル扱いしてしまうため、区切り行の有無まで見る。
+ * GFM 仕様上、区切り行はヘッダ行の直後でなければならず、間に空行を挟むと表として
+ * 成立しない（Markdown レンダラもテーブルとして解釈しない）ため、空行はスキップしない。
  */
 function startsWithTableRow(markdown: string): boolean {
   const lines = markdown.split('\n');
@@ -568,11 +570,8 @@ function startsWithTableRow(markdown: string): boolean {
   }
   if (firstContentIndex === -1 || !/^\s*\|/.test(lines[firstContentIndex])) return false;
 
-  for (let i = firstContentIndex + 1; i < lines.length; i++) {
-    if (lines[i].trim().length === 0) continue;
-    return isTableDelimiterRow(lines[i]);
-  }
-  return false;
+  const nextLine = lines[firstContentIndex + 1];
+  return nextLine !== undefined && isTableDelimiterRow(nextLine);
 }
 
 /**

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -542,14 +542,35 @@ export function splitMarkdownIntoBlocks(markdown: string): MarkdownBlockData[] {
 }
 
 /**
- * 与えられた markdown の先頭「非空行」が GFM テーブル行（`|` 始まり）かを判定する。
+ * `|` で始まる行が GFM テーブルの区切り行（例 `| --- | :---: |`）かを判定する。
+ */
+function isTableDelimiterRow(line: string): boolean {
+  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
+  const cells = trimmed.split('|');
+  return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell.trim()));
+}
+
+/**
+ * 与えられた markdown が GFM テーブルで始まるかを判定する（先頭「非空行」が `|` 始まり、
+ * かつその次の非空行がテーブル区切り行であることまで確認する）。
  * lazy continuation でテーブルが直前段落へ飲み込まれるのは、後続ブロックの先頭が
  * テーブル行のときだけなので、この 1 点で連結セパレータを切り替える。
+ * `|` 始まりだけを見ると、区切り行を伴わない通常の markdown（先頭が `|` の地の文や
+ * コードサンプル等）まで誤って GFM テーブル扱いしてしまうため、区切り行の有無まで見る。
  */
 function startsWithTableRow(markdown: string): boolean {
-  for (const line of markdown.split('\n')) {
-    if (line.trim().length === 0) continue;
-    return /^\s*\|/.test(line);
+  const lines = markdown.split('\n');
+  let firstContentIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim().length === 0) continue;
+    firstContentIndex = i;
+    break;
+  }
+  if (firstContentIndex === -1 || !/^\s*\|/.test(lines[firstContentIndex])) return false;
+
+  for (let i = firstContentIndex + 1; i < lines.length; i++) {
+    if (lines[i].trim().length === 0) continue;
+    return isTableDelimiterRow(lines[i]);
   }
   return false;
 }


### PR DESCRIPTION
## Issue リンク / Link to Issue

<!-- Issue へのリンク（あれば）を記載します。#のあとにissue番号を記載 -->

close #

### 概要

PR #102（blockJoinSeparator共通化）のマージ後に残っていた、未解決のボットレビュー指摘3件を修正します。

- **assembleMarkdown（builder-client.tsx）**: `items[i - 1]` を位置で参照していたため、sparse配列（途中にundefined要素がある場合）で実際の直前ブロックを見失うことがありました。実際にレンダリングした直前アイテムを`prev`で追跡する方式に変更しました（Gemini指摘）。
- **startsWithTableRow（blocks.ts）**: 先頭行が`|`で始まるかどうかだけでGFMテーブルと判定していたため、区切り行（`| --- |`）を伴わない通常の文章まで誤ってテーブル扱いし、`\n`のはずが`\n\n`に変わってしまう不具合がありました。区切り行の有無まで確認するよう厳密化しました（chatgpt-codex-connector指摘）。
- **revalidate route test**: `vi.mock`ファクトリ内で通常の`const`変数を参照していたのを`vi.hoisted`に変更し、hoisting起因の初期化順序リスクを取り除きました（coderabbitai指摘）。

### 見て欲しいポイント

- [ ] `blocks.ts`の`startsWithTableRow`の区切り行判定ロジック（GFM仕様に沿っているか）
- [ ] `assembleMarkdown`の`prev`追跡方式で既存の結合ロジック（\n / \n\n の切り替え）に回帰がないか

### 見なくてもよいポイント

- [ ] `revalidate/route.test.ts`の`vi.hoisted`化（挙動は変わらず、防御的な書き方の変更のみ）

### その他(あれば)

- 3件とも #102 のレビューコメントに返信済み・スレッドをresolve済みです。
- 変更ファイルすべてで `type-check` / `test`（apps/web 126件・packages/db 86件）/ Biome lint 実行済み、全てパスしています。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

<!-- 特に注意してレビューしてほしい点を記載します。 -->

- [x] 想定通りに動作するか
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)

<!-- no-sbi: PR#102の未解決ボットレビュー指摘への直接対応。紐づくPBI/SBI issueは存在しない -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Markdownブロックの結合処理を改善し、空の要素が含まれる場合でも適切な順序と区切りで表示されるようになりました。
  * 通常のMarkdown記法をテーブルと誤認するケースを減らし、文章のレイアウトがより安定しました。

* **テスト**
  * テーブル形式と通常の文章を正しく判定するための検証を追加・整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->