### PR TITLE
fix(db): GitHub seedを任意化しビルダー空シートで無用なエラーを出さない

### DIFF
--- a/packages/db/src/skillsheet.test.ts
+++ b/packages/db/src/skillsheet.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { type Block, blocksToMarkdown, splitMarkdownIntoBlocks } from './blocks';
+import { isGitHubSeedConfigured } from './skillsheet';
 
 // 注意: skillsheet.ts の getOwnerId は export されておらず（module-private）、
 // getSkillSheet/saveSkillSheetBlocks 経由でしか到達できない。これらは getDb() で
@@ -10,6 +11,47 @@ import { type Block, blocksToMarkdown, splitMarkdownIntoBlocks } from './blocks'
 beforeEach(() => {
   process.env.SESSION_SECRET = 'test-session-secret-deadbeef';
   process.env.SKILLSHEET_OWNER_ID = 'test-owner-id';
+});
+
+describe('isGitHubSeedConfigured', () => {
+  const GH_KEYS = ['GITHUB_TOKEN', 'GITHUB_OWNER', 'GITHUB_REPO', 'VITE_GITHUB_TOKEN', 'VITE_GITHUB_OWNER', 'VITE_GITHUB_REPO'];
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of GH_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of GH_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('GITHUB_* が未設定なら false（未設定は正常系・seed をスキップする合図）', () => {
+    expect(isGitHubSeedConfigured()).toBe(false);
+  });
+
+  it('TOKEN/OWNER/REPO が全て揃うと true', () => {
+    process.env.GITHUB_TOKEN = 't';
+    process.env.GITHUB_OWNER = 'o';
+    process.env.GITHUB_REPO = 'r';
+    expect(isGitHubSeedConfigured()).toBe(true);
+  });
+
+  it('一つでも欠けると false（REPO 欠落）', () => {
+    process.env.GITHUB_TOKEN = 't';
+    process.env.GITHUB_OWNER = 'o';
+    expect(isGitHubSeedConfigured()).toBe(false);
+  });
+
+  it('VITE_ プレフィックスの env でも認識する', () => {
+    process.env.VITE_GITHUB_TOKEN = 't';
+    process.env.VITE_GITHUB_OWNER = 'o';
+    process.env.VITE_GITHUB_REPO = 'r';
+    expect(isGitHubSeedConfigured()).toBe(true);
+  });
 });
 
 // MarkdownBlockData[] を order 付きの Block[] へ変換するヘルパ（blocksToMarkdown 用）。

--- a/packages/db/src/skillsheet.test.ts
+++ b/packages/db/src/skillsheet.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { type Block, blocksToMarkdown, splitMarkdownIntoBlocks } from './blocks';
-import { isGitHubSeedConfigured } from './skillsheet';
+import { getGitHubSeedConfig, isGitHubSeedConfigured } from './skillsheet';
 
 // 注意: skillsheet.ts の getOwnerId は export されておらず（module-private）、
 // getSkillSheet/saveSkillSheetBlocks 経由でしか到達できない。これらは getDb() で
@@ -58,6 +58,17 @@ describe('isGitHubSeedConfigured', () => {
     process.env.VITE_GITHUB_OWNER = 'o';
     process.env.VITE_GITHUB_REPO = 'r';
     expect(isGitHubSeedConfigured()).toBe(true);
+  });
+
+  it('getGitHubSeedConfig は未設定なら null を返す', () => {
+    expect(getGitHubSeedConfig()).toBeNull();
+  });
+
+  it('getGitHubSeedConfig は全て揃うと型を絞った設定を返す', () => {
+    process.env.GITHUB_TOKEN = 't';
+    process.env.GITHUB_OWNER = 'o';
+    process.env.GITHUB_REPO = 'r';
+    expect(getGitHubSeedConfig()).toEqual({ token: 't', owner: 'o', repo: 'r' });
   });
 });
 

--- a/packages/db/src/skillsheet.test.ts
+++ b/packages/db/src/skillsheet.test.ts
@@ -14,7 +14,14 @@ beforeEach(() => {
 });
 
 describe('isGitHubSeedConfigured', () => {
-  const GH_KEYS = ['GITHUB_TOKEN', 'GITHUB_OWNER', 'GITHUB_REPO', 'VITE_GITHUB_TOKEN', 'VITE_GITHUB_OWNER', 'VITE_GITHUB_REPO'];
+  const GH_KEYS = [
+    'GITHUB_TOKEN',
+    'GITHUB_OWNER',
+    'GITHUB_REPO',
+    'VITE_GITHUB_TOKEN',
+    'VITE_GITHUB_OWNER',
+    'VITE_GITHUB_REPO',
+  ];
   const saved: Record<string, string | undefined> = {};
   beforeEach(() => {
     for (const k of GH_KEYS) {

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -74,15 +74,25 @@ export interface SheetSummary {
 }
 
 /**
- * GitHub からの seed（初期データ流し込み）が使えるだけの env が揃っているか。
- * GITHUB_TOKEN / OWNER / REPO が必須。seed はあくまで任意の副系統（正本は DB）なので、
- * 未設定は「異常」ではなく「seed をスキップして空から始める」正常系として扱う。
+ * GitHub からの seed（初期データ流し込み）に必要な env をまとめて取得する。
+ * GITHUB_TOKEN / OWNER / REPO が全て揃っていれば型を絞った設定オブジェクトを、
+ * 一つでも欠ければ null を返す。呼び出し側で env 取得を重複させないための単一窓口。
  */
-export function isGitHubSeedConfigured(): boolean {
+export function getGitHubSeedConfig(): { token: string; owner: string; repo: string } | null {
   const token = process.env.GITHUB_TOKEN ?? process.env.VITE_GITHUB_TOKEN;
   const owner = process.env.GITHUB_OWNER ?? process.env.VITE_GITHUB_OWNER;
   const repo = process.env.GITHUB_REPO ?? process.env.VITE_GITHUB_REPO;
-  return Boolean(token && owner && repo);
+  if (!token || !owner || !repo) return null;
+  return { token, owner, repo };
+}
+
+/**
+ * GitHub からの seed が使えるだけの env が揃っているか。seed はあくまで任意の副系統
+ * （正本は DB）なので、未設定は「異常」ではなく「seed をスキップして空から始める」
+ * 正常系として扱う。
+ */
+export function isGitHubSeedConfigured(): boolean {
+  return getGitHubSeedConfig() !== null;
 }
 
 /**
@@ -90,14 +100,13 @@ export function isGitHubSeedConfigured(): boolean {
  * Uses GITHUB_* env vars so the token is never exposed to the browser.
  */
 export async function fetchMarkdownFromGitHub(): Promise<string> {
-  const token = process.env.GITHUB_TOKEN ?? process.env.VITE_GITHUB_TOKEN;
-  const owner = process.env.GITHUB_OWNER ?? process.env.VITE_GITHUB_OWNER;
-  const repo = process.env.GITHUB_REPO ?? process.env.VITE_GITHUB_REPO;
-  const filePath = process.env.GITHUB_FILE_PATH ?? process.env.VITE_GITHUB_FILE_PATH ?? 'skillsheet.md';
-  const branch = process.env.GITHUB_BRANCH ?? process.env.VITE_GITHUB_BRANCH ?? 'main';
-  if (!isGitHubSeedConfigured()) {
+  const config = getGitHubSeedConfig();
+  if (!config) {
     throw new Error('GitHub seed source is not configured (GITHUB_TOKEN/OWNER/REPO)');
   }
+  const { token, owner, repo } = config;
+  const filePath = process.env.GITHUB_FILE_PATH ?? process.env.VITE_GITHUB_FILE_PATH ?? 'skillsheet.md';
+  const branch = process.env.GITHUB_BRANCH ?? process.env.VITE_GITHUB_BRANCH ?? 'main';
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
   const res = await fetch(url, {
     headers: {

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -98,9 +98,12 @@ export function isGitHubSeedConfigured(): boolean {
 /**
  * Fetch the seed markdown from the existing private GitHub repository (server-side).
  * Uses GITHUB_* env vars so the token is never exposed to the browser.
+ * 呼び出し側が既に getGitHubSeedConfig() を解決済みなら config 引数で渡すことで
+ * env の再読み取りを避けられる（省略時は自前で解決する＝後方互換）。
  */
-export async function fetchMarkdownFromGitHub(): Promise<string> {
-  const config = getGitHubSeedConfig();
+export async function fetchMarkdownFromGitHub(
+  config: { token: string; owner: string; repo: string } | null = getGitHubSeedConfig(),
+): Promise<string> {
   if (!config) {
     throw new Error('GitHub seed source is not configured (GITHUB_TOKEN/OWNER/REPO)');
   }
@@ -162,14 +165,22 @@ async function ensureSeeded(db: Database): Promise<string> {
   // ブロックが 0 個なのは新規オーナー / 全削除後の正常状態。GitHub seed は任意の副系統で
   // 正本は DB のため、未設定なら seed をスキップして空のまま返す（throw して「エラー」に
   // しない）。設定済みで取得に失敗した場合だけ本物の異常として throw が伝播する。
-  if (existingBlocks.length === 0 && isGitHubSeedConfigured()) {
-    const markdown = await fetchMarkdownFromGitHub();
-    const segments = splitMarkdownIntoBlocks(markdown);
-    if (segments.length > 0) {
-      await db
-        .insert(blocks)
-        .values(segments.map((data, order) => ({ sheetId, type: 'markdown', order, data })))
-        .onConflictDoNothing();
+  if (existingBlocks.length === 0) {
+    const config = getGitHubSeedConfig();
+    if (config) {
+      const markdown = await fetchMarkdownFromGitHub(config);
+      const segments = splitMarkdownIntoBlocks(markdown);
+      if (segments.length > 0) {
+        await db
+          .insert(blocks)
+          .values(segments.map((data, order) => ({ sheetId, type: 'markdown', order, data })))
+          .onConflictDoNothing();
+      }
+    } else {
+      // 未設定は正常系だが、意図せぬ設定漏れの調査ができるよう記録だけは残す。
+      console.warn(
+        '[skillsheet] GitHub seed is not configured (GITHUB_TOKEN/OWNER/REPO); starting with an empty sheet.',
+      );
     }
   }
   return sheetId;

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -74,6 +74,18 @@ export interface SheetSummary {
 }
 
 /**
+ * GitHub からの seed（初期データ流し込み）が使えるだけの env が揃っているか。
+ * GITHUB_TOKEN / OWNER / REPO が必須。seed はあくまで任意の副系統（正本は DB）なので、
+ * 未設定は「異常」ではなく「seed をスキップして空から始める」正常系として扱う。
+ */
+export function isGitHubSeedConfigured(): boolean {
+  const token = process.env.GITHUB_TOKEN ?? process.env.VITE_GITHUB_TOKEN;
+  const owner = process.env.GITHUB_OWNER ?? process.env.VITE_GITHUB_OWNER;
+  const repo = process.env.GITHUB_REPO ?? process.env.VITE_GITHUB_REPO;
+  return Boolean(token && owner && repo);
+}
+
+/**
  * Fetch the seed markdown from the existing private GitHub repository (server-side).
  * Uses GITHUB_* env vars so the token is never exposed to the browser.
  */
@@ -83,7 +95,7 @@ export async function fetchMarkdownFromGitHub(): Promise<string> {
   const repo = process.env.GITHUB_REPO ?? process.env.VITE_GITHUB_REPO;
   const filePath = process.env.GITHUB_FILE_PATH ?? process.env.VITE_GITHUB_FILE_PATH ?? 'skillsheet.md';
   const branch = process.env.GITHUB_BRANCH ?? process.env.VITE_GITHUB_BRANCH ?? 'main';
-  if (!token || !owner || !repo) {
+  if (!isGitHubSeedConfigured()) {
     throw new Error('GitHub seed source is not configured (GITHUB_TOKEN/OWNER/REPO)');
   }
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
@@ -138,7 +150,10 @@ async function ensureSeeded(db: Database): Promise<string> {
   const sheetId = await getOrCreateDefaultSheetId(db);
 
   const existingBlocks = await db.select({ id: blocks.id }).from(blocks).where(eq(blocks.sheetId, sheetId)).limit(1);
-  if (existingBlocks.length === 0) {
+  // ブロックが 0 個なのは新規オーナー / 全削除後の正常状態。GitHub seed は任意の副系統で
+  // 正本は DB のため、未設定なら seed をスキップして空のまま返す（throw して「エラー」に
+  // しない）。設定済みで取得に失敗した場合だけ本物の異常として throw が伝播する。
+  if (existingBlocks.length === 0 && isGitHubSeedConfigured()) {
     const markdown = await fetchMarkdownFromGitHub();
     const segments = splitMarkdownIntoBlocks(markdown);
     if (segments.length > 0) {


### PR DESCRIPTION
<!-- quality-ok -->
<!-- no-sbi: プレビュー別窓E2E検証中に発見した不具合を局長承認で修正。対応する既存SBIなし -->
## Issue リンク / Link to Issue

close #

（対応する Issue なし。プレビュー別窓機能の E2E 検証中に見つけた不具合を、局長の指示で修正）

### 概要

新規オーナーや全ブロック削除後の空シートで `/builder` を開くと、`ensureSeeded` が無条件で `fetchMarkdownFromGitHub` を呼び、`GITHUB_*` 未設定時に必ず throw していた。GitHub seed（初期データの流し込み）は任意の副系統で正本は DB なので、この throw は `builder/page.tsx` で catch されるものの `console.error` として開発ログに出て、Next dev の Issue バッジを点灯させていた。本番でも空シート時に同じ経路を踏みうる。

`isGitHubSeedConfigured()` を追加し、seed は設定済みのときだけ試みるようガードした。未設定なら seed をスキップして空のまま返す（正常系）。設定済みで取得に失敗した場合だけ従来通り本物の異常として throw が伝播する。

### 見て欲しいポイント

- [ ] `ensureSeeded` のガード条件 `existingBlocks.length === 0 && isGitHubSeedConfigured()`。空シート＋seed未設定を正常系として扱う意図が伝わるか
- [ ] `isGitHubSeedConfigured()` を切り出して `fetchMarkdownFromGitHub` の既存チェックとも共有した点

### 見なくてもよいポイント

- [ ] コメントの文言（挙動は変えていない）

### その他(あれば)

ローカル実 DB + 空ユーザーで修正前後を A/B 検証した。修正前は `GitHub seed source is not configured` ログが出て Issue バッジ点灯、修正後は 0 件。既存の hydration 警告（builder-client 側の乱数/時刻依存 ID 由来）は本変更と無関係で、修正前後とも同じく出ることを実測で確認済み。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外） … 対応 Issue なしのため省略
- [x] 複数の変更が 1 つの PR に入り込んでいないか … seed 任意化の 1 点のみ
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか … なし
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか … 該当なし

### レビュー観点

- [ ] 想定通りに動作するか … 空シート＋GITHUB_未設定でエラーを出さず空ビルダーで開始する
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？ … seed を必須依存から任意 best-effort へ変えた妥当性
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？ … `isGitHubSeedConfigured()` の切り出し粒度
- [ ] その他 … 単体テスト4件（全揃い/一部欠落/VITE_プレフィックス/未設定）を追加

https://claude.ai/code/session_01MLyLfn1q1aZw3CczmooF7w


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - GitHub連携に必要な設定が未登録の場合、初回アクセス時に自動取得を試みず、空のスキルシートから開始するようになりました。
  - GitHub連携設定が一部不足している場合も安全に判定され、不要なエラーを防止します。
  - 必要な設定がすべて揃っている場合は、従来どおりGitHubからスキルシートを取得して初期化します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->