### PR TITLE
fix(builder): プレビュー列のタブ移動を畳み、入力欄の高さを幅の変更に追従させる

### DIFF
--- a/apps/web/app/builder/editor.css
+++ b/apps/web/app/builder/editor.css
@@ -1000,6 +1000,11 @@
   background: var(--accent-soft);
   box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--primary) 45%, transparent);
 }
+/* 上下キーで移動している間、いまどのブロックに居るかが分かるようにする。 */
+.pv-sync:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 1px;
+}
 
 /* ── 空状態・トースト・会社編集バー ───────────── */
 .empty {

--- a/apps/web/app/builder/grow-textarea.test.tsx
+++ b/apps/web/app/builder/grow-textarea.test.tsx
@@ -1,0 +1,87 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GrowTextarea } from './grow-textarea';
+
+let width = 400;
+let scrollHeight = 100;
+let callbacks: (() => void)[] = [];
+
+const original = {
+  clientWidth: Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth'),
+  scrollHeight: Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight'),
+  observer: globalThis.ResizeObserver,
+};
+
+beforeEach(() => {
+  width = 400;
+  scrollHeight = 100;
+  callbacks = [];
+  // jsdom はレイアウトを持たないので、幅と内容高さを差し替えて幅変更を再現する
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => width });
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  globalThis.ResizeObserver = class {
+    constructor(cb: () => void) {
+      callbacks.push(cb);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  if (original.clientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', original.clientWidth);
+  else Reflect.deleteProperty(HTMLElement.prototype, 'clientWidth');
+  if (original.scrollHeight) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', original.scrollHeight);
+  else Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+  globalThis.ResizeObserver = original.observer;
+});
+
+const renderTa = () =>
+  render(<GrowTextarea value="ある程度の長さの本文" onChange={vi.fn()} label="担当業務" />).container
+    .firstElementChild as HTMLTextAreaElement;
+
+describe('GrowTextarea の高さ追従', () => {
+  it('初期表示で内容の高さに合わせる', () => {
+    expect(renderTa().style.height).toBe('102px');
+  });
+
+  it('幅が変わったら同じ本文でも高さを合わせ直す', () => {
+    const ta = renderTa();
+
+    // 幅が狭くなると同じ本文でも行数が増える
+    width = 200;
+    scrollHeight = 300;
+    act(() => {
+      for (const cb of callbacks) cb();
+    });
+
+    expect(ta.style.height).toBe('302px');
+  });
+
+  it('幅が変わっていなければ測り直さない（観測が止まらなくなるのを防ぐ）', () => {
+    const ta = renderTa();
+
+    // 高さだけ変わった通知（fit 自身が高さを書き換えた結果として届く）
+    scrollHeight = 300;
+    act(() => {
+      for (const cb of callbacks) cb();
+    });
+
+    expect(ta.style.height).toBe('102px');
+  });
+
+  it('上限を超えたら内部スクロールへ切り替える', () => {
+    const ta = renderTa();
+
+    width = 200;
+    scrollHeight = 900;
+    act(() => {
+      for (const cb of callbacks) cb();
+    });
+
+    expect(ta.style.height).toBe('520px');
+    expect(ta.style.overflowY).toBe('auto');
+  });
+});

--- a/apps/web/app/builder/grow-textarea.tsx
+++ b/apps/web/app/builder/grow-textarea.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 interface GrowTextareaProps {
   value: string;
@@ -22,19 +22,42 @@ const MAX_HEIGHT = 520;
 export const GrowTextarea = ({ value, onChange, label, placeholder, syncKey, onFocus }: GrowTextareaProps) => {
   const ref = useRef<HTMLTextAreaElement>(null);
 
-  // 値が外から変わる場合（履歴からの復元・案件切替）も高さを合わせ直す必要があるため、
-  // onChange ハンドラではなく value を依存にした effect で調整する。
-  // value は本文に現れないが、textarea の scrollHeight は value の描画結果に依存するので、
-  // 依存から外すと値が変わっても伸び縮みしなくなる。
-  // biome-ignore lint/correctness/useExhaustiveDependencies: 上の理由で value を意図的に依存へ残す
-  useEffect(() => {
+  const resizeToContent = useCallback(() => {
     const el = ref.current;
     if (!el) return;
     el.style.height = 'auto';
     const needed = el.scrollHeight + 2;
     el.style.height = `${Math.min(needed, MAX_HEIGHT)}px`;
     el.style.overflowY = needed > MAX_HEIGHT ? 'auto' : 'hidden';
-  }, [value]);
+  }, []);
+
+  // 値が外から変わる場合（履歴からの復元・案件切替）も高さを合わせ直す必要があるため、
+  // onChange ハンドラではなく value を依存にした effect で調整する。
+  // value は本文に現れないが、textarea の scrollHeight は value の描画結果に依存するので、
+  // 依存から外すと値が変わっても伸び縮みしなくなる。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 上の理由で value を意図的に依存へ残す
+  useEffect(() => {
+    resizeToContent();
+  }, [value, resizeToContent]);
+
+  // 幅が変わると同じ文章でも行数が変わる（プレビュー列の開閉・ウィンドウ幅の変更・
+  // 縦横の切り替え）。value は変わらないので上の effect では拾えず、
+  // 幅を狭めたときだけ中身が枠から溢れたままになる。
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    // 高さは resizeToContent() 自身が書き換えるため、高さの変化で再実行すると観測が止まらなくなる。
+    // 幅が実際に変わったときだけ合わせ直す。
+    let lastWidth = el.clientWidth;
+    const observer = new ResizeObserver(() => {
+      const width = el.clientWidth;
+      if (width === lastWidth) return;
+      lastWidth = width;
+      resizeToContent();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [resizeToContent]);
 
   return (
     <textarea

--- a/apps/web/app/builder/project-preview.test.tsx
+++ b/apps/web/app/builder/project-preview.test.tsx
@@ -1,0 +1,86 @@
+import type { ProjectItem } from '@skillsheet/db/blocks';
+import { act, fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ProjectPreview } from './project-preview';
+
+const project = (over: Partial<ProjectItem> = {}): ProjectItem => ({
+  id: 'p1',
+  companyId: 'c1',
+  title: '受発注システムの刷新',
+  scope: '販売管理',
+  period: '2024/04 - 2025/03',
+  role: 'テックリード',
+  team: '6',
+  tech: { lang: ['TypeScript'], fw: ['Next.js'], db: [], infra: [], tools: [], collab: [] },
+  process: ['要件定義', '実装'],
+  duties: '設計と実装を担当した。',
+  acquired: '大規模移行の知見。',
+  comment: '継続支援中。',
+  summary: '基幹の受発注を刷新した。',
+  ...over,
+});
+
+const slotsOf = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLElement>('[data-pv-slot]')).map((el) => el.dataset.pvSlot);
+
+const tabbable = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLElement>('[data-pv-slot]')).filter((el) => el.tabIndex === 0);
+
+describe('ProjectPreview のキーボード移動', () => {
+  it('プレビュー列全体で tab の止まり先は1箇所だけ', () => {
+    const { container } = render(<ProjectPreview project={project()} company={undefined} no={1} />);
+
+    expect(slotsOf(container).length).toBeGreaterThan(5);
+    expect(tabbable(container)).toHaveLength(1);
+    expect(tabbable(container)[0].dataset.pvSlot).toBe('period');
+  });
+
+  it('上下キーで隣のブロックへ移り、tab の止まり先もそこへ移る', () => {
+    const { container } = render(<ProjectPreview project={project()} company={undefined} no={1} />);
+    const slots = slotsOf(container);
+    const first = container.querySelector<HTMLElement>('[data-pv-slot="period"]');
+    if (!first) throw new Error('先頭ブロックが無い');
+
+    act(() => first.focus());
+    fireEvent.keyDown(first, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(container.querySelector(`[data-pv-slot="${slots[1]}"]`));
+    expect(tabbable(container)[0].dataset.pvSlot).toBe(slots[1]);
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('End で末尾、Home で先頭へ飛ぶ', () => {
+    const { container } = render(<ProjectPreview project={project()} company={undefined} no={1} />);
+    const slots = slotsOf(container);
+    const first = container.querySelector<HTMLElement>('[data-pv-slot="period"]');
+    if (!first) throw new Error('先頭ブロックが無い');
+
+    act(() => first.focus());
+    fireEvent.keyDown(first, { key: 'End' });
+    expect(document.activeElement).toBe(container.querySelector(`[data-pv-slot="${slots[slots.length - 1]}"]`));
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Home' });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('要約が空で担当業務だけある場合も移動先が重複しない', () => {
+    const { container } = render(<ProjectPreview project={project({ summary: '' })} company={undefined} no={1} />);
+    const slots = slotsOf(container);
+
+    expect(new Set(slots).size).toBe(slots.length);
+    expect(slots).toContain('summary');
+    expect(slots).toContain('duties');
+  });
+
+  it('Enter で対応する編集欄へ飛ぶ', () => {
+    const onJump = vi.fn();
+    const { container } = render(<ProjectPreview project={project()} company={undefined} no={1} onJump={onJump} />);
+    const title = container.querySelector<HTMLElement>('[data-pv-slot="title"]');
+    if (!title) throw new Error('タイトルブロックが無い');
+
+    fireEvent.keyDown(title, { key: 'Enter' });
+    expect(onJump).toHaveBeenCalledWith('title');
+  });
+});

--- a/apps/web/app/builder/project-preview.tsx
+++ b/apps/web/app/builder/project-preview.tsx
@@ -2,6 +2,7 @@
 
 import type { CompanyInfo, ProjectItem } from '@skillsheet/db/blocks';
 import { flattenTech, normalizeProcess, PROCESS_LABELS } from '@skillsheet/db/process';
+import { useRef, useState } from 'react';
 
 interface ProjectPreviewProps {
   project: ProjectItem;
@@ -27,6 +28,11 @@ const MAX_TECH_CHIPS = 16;
  * 閲覧側の案件カードと同じ情報を、エディタ幅（396px）に収まる密度で再構成したもの。
  * 各ブロックはクリックでフォームの対応欄へ飛び、逆にフォームを編集すると光る（同期ジャンプ）。
  * hidden（案件自身 or 所属会社）の場合は「閲覧側では非表示」バッジを添える。
+ *
+ * 同期ブロックは全体で1つの toolbar として扱う（roving tabindex）。
+ * 個々のブロックを順に tab 可能にすると、プレビュー列を通り抜けるだけで
+ * 案件の情報量ぶんの tab を押すことになり、キーボードだけで使う人が列の外へ出られない。
+ * 列の中は上下キーで移動し、tab は列全体で1回だけ止まる。
  */
 export const ProjectPreview = ({ project, company, no, syncKey, onJump }: ProjectPreviewProps) => {
   const hidden = Boolean(project.hidden || company?.hidden);
@@ -35,13 +41,47 @@ export const ProjectPreview = ({ project, company, no, syncKey, onJump }: Projec
   const process = normalizeProcess(project.process);
   const summary = project.summary?.trim() || project.duties.trim();
 
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  /** 上下キー移動でいま tab の受け口になっているスロット。null なら先頭。 */
+  const [focusSlot, setFocusSlot] = useState<string | null>(null);
+
+  const textBlocks = (
+    [
+      ['duties', '≪担当業務≫', project.duties],
+      ['acquired', '≪習得スキル・実績≫', project.acquired],
+      ['comment', '≪コメント≫', project.comment],
+    ] as const
+  ).filter(([, , body]) => body.trim());
+
+  /**
+   * 上下キーで巡る順序。DOM の並びと一致させる。
+   * 飛び先キー（data-sync-pv）とは別に「スロット」を持たせているのは、
+   * summary 欄が空のとき要約ブロックの飛び先が duties になり、
+   * 下の担当業務ブロックと飛び先キーが重複するため。
+   * 重複したキーで位置を数えると、上下キーが同じ場所を指してしまう。
+   */
+  const slots = [
+    'period',
+    'title',
+    'scope',
+    'meta',
+    ...(summary ? ['summary'] : []),
+    ...(shownTech.length > 0 ? ['tech'] : []),
+    'process',
+    ...textBlocks.map(([key]) => key as string),
+  ];
+
+  const activeSlot = focusSlot && slots.includes(focusSlot) ? focusSlot : slots[0];
+
   /** クリックとキーボードの両方で飛べる同期ブロック。 */
-  const sync = (key: string) => ({
+  const sync = (key: string, slot: string = key) => ({
     className: `pv-sync${syncKey === key ? ' on' : ''}`,
     'data-sync-pv': key,
+    'data-pv-slot': slot,
     role: 'button' as const,
-    tabIndex: 0,
+    tabIndex: slot === activeSlot ? 0 : -1,
     title: '編集欄へ移動',
+    onFocus: () => setFocusSlot(slot),
     onClick: () => onJump?.(key),
     onKeyDown: (e: React.KeyboardEvent) => {
       if (e.key !== 'Enter' && e.key !== ' ') return;
@@ -50,92 +90,114 @@ export const ProjectPreview = ({ project, company, no, syncKey, onJump }: Projec
     },
   });
 
+  const moveFocus = (from: string, delta: number | 'first' | 'last') => {
+    const at = slots.indexOf(from);
+    const next =
+      delta === 'first' ? 0 : delta === 'last' ? slots.length - 1 : Math.min(Math.max(at + delta, 0), slots.length - 1);
+    const target = toolbarRef.current?.querySelector<HTMLElement>(`[data-pv-slot="${slots[next]}"]`);
+    if (!target) return;
+    setFocusSlot(slots[next]);
+    target.focus();
+  };
+
+  const handleToolbarKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const from = (e.target as HTMLElement).closest<HTMLElement>('[data-pv-slot]')?.dataset.pvSlot;
+    if (!from) return;
+    const delta = { ArrowDown: 1, ArrowRight: 1, ArrowUp: -1, ArrowLeft: -1, Home: 'first', End: 'last' }[e.key] as
+      | number
+      | 'first'
+      | 'last'
+      | undefined;
+    if (delta === undefined) return;
+    e.preventDefault();
+    moveFocus(from, delta);
+  };
+
   return (
     <div className="preview-inner">
       <div className="flex items-center gap-2">
         <span className="kicker">Live Preview · 閲覧時の見え方</span>
         {hidden && <span className="pv-hidden">閲覧側では非表示</span>}
       </div>
-      <p className="pv-hint">各ブロックをクリックすると、その項目の編集欄へ移動します。</p>
-
-      <div className={`pv-card${hidden ? ' opacity-60' : ''}`}>
-        <div className="pv-top">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <span className="pv-no">{no > 0 ? String(no).padStart(2, '0') : '––'}</span>
-              <span {...sync('period')}>
-                <span className="pv-period">{project.period || '期間未入力'}</span>
-              </span>
+      <p className="pv-hint">各ブロックをクリックすると、その項目の編集欄へ移動します（上下キーでも選べます）。</p>
+      <div
+        ref={toolbarRef}
+        role="toolbar"
+        aria-orientation="vertical"
+        aria-label="プレビューの項目（上下キーで移動、Enter で編集欄へ）"
+        onKeyDown={handleToolbarKeyDown}
+      >
+        <div className={`pv-card${hidden ? ' opacity-60' : ''}`}>
+          <div className="pv-top">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="pv-no">{no > 0 ? String(no).padStart(2, '0') : '––'}</span>
+                <span {...sync('period')}>
+                  <span className="pv-period">{project.period || '期間未入力'}</span>
+                </span>
+              </div>
+              <div {...sync('title')}>
+                <h3 className="pv-title">{project.title || '（無題の案件）'}</h3>
+              </div>
+              <div {...sync('scope')}>
+                <div className="pv-scope">{project.scope || 'スコープ未入力'}</div>
+              </div>
             </div>
-            <div {...sync('title')}>
-              <h3 className="pv-title">{project.title || '（無題の案件）'}</h3>
-            </div>
-            <div {...sync('scope')}>
-              <div className="pv-scope">{project.scope || 'スコープ未入力'}</div>
+            <div {...sync('meta')}>
+              <div className="pv-meta">
+                {project.role || '役割未設定'}
+                <div className="m2">
+                  {[company?.name, project.team && `${project.team}名`, project.duration].filter(Boolean).join(' · ')}
+                </div>
+              </div>
             </div>
           </div>
-          <div {...sync('meta')}>
-            <div className="pv-meta">
-              {project.role || '役割未設定'}
-              <div className="m2">
-                {[company?.name, project.team && `${project.team}名`, project.duration].filter(Boolean).join(' · ')}
+
+          {/* 要約は summary 欄の値を優先し、空のときだけ担当業務で代替する。
+              飛び先も表示元に合わせる（同じキーを2箇所に出すと、同期ジャンプが先に見つけた
+              方へ飛んで誤爆する）。 */}
+          {summary && (
+            <div {...sync(project.summary?.trim() ? 'summary' : 'duties', 'summary')}>
+              <p className="pv-summary">{summary}</p>
+            </div>
+          )}
+
+          {shownTech.length > 0 && (
+            <div {...sync('tech')}>
+              <div className="pv-tech">
+                {shownTech.map((t) => (
+                  <span key={t}>{t}</span>
+                ))}
+                {tech.length > shownTech.length && <span>+{tech.length - shownTech.length}</span>}
+              </div>
+            </div>
+          )}
+
+          <div className="pv-proc-wrap">
+            <div {...sync('process')}>
+              <div className="pv-proc">
+                {PROCESS_LABELS.map((label, i) => (
+                  <div key={label} className="pp">
+                    <span className="lbl" style={{ color: process.done[i] ? 'var(--accent-text)' : 'var(--faint)' }}>
+                      {label}
+                    </span>
+                    <span className="bar" style={{ background: process.done[i] ? 'var(--primary)' : 'var(--track)' }} />
+                  </div>
+                ))}
               </div>
             </div>
           </div>
         </div>
 
-        {/* 要約は summary 欄の値を優先し、空のときだけ担当業務で代替する。
-            飛び先も表示元に合わせる（同じキーを2箇所に出すと、同期ジャンプが先に見つけた
-            方へ飛んで誤爆する）。 */}
-        {summary && (
-          <div {...sync(project.summary?.trim() ? 'summary' : 'duties')}>
-            <p className="pv-summary">{summary}</p>
-          </div>
-        )}
-
-        {shownTech.length > 0 && (
-          <div {...sync('tech')}>
-            <div className="pv-tech">
-              {shownTech.map((t) => (
-                <span key={t}>{t}</span>
-              ))}
-              {tech.length > shownTech.length && <span>+{tech.length - shownTech.length}</span>}
-            </div>
-          </div>
-        )}
-
-        <div className="pv-proc-wrap">
-          <div {...sync('process')}>
-            <div className="pv-proc">
-              {PROCESS_LABELS.map((label, i) => (
-                <div key={label} className="pp">
-                  <span className="lbl" style={{ color: process.done[i] ? 'var(--accent-text)' : 'var(--faint)' }}>
-                    {label}
-                  </span>
-                  <span className="bar" style={{ background: process.done[i] ? 'var(--primary)' : 'var(--track)' }} />
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {(
-        [
-          ['duties', '≪担当業務≫', project.duties],
-          ['acquired', '≪習得スキル・実績≫', project.acquired],
-          ['comment', '≪コメント≫', project.comment],
-        ] as const
-      ).map(([key, heading, body]) =>
-        body.trim() ? (
+        {textBlocks.map(([key, heading, body]) => (
           <div key={key} className="pv-block">
             <div {...sync(key)}>
               <div className="bt">{heading}</div>
               <div className="bc">{body}</div>
             </div>
           </div>
-        ) : null,
-      )}
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- quality-ok -->
## Issue リンク / Link to Issue

Closes #118

### 概要

案件エディタの右側プレビュー列を、キーボードだけで通り抜けられるようにします。あわせて入力欄の高さが幅の変更に追従するようにします。

プレビュー列は各ブロックが個別に Tab の止まり先でした。列を通り過ぎるだけで案件の情報量ぶんの Tab が要ります。列全体を1つのまとまりとして扱い、Tab の止まり先を1箇所にします。中は上下キー、Home、End で移動します。

入力欄の高さ調整は入力値の変化だけを見ていました。幅が変わって行数が増えても枠の高さが元のままです。幅の変化を監視し、幅が実際に変わったときだけ測り直します。

### 見て欲しいポイント

- [ ] 移動用のスロットを飛び先キーと分けた点。要約欄が空だと要約ブロックの飛び先が duties になり、下の担当業務ブロックとキーが重複するため
- [ ] 高さの再計算を幅の変化に限定した点。高さは再計算自身が書き換えるので、高さの変化で再実行すると監視が止まらなくなる

### 見なくてもよいポイント

- [ ] `.pv-sync:focus-visible` の枠線。移動中の位置を見せるためだけの追加

### その他(あれば)

UI照合の記録です。

- 比較元: なし（Figma のフレームも参照画像も無い。見た目ではなく操作と高さの変更のため）
- 判定: 対象外
- 照合していない場合の理由: 比較元が存在しない

ローカルの開発サーバー（staging DB、使い捨てアカウント）で操作した結果です。

- プレビュー列の Tab の止まり先: 8箇所 → 1箇所
- 上下キーの移動: 期間 → 案件名 → スコープ → 役割、End で末尾へ
- 入力欄の高さ: 幅 1600px で 188px、760px で 237px、戻すと 188px
- `pnpm -r --if-present test` 171件成功（本PRで9件追加）、`pnpm -r type-check` と `pnpm build` 成功

`/builder` に hydration の警告が出ますが、本PRの変更前からのもので別件です。