### PR TITLE
fix(builder): 要約が担当業務の代替表示のとき飛び先キーが重複するのを直す

### DIFF
--- a/apps/web/app/builder/project-preview.test.tsx
+++ b/apps/web/app/builder/project-preview.test.tsx
@@ -65,13 +65,60 @@ describe('ProjectPreview のキーボード移動', () => {
     expect(document.activeElement).toBe(first);
   });
 
-  it('要約が空で担当業務だけある場合も移動先が重複しない', () => {
-    const { container } = render(<ProjectPreview project={project({ summary: '' })} company={undefined} no={1} />);
-    const slots = slotsOf(container);
+  it('移動先が重複せず、要約が担当業務の代替表示のときは移動先に入らない', () => {
+    const withSummary = render(<ProjectPreview project={project()} company={undefined} no={1} />);
+    const withSlots = slotsOf(withSummary.container);
+    expect(new Set(withSlots).size).toBe(withSlots.length);
+    expect(withSlots).toContain('summary');
 
-    expect(new Set(slots).size).toBe(slots.length);
-    expect(slots).toContain('summary');
-    expect(slots).toContain('duties');
+    const fallback = render(<ProjectPreview project={project({ summary: '' })} company={undefined} no={1} />);
+    const fbSlots = slotsOf(fallback.container);
+    expect(new Set(fbSlots).size).toBe(fbSlots.length);
+    expect(fbSlots).not.toContain('summary');
+    expect(fbSlots).toContain('duties');
+  });
+
+  it('要約が空でも飛び先キーが重複しない', () => {
+    // 飛び先キーが2箇所に出ると、編集欄→プレビューの追従が先に見つけた方（要約ブロック）へ
+    // 走り、本来の ≪担当業務≫ ブロックへ行かない。ハイライトも2箇所同時に点く。
+    const { container } = render(<ProjectPreview project={project({ summary: '' })} company={undefined} no={1} />);
+    const keys = Array.from(container.querySelectorAll<HTMLElement>('[data-sync-pv]')).map((el) => el.dataset.syncPv);
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('クリックでも対応する編集欄へ飛ぶ', () => {
+    const onJump = vi.fn();
+    const { container } = render(<ProjectPreview project={project()} company={undefined} no={1} onJump={onJump} />);
+    const tech = container.querySelector<HTMLElement>('[data-pv-slot="tech"]');
+    if (!tech) throw new Error('技術ブロックが無い');
+
+    fireEvent.click(tech);
+    expect(onJump).toHaveBeenCalledWith('tech');
+  });
+
+  it('Space でも対応する編集欄へ飛ぶ', () => {
+    const onJump = vi.fn();
+    const { container } = render(<ProjectPreview project={project()} company={undefined} no={1} onJump={onJump} />);
+    const scope = container.querySelector<HTMLElement>('[data-pv-slot="scope"]');
+    if (!scope) throw new Error('スコープブロックが無い');
+
+    fireEvent.keyDown(scope, { key: ' ' });
+    expect(onJump).toHaveBeenCalledWith('scope');
+  });
+
+  it('左右キーでも隣のブロックへ移る', () => {
+    const { container } = render(<ProjectPreview project={project()} company={undefined} no={1} />);
+    const slots = slotsOf(container);
+    const first = container.querySelector<HTMLElement>('[data-pv-slot="period"]');
+    if (!first) throw new Error('先頭ブロックが無い');
+
+    act(() => first.focus());
+    fireEvent.keyDown(first, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(container.querySelector(`[data-pv-slot="${slots[1]}"]`));
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(first);
   });
 
   it('Enter で対応する編集欄へ飛ぶ', () => {

--- a/apps/web/app/builder/project-preview.tsx
+++ b/apps/web/app/builder/project-preview.tsx
@@ -39,6 +39,8 @@ export const ProjectPreview = ({ project, company, no, syncKey, onJump }: Projec
   const tech = flattenTech(project.tech);
   const shownTech = tech.slice(0, MAX_TECH_CHIPS);
   const process = normalizeProcess(project.process);
+  /** 要約欄そのものに値がある（担当業務での代替ではない）。 */
+  const hasOwnSummary = Boolean(project.summary?.trim());
   const summary = project.summary?.trim() || project.duties.trim();
 
   const toolbarRef = useRef<HTMLDivElement>(null);
@@ -56,16 +58,14 @@ export const ProjectPreview = ({ project, company, no, syncKey, onJump }: Projec
   /**
    * 上下キーで巡る順序。DOM の並びと一致させる。
    * 飛び先キー（data-sync-pv）とは別に「スロット」を持たせているのは、
-   * summary 欄が空のとき要約ブロックの飛び先が duties になり、
-   * 下の担当業務ブロックと飛び先キーが重複するため。
-   * 重複したキーで位置を数えると、上下キーが同じ場所を指してしまう。
+   * 飛び先が同じでも移動先としては別物として数える必要があるため。
    */
   const slots = [
     'period',
     'title',
     'scope',
     'meta',
-    ...(summary ? ['summary'] : []),
+    ...(summary && hasOwnSummary ? ['summary'] : []),
     ...(shownTech.length > 0 ? ['tech'] : []),
     'process',
     ...textBlocks.map(([key]) => key as string),
@@ -124,7 +124,8 @@ export const ProjectPreview = ({ project, company, no, syncKey, onJump }: Projec
         ref={toolbarRef}
         role="toolbar"
         aria-orientation="vertical"
-        aria-label="プレビューの項目（上下キーで移動、Enter で編集欄へ）"
+        // 矢印キーは読み上げソフトの通常モードでは奪われて届かないので、案内には書かない。
+        aria-label="プレビューの項目（Enter で編集欄へ移動）"
         onKeyDown={handleToolbarKeyDown}
       >
         <div className={`pv-card${hidden ? ' opacity-60' : ''}`}>
@@ -154,13 +155,17 @@ export const ProjectPreview = ({ project, company, no, syncKey, onJump }: Projec
           </div>
 
           {/* 要約は summary 欄の値を優先し、空のときだけ担当業務で代替する。
-              飛び先も表示元に合わせる（同じキーを2箇所に出すと、同期ジャンプが先に見つけた
-              方へ飛んで誤爆する）。 */}
-          {summary && (
-            <div {...sync(project.summary?.trim() ? 'summary' : 'duties', 'summary')}>
+              代替表示のときはクリックもキーボード移動も付けない。付けると飛び先キーが
+              下の ≪担当業務≫ ブロックと重複し、編集欄からの追従が先に見つけた
+              こちらへ走って、本来の担当業務ブロックへ行かなくなる。 */}
+          {summary &&
+            (hasOwnSummary ? (
+              <div {...sync('summary')}>
+                <p className="pv-summary">{summary}</p>
+              </div>
+            ) : (
               <p className="pv-summary">{summary}</p>
-            </div>
-          )}
+            ))}
 
           {shownTech.length > 0 && (
             <div {...sync('tech')}>

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -126,6 +126,11 @@ CI（`.github/workflows/security-scan.yml`）は `pnpm audit` を2本走らせ�
 | 3.0.2 / 4.0.1 | object（`default` 経由） |
 | 5.0.8 | object（`expand` 経由） |
 
+3.x / 4.x と 5.x も取り出し方が違うので、3.x / 4.x を要求する依存が新しく入ってきた場合は
+この override が原因で読み込みに失敗する。現在のロックファイルに 3.x / 4.x は無く、
+`brace-expansion` は 5.0.8 の1個だけなので実害は無い。落ちる場合も起動時にエラーが出る。
+その時は override を狭めるのではなく、依存側を上げる。狭めると脆弱性検査が赤くなる。
+
 ### Storybook のビルダー
 
 Storybook のフレームワークは `@storybook/nextjs-vite` を使う。webpack 版の


### PR DESCRIPTION
<!-- quality-ok -->
## Issue リンク / Link to Issue

Closes #120

### 概要

要約欄が空の案件では、プレビューの要約ブロックが担当業務の本文を代わりに表示します。このとき飛び先キー（フォームのどの欄へ移動するかの印）も `duties` になり、下の ≪担当業務≫ ブロックと同じ印が2箇所に出ていました。

そのため編集欄にカーソルを置くと、追従が先に見つけた要約ブロックへ走り、本来の ≪担当業務≫ ブロックへ行きません。現在位置のハイライトも2箇所同時に点きます。

代替表示のときはクリックもキーボード移動も付けないようにしました。表示内容は変えていません。

### 見て欲しいポイント

- [ ] 代替表示かどうかを `hasOwnSummary` で判定し、移動先の一覧からも外している点
- [ ] 読み上げソフトの通常モードでは矢印キーが届かないため、案内文から矢印キーの記述を落とした点

### 見なくてもよいポイント

- [ ] `doc/dev-guide.md` への追記。brace-expansion の設定を将来狭めないための注意書き

### その他(あれば)

UI照合の記録です。

- 比較元: なし（Figma のフレームも参照画像も無い。表示は変えず、移動と追従の対象だけを変えたため）
- 判定: 対象外
- 照合していない場合の理由: 比較元が存在しない

ローカルの開発サーバー（staging DB、使い捨てアカウント）で、要約欄を空のまま担当業務だけ入れて操作した結果です。

- 飛び先キー: 6個すべて重複なし（修正前は10個中1個が重複）
- 担当業務の入力欄にフォーカス: 点灯したのは ≪担当業務≫ ブロック1件のみ（修正前は2件）
- 移動先の並び: 期間 → 案件名 → スコープ → 役割 → 工程 → 担当業務
- 要約の文字自体は従来どおり表示（表示内容は不変）
- テスト175件成功（本PRで4件追加）、型チェックと本番ビルド成功

この不具合は、多角的な自己レビューで見つけました。