### PR TITLE
fix: full テンプレートの空職務経歴 / 工程ステッパー色だけ / skill-sheet インポート

### DIFF
--- a/apps/web/app/builder/templates.ts
+++ b/apps/web/app/builder/templates.ts
@@ -78,20 +78,6 @@ export const TEMPLATES: SheetTemplate[] = [
           skills: [{ name: '', years: 0, level: '' }],
         },
       },
-      {
-        type: 'markdown',
-        data: { markdown: '## 職務経歴' },
-      },
-      {
-        type: 'experience',
-        data: {
-          company: '',
-          startDate: '',
-          endDate: '',
-          role: '',
-          description: '',
-        },
-      },
     ],
   },
   {

--- a/apps/web/src/component/blocks/process-stepper.tsx
+++ b/apps/web/src/component/blocks/process-stepper.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { PROCESS_LABELS } from '@skillsheet/db/process';
+import { Check, Circle } from 'lucide-react';
 
 interface ProcessStepperProps {
   /** normalizeProcess() の done（7要素）。 */
@@ -9,19 +10,22 @@ interface ProcessStepperProps {
   compact?: boolean;
 }
 
-// 7段SDLCモデルの担当工程ステッパー。担当あり/なし の2状態。
+// 7段SDLCモデルの担当工程ステッパー。担当あり/なし はアイコン＋色で区別する。
 export function ProcessStepper({ done, compact = false }: ProcessStepperProps) {
   return (
     <div className="flex items-end gap-1.5">
       {PROCESS_LABELS.map((label, i) => {
         const isDone = done?.[i] ?? false;
-        const title = isDone ? `${label}：経験あり` : label;
+        const title = isDone ? `${label}：経験あり` : `${label}：未経験`;
+        const StatusIcon = isDone ? Check : Circle;
         return (
           <div key={label} className="flex min-w-0 flex-1 flex-col items-center gap-1">
             {!compact && (
               <span
-                className={`break-keep text-center font-mono text-[10px] leading-tight [overflow-wrap:anywhere] ${isDone ? 'text-accent-text' : 'text-faint'}`}
+                title={title}
+                className={`flex items-center justify-center gap-0.5 break-keep text-center font-mono text-[10px] leading-tight [overflow-wrap:anywhere] ${isDone ? 'text-accent-text' : 'text-faint'}`}
               >
+                <StatusIcon className="size-2.5 shrink-0" aria-hidden="true" />
                 {/* 狭幅では「・」の直後だけで折り返す（語中の「実装・単/体」折れを防ぐ）。 */}
                 {label.split('・').map((part, j, parts) => {
                   // 配列indexをkeyへ使わず、先頭からの累積文字列（各要素で自然に一意）を使う。

--- a/packages/db/scripts/import-skill-sheet.ts
+++ b/packages/db/scripts/import-skill-sheet.ts
@@ -1,0 +1,66 @@
+/**
+ * kouiso/skill-sheet の skillsheet.md を Markdown ブロックとして DB にインポートする。
+ *
+ * 実行:
+ *   GITHUB_TOKEN=... pnpm --filter @skillsheet/db exec tsx scripts/import-skill-sheet.ts
+ *
+ * 既存の `エンジニアスキルシート` タイトルがあれば削除して新規作成する。
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { splitMarkdownIntoBlocks } from '../src/blocks';
+import { createSheet, deleteSheet, fetchMarkdownFromGitHub, getGitHubSeedConfig, listSheets } from '../src/skillsheet';
+
+function loadWebEnvLocal(): void {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const envPath = resolve(here, '../../../apps/web/.env.local');
+  if (!existsSync(envPath)) throw new Error(`apps/web/.env.local が見つかりません: ${envPath}`);
+  const content = readFileSync(envPath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+loadWebEnvLocal();
+
+const SHEET_TITLE = 'エンジニアスキルシート';
+
+async function main() {
+  const config = getGitHubSeedConfig();
+  if (!config) {
+    throw new Error('GITHUB_TOKEN / GITHUB_OWNER / GITHUB_REPO が未設定です');
+  }
+
+  console.log(`Fetching ${config.owner}/${config.repo}/skillsheet.md ...`);
+  const markdown = await fetchMarkdownFromGitHub({ ...config, filePath: 'skillsheet.md' });
+  const segments = splitMarkdownIntoBlocks(markdown);
+  console.log(`Split into ${segments.length} markdown blocks`);
+
+  const blockInputs = segments.map((data) => ({ type: 'markdown' as const, data }));
+
+  // 既存の同タイトルシートを削除して重複を防ぐ
+  const existing = (await listSheets()).find((s) => s.title === SHEET_TITLE);
+  if (existing) {
+    console.log(`Deleting existing sheet ${existing.id}`);
+    await deleteSheet(existing.id);
+  }
+
+  const sheetId = await createSheet(SHEET_TITLE, blockInputs);
+  console.log(`Created sheet: ${sheetId}`);
+  console.log(`View URL: /view/db/${sheetId}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
close #129
close #122
close #126
close #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロセス表示に、経験の有無を示すチェック／未完了アイコンを追加しました。
  - 状態に応じて色分けされ、各ラベルの内容を確認しやすくなりました。

- **変更**
  - 新しい職務経歴テンプレートから「職務経歴」セクションを削除しました。
  - 会社名、期間、役割、説明を含む職務経歴ブロックをテンプレートから除外しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->