### PR TITLE
fix: 空ブロックの永続化フィルタを撤廃し、空判定を描画時へ移す (#128)

### DIFF
--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -372,13 +372,16 @@ describe('BuilderClient 自動保存', () => {
     );
   });
 
-  it('案件エディタタブを開いただけ（空 project ブロックの自動追加）では dirty にならず自動保存されない', async () => {
+  it('案件エディタタブを開いただけでは空 project ブロックが追加されず、dirty にも自動保存にもならない', async () => {
+    // ensureProjectBlock 廃止の回帰テスト（issue #128）。ProjectEditor は data 未指定時に
+    // {companies:[],items:[]} へフォールバックするため、タブを開くだけではブロックを
+    // 追加する必要がない。追加していれば（サーバがもう空ブロックを drop しないため）
+    // dirty になり、放置後に自動保存されてしまう。
     render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="t" {...defaultProps} />);
     fireEvent.click(screen.getByRole('button', { name: '案件エディタ' }));
     await act(async () => {
       vi.advanceTimersByTime(5000);
     });
-    // 空 project ブロックはサーバ保存時に drop される＝保存結果が変わらないため dirty にしない
     expect(mockSave).not.toHaveBeenCalled();
     expect(screen.queryByText('未保存の変更')).not.toBeInTheDocument();
   });

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -201,6 +201,11 @@ export const assembleMarkdown = (items: EditorItem[], opts?: { includeHidden?: b
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (!item) continue;
+    // 中身が空のブロックはプレビュー/エクスポートにも出さない（viewer の groupBlocks・
+    // サーバ側 blocksToMarkdown と揃える）。markdown 計算前・prev 更新前に skip すること
+    // — 後から continue すると直前ブロック判定（blockJoinSeparator / 先頭判定）が
+    // スキップされた要素を指してしまう。
+    if (isBlockInputEmpty(itemToBlockInput(item))) continue;
     const markdown = itemToMarkdown(item, opts);
     // items[i - 1] を位置で参照すると sparse 配列（途中の undefined 要素）で
     // 実際に直前にレンダリングされたブロックを見失う。実際にレンダリングした
@@ -215,10 +220,10 @@ export const assembleMarkdown = (items: EditorItem[], opts?: { includeHidden?: b
 // markdown 比較だと markdown に落ちないフィールド（profile.company / 会社 kind・note /
 // 案件 comment・summary / hidden トグル等）の編集を取りこぼし、自動保存も
 // beforeunload ガードも発火せず黙ってデータが失われるため、保存される構造化データで差分を見る。
-// サーバ保存時に drop される空ブロックは除外する（案件エディタタブを開いただけの
-// 空 project ブロック追加などで dirty / 幽霊自動保存を発生させない）。
-const snapshot = (items: EditorItem[], title: string): string =>
-  JSON.stringify([title, items.map(itemToBlockInput).filter((block) => !isBlockInputEmpty(block))]);
+// サーバはもう空ブロックを drop しない（issue #128）ので、ここも空ブロックを含めて
+// 保存 payload と完全一致させる。全ブロックが空のときの dirty 抑制は isDirty 計算側の
+// allEmpty ガードで別途行う（全消しの是非は手動保存の confirm に委ねる）。
+const snapshot = (items: EditorItem[], title: string): string => JSON.stringify([title, items.map(itemToBlockInput)]);
 
 const ALIGN_OPTIONS: { value: TableAlign; Icon: typeof AlignLeft; label: string }[] = [
   { value: 'left', Icon: AlignLeft, label: '左揃え' },
@@ -907,6 +912,13 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
   };
 
   // 現在の内容（タイトル含む）が最後の保存スナップショットと異なれば dirty にする。
+  // サーバはもう空ブロックを drop しないので（issue #128）、空ブロックの追加も
+  // 「保存すれば実際に DB へ残る変更」として正しく dirty 扱いになる
+  // （旧コードは drop される前提で空ブロックを比較から除外していたが、その前提が消えた）。
+  // 全ブロックが空の状態で dirty になる場合（例:「テキスト」を押して何も打たず放置）は
+  // 自動保存されず（:942 の全消しガード）dirty のままになるが、これは意図した仕様。
+  // 手動保存＋確認ダイアログ（:1194 付近）でクリアできる — 全消し保存の是非を
+  // ユーザーに問う導線と一致させるため、あえて自動で dirty を解除しない。
   useEffect(() => {
     setIsDirty(snapshot(items, title) !== lastSavedSnapshotRef.current);
   }, [items, title]);
@@ -1085,11 +1097,16 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
   const updateProjectData = (data: ProjectBlockData) => {
     // 変更履歴は「変更前の状態」と突き合わせてラベルを作るため、更新関数の外で先に取る。
     // setItems の更新関数の中で副作用を起こすと StrictMode の二重呼び出しで履歴が重複する。
-    const before = items.find((i) => i.type === 'project') as { data: ProjectBlockData } | undefined;
+    // project ブロックがまだ無い（初回編集）場合は ProjectEditor と同じ空データへ
+    // フォールバックする — ensureProjectBlock 廃止後もここが history.ts の初回エントリを
+    // 「追加」として記録できる唯一の場所になる。
+    const before =
+      (items.find((i) => i.type === 'project') as { data: ProjectBlockData } | undefined)?.data ??
+      ({ companies: [], items: [] } satisfies ProjectBlockData);
     // 参照比較だと ProjectEditor が毎回新しいオブジェクトを渡すため常に真になる。
     // 中身が同じ更新で履歴を増やさないよう、内容で比べる。
-    if (before && JSON.stringify(before.data) !== JSON.stringify(data)) {
-      setHistory(pushHistory(before.data, data, Date.now(), activeSheetId));
+    if (JSON.stringify(before) !== JSON.stringify(data)) {
+      setHistory(pushHistory(before, data, Date.now(), activeSheetId));
     }
     setItems((prev) => {
       const idx = prev.findIndex((i) => i.type === 'project');
@@ -1102,13 +1119,6 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
   const restoreProjectData = (snapshot: ProjectBlockData) => {
     updateProjectData(snapshot);
     setHistoryOpen(false);
-  };
-
-  const ensureProjectBlock = () => {
-    setItems((prev) => {
-      if (prev.some((i) => i.type === 'project')) return prev;
-      return [...prev, { id: newId(), type: 'project', data: { companies: [], items: [] } }];
-    });
   };
 
   const handleCreateSheet = () => {
@@ -1157,6 +1167,9 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
   const handleExport = () => {
     // バックアップは閲覧面ではないため hidden な会社・案件も含める
     // （黙って欠落させると、このバックアップからの復元で hidden データが失われる）。
+    // 一方で中身が空のブロック（未入力のテンプレスカフォールド等）は assembleMarkdown が
+    // 描画時と同じ基準でスキップする。DB 側は空ブロックも保持するので、データそのものは
+    // 失われない（このバックアップは markdown 文字列であり、空スカフォールドの復元は保証しない）。
     const content = assembleMarkdown(items, { includeHidden: true });
     const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
     const url = URL.createObjectURL(blob);
@@ -1492,10 +1505,7 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
               </button>
               <button
                 type="button"
-                onClick={() => {
-                  setActiveTab('project');
-                  ensureProjectBlock();
-                }}
+                onClick={() => setActiveTab('project')}
                 className={`px-4 py-2 text-sm font-medium transition-colors ${
                   activeTab === 'project'
                     ? 'border-b-2 border-primary text-primary'

--- a/apps/web/app/builder/templates.ts
+++ b/apps/web/app/builder/templates.ts
@@ -78,6 +78,14 @@ export const TEMPLATES: SheetTemplate[] = [
           skills: [{ name: '', years: 0, level: '' }],
         },
       },
+      {
+        type: 'markdown',
+        data: { markdown: '## 職務経歴' },
+      },
+      {
+        type: 'experience',
+        data: { company: '', startDate: '', endDate: '', role: '', description: '' },
+      },
     ],
   },
   {

--- a/apps/web/app/view/[path]/sheet-view-client.tsx
+++ b/apps/web/app/view/[path]/sheet-view-client.tsx
@@ -18,6 +18,8 @@ const REVOKE_OBJECT_URL_DELAY_MS = 100;
 const SheetViewClient = ({ title, content, blocks }: SheetViewClientProps) => {
   const [pdfLoading, setPdfLoading] = useState(false);
   // project ブロックを含むシートはダッシュボード扱いにし、Console トップバー＋ビュートグルを出す。
+  // 意図的に raw blocks（中身が空でも）で判定する — skill-sheet-viewer.tsx の isDashboard と
+  // 必ず揃えること（片方だけ直すとヘッダー/レイアウトがページ間で食い違う）。
   const isDashboard = useMemo(() => (blocks ?? []).some((b) => b.type === 'project'), [blocks]);
   // ビュー表示のON/OFF状態。初期値は全ビューON（トグルはダッシュボードのみ）。
   const [views, setViews] = useState<ViewKey[]>(() => [...ALL_VIEW_KEYS]);

--- a/apps/web/src/component/skill-sheet-viewer.test.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.test.tsx
@@ -116,6 +116,66 @@ describe('SkillSheetViewer', () => {
     expect(screen.queryByText('空')).toBeNull();
   });
 
+  it('中身が空の profile ブロックは描画しない（issue #128: 迷子の "SKILL SHEET" kicker を防ぐ）', async () => {
+    const blocks: Block[] = [
+      {
+        id: 'p1',
+        type: 'profile',
+        order: 0,
+        data: { name: '', title: '', pr: '', strengths: [], meta: {} },
+      },
+      { id: 'm1', type: 'markdown', order: 1, data: { markdown: '## 目印' } },
+    ];
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: '' }} blocks={blocks} />);
+
+    await waitFor(() => {
+      const markdown = document.querySelector('.markdown-content') as HTMLElement;
+      expect(within(markdown).getByText('目印')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('SKILL SHEET')).toBeNull();
+  });
+
+  it('中身が空の experience ブロックは描画せず、目次にも出ない（issue #128: 「（現在）」孤立ブロック）', async () => {
+    const blocks: Block[] = [
+      { id: 'm1', type: 'markdown', order: 0, data: { markdown: '## 職務経歴' } },
+      {
+        id: 'e1',
+        type: 'experience',
+        order: 1,
+        data: { company: '', startDate: '', endDate: '', role: '', description: '' },
+      },
+    ];
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: '' }} blocks={blocks} />);
+
+    await waitFor(() => {
+      const markdown = document.querySelector('.markdown-content') as HTMLElement;
+      expect(within(markdown).getByText('職務経歴')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/現在/)).toBeNull();
+  });
+
+  it('全ラベル・全セルが空の table ブロックは描画しない（issue #128: 空の枠線グリッド）', async () => {
+    const blocks: Block[] = [
+      { id: 'm1', type: 'markdown', order: 0, data: { markdown: '## 目印' } },
+      {
+        id: 't1',
+        type: 'table',
+        order: 1,
+        data: { columns: [{ label: '', align: 'left' }], rows: [['']] },
+      },
+    ];
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content: '' }} blocks={blocks} />);
+
+    await waitFor(() => {
+      const markdown = document.querySelector('.markdown-content') as HTMLElement;
+      expect(within(markdown).getByText('目印')).toBeInTheDocument();
+    });
+
+    expect(document.querySelector('table')).toBeNull();
+  });
+
   it('複数の markdown ブロックに同じ見出しテキストがあっても id を一意化し、React の重複key警告を出さない', async () => {
     // 各 markdown ブロックは独立した <ReactMarkdown>（rehype-slug も独立実行）で描画されるため、
     // 同じ見出しテキストを持つブロックが複数あると rehype-slug が同一 id を付与してしまう

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -12,7 +12,7 @@ import Lightbox from 'yet-another-react-lightbox';
 import 'yet-another-react-lightbox/styles.css';
 
 import type { Block } from '@skillsheet/db/blocks';
-import { experienceBlockToMarkdown, tableBlockToMarkdown } from '@skillsheet/db/blocks';
+import { experienceBlockToMarkdown, isBlockInputEmpty, tableBlockToMarkdown } from '@skillsheet/db/blocks';
 import { useActiveHeading } from '@/hooks/use-active-heading';
 import { ProfileIntro } from './blocks/profile-intro';
 import { ProjectSection } from './blocks/project-section';
@@ -208,8 +208,13 @@ function FadeUpSection({ children }: { children: ReactNode }) {
 function groupBlocks(blocks: Block[]): RenderGroup[] {
   const groups: RenderGroup[] = [];
   for (const block of blocks) {
-    // SkillMatrix は空の skills ブロックを null 描画するため、グループにも含めない
-    // （含めると中身が空の枠線コンテナだけが描画されてしまう）。
+    // 中身が空のブロックは描画しない（issue #128: テンプレの空 profile/experience/table が
+    // 迷子の見出しや空枠線だけの箱として出るのを防ぐ）。ブロック自体は DB に残る —
+    // 空判定はあくまで描画時のスキップであり、保存を妨げるものではない。
+    if (isBlockInputEmpty(block)) continue;
+    // SkillMatrix は category ありでも skills が 0 件なら null 描画するため、グループにも
+    // 含めない（isBlockInputEmpty は category 空 かつ skills 0 件の場合のみ空とみなすので、
+    // この判定は別途必要）。含めると中身が空の枠線コンテナだけが描画されてしまう。
     if (block.type === 'skills' && block.data.skills.length === 0) continue;
     const lastGroup = groups.at(-1);
     if (block.type === 'skills') {
@@ -232,6 +237,10 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false, views }: Sk
   const groupedBlocks = useMemo(() => (blocks ? groupBlocks(blocks) : []), [blocks]);
   // project ブロックを含むシートは「外枠カード無し・セクションが縦に並ぶダッシュボード」レイアウトにする。
   // markdown/table/skills のみの既存シートは従来の単一カード＋max-w-4xlを維持する。
+  // 意図的に raw blocks（中身が空でも）で判定する — ダッシュボードテンプレはレイアウトの
+  // 意図そのものが project ブロックの有無なので、中身の空判定（isBlockInputEmpty）を
+  // 通さない。sheet-view-client.tsx の同名ロジックと必ず揃えること（片方だけ直すと
+  // ヘッダー/レイアウトがページ間で食い違う）。
   const isDashboard = useMemo(() => (blocks ?? []).some((b) => b.type === 'project'), [blocks]);
   const [headings, setHeadings] = useState<Heading[]>([]);
   const [mounted, setMounted] = useState(false);

--- a/doc/03-github-api.md
+++ b/doc/03-github-api.md
@@ -71,7 +71,7 @@ export function blocksToMarkdown(blocks: Block[]): string {
 ```
 
 - 表への変換では `escapeCell()` がセル内改行を空白へ、`|` をエスケープし、空セルを半角スペース 1 つに整えて GFM 表の崩れを防ぐ。列揃えは `:---` / `:---:` / `---:` で表現する。
-- 型システム上到達不能な未知 type は `''` を返し、他ブロックを壊さない（`isBlockInputEmpty` も未知 type を空として扱う）。
+- `blockToMarkdown` は型システム上到達不能な未知 type を `''` として扱い、他ブロックを壊さない。`isBlockInputEmpty` も未知 type を空として扱うが、こちらは DB 由来の壊れた/未知の行を実際に受け取りうる実行時の防御であり、両者とも単なる型システムの建前ではない。
 - **中身が空のブロックは `blocksToMarkdown` の連結対象から除かれる** — テンプレの空スカフォールドが `### （現在）` のような孤立セクションとして PDF や `/view/db` に出るのを防ぐ（issue #128）。ブロック自体は DB に残るので、Web の viewer（`groupBlocks`）でも同じ基準（`isBlockInputEmpty`）でスキップしている。
 
 table / experience は Markdown 経由で描画するが、skills / profile / stats / project は Web 側で専用の React コンポーネントとして描画される（[04](04-markdown-display.md) 参照）。PDF は mdast → `@react-pdf` パイプラインを共有する。

--- a/doc/03-github-api.md
+++ b/doc/03-github-api.md
@@ -60,21 +60,26 @@ export const blocks = pgTable('blocks', {
 各ブロックは `type` に応じて Markdown 文字列へ変換される（`tableBlockToMarkdown` / `skillsBlockToMarkdown` / `experienceBlockToMarkdown` / `profileBlockToMarkdown` / `statsBlockToMarkdown` / `projectBlockToMarkdown`）。`blocksToMarkdown` はブロック配列を `order` 昇順で連結する。
 
 ```ts
-// packages/db/src/blocks.ts（抜粋）
+// packages/db/src/blocks.ts（抜粋・要約。実際は隣接ブロックの区切り規則 blockJoinSeparator も適用する）
 export function blocksToMarkdown(blocks: Block[]): string {
-  return [...blocks].sort((a, b) => a.order - b.order).map(blockToMarkdown).join('\n');
+  return [...blocks]
+    .filter((b) => !isBlockInputEmpty(b)) // 中身が空のブロックは連結対象から除く（描画時のスキップ）
+    .sort((a, b) => a.order - b.order)
+    .map(blockToMarkdown)
+    .join('\n');
 }
 ```
 
 - 表への変換では `escapeCell()` がセル内改行を空白へ、`|` をエスケープし、空セルを半角スペース 1 つに整えて GFM 表の崩れを防ぐ。列揃えは `:---` / `:---:` / `---:` で表現する。
-- 型システム上到達不能な未知 type は `''` を返し、他ブロックを壊さない。
+- 型システム上到達不能な未知 type は `''` を返し、他ブロックを壊さない（`isBlockInputEmpty` も未知 type を空として扱う）。
+- **中身が空のブロックは `blocksToMarkdown` の連結対象から除かれる** — テンプレの空スカフォールドが `### （現在）` のような孤立セクションとして PDF や `/view/db` に出るのを防ぐ（issue #128）。ブロック自体は DB に残るので、Web の viewer（`groupBlocks`）でも同じ基準（`isBlockInputEmpty`）でスキップしている。
 
 table / experience は Markdown 経由で描画するが、skills / profile / stats / project は Web 側で専用の React コンポーネントとして描画される（[04](04-markdown-display.md) 参照）。PDF は mdast → `@react-pdf` パイプラインを共有する。
 
 ### バリデータと splitMarkdownIntoBlocks
 
 - 各ブロックには `isMarkdownBlockData` などの軽量型ガードがあり、`isBlockInput()` がクライアント由来の untyped 入力を検証する（zod を入れず DB パッケージの依存を増やさない方針）。
-- `splitMarkdownIntoBlocks()` は Markdown 文書をレベル 2〜4 見出しや `<details>` の境界で分割し、無損失な `markdown` ブロック配列にする。連結すると元文書に一致する（シード用）。
+- `splitMarkdownIntoBlocks()` は Markdown 文書をレベル 2〜4 見出しや `<details>` の境界で分割し、`markdown` ブロック配列にする（シード用）。連結（`blocksToMarkdown`）すると、空白のみのセグメント（分割ノイズ。シード経路で事前に除いている）を除いて元文書とおおむね一致する。
 
 ---
 
@@ -136,7 +141,7 @@ return db.transaction(async (tx) => {
 - **A2 所有者検証**: `sheetId` 指定時に `id + ownerId` を同一トランザクション内で照合し、他人のシートを破壊しない。
 - **A3 楽観ロック**: `expectedUpdatedAt` を渡すと、`for('update')` で行ロックを取り、現在の `updatedAt` がそれより新しい場合に `ConflictError`（`skillsheet.ts` で定義）を throw する。ロストアップデートを防ぐ。
 - **A4**: 保存後のサーバー時刻 `updatedAt` を返す。クライアントはこれを次回の `expectedUpdatedAt` に使い、時計ズレによる誤 Conflict を防ぐ。
-- 保存前に `normalizeBlockInput()`（markdown 末尾空白除去・table 行の列数正規化）と `isBlockInputEmpty()` による空ブロック除去を行う。
+- 保存前に `normalizeBlockInput()`（markdown 末尾空白除去・table 行の列数正規化）だけを行う。**`isBlockInputEmpty()` は永続化フィルタとして使わない** — テンプレの空ブロック（入力用スカフォールド）やユーザーが「追加」したばかりの空ブロックも、中身が空のまま insert される。空判定は描画時（`blocksToMarkdown` / Web の `groupBlocks`）と「シート全体が空」ガード（自動保存スキップ・全消し保存の confirm）でのみ使う（issue #128 / `.gemini/styleguide.md` [K]）。
 
 `createSheet()` / `deleteSheet()` も同様にオーナーを検証し、`createSheet` はシートとブロックの挿入を単一トランザクションで囲む。
 

--- a/doc/04-markdown-display.md
+++ b/doc/04-markdown-display.md
@@ -100,7 +100,7 @@ const cellTextAlign = (align: unknown): 'left' | 'center' | 'right' =>
 
 DB のブロック（[03](03-github-api.md)）を渡す場合、`markdown` / `table` / `experience` は Markdown 文字列に変換して `MarkdownContent` で描画し、`skills` / `profile` / `stats` / `project` は専用の React コンポーネント（`SkillMatrix` / `ProfileIntro` / `StatRow` / `ProjectCard`）で描画する。連続する `skills` ブロックは 1 つのコンテナへグループ化する。本文は `activeId` に依存しないよう `MarkdownContent` を `memo` 化し、スクロールごとの再描画を避けている。
 
-**空ブロックの扱い**: `groupBlocks()`（`skill-sheet-viewer.tsx`）は `isBlockInputEmpty()` で中身が空のブロックを描画対象から除く。DB は空ブロックも保持する（保存時に drop しない、issue #128）ため、この描画時のスキップが「テンプレの空スカフォールドは見出しだけ残らず、何も描画しない」を担保する唯一の場所になる。空 `skills` ブロック（category も空）は `isBlockInputEmpty` に加えて `skills.length === 0` の別チェックもあり、両方必要（`isBlockInputEmpty` は「category 空 **かつ** skills 0 件」でしか空と判定しないため）。
+**空ブロックの扱い**: `groupBlocks()`（`skill-sheet-viewer.tsx`）は `isBlockInputEmpty()` で中身が空のブロックを描画対象から除く。DB は空ブロックも保持する（保存時に drop しない、issue #128）ため、この描画時のスキップが「テンプレの空スカフォールドは見出しだけ残らず、何も描画しない」を担保する唯一の場所になる。`skills` ブロックは `isBlockInputEmpty`（category 空 **かつ** skills 0 件）に加えて `skills.length === 0` 単独の別チェックもある — category が空でなくても skills が 0 件なら `SkillMatrix` が `null` を返すため、空の枠線コンテナだけが描画されるのを防ぐのに必要。
 
 ---
 

--- a/doc/04-markdown-display.md
+++ b/doc/04-markdown-display.md
@@ -100,6 +100,8 @@ const cellTextAlign = (align: unknown): 'left' | 'center' | 'right' =>
 
 DB のブロック（[03](03-github-api.md)）を渡す場合、`markdown` / `table` / `experience` は Markdown 文字列に変換して `MarkdownContent` で描画し、`skills` / `profile` / `stats` / `project` は専用の React コンポーネント（`SkillMatrix` / `ProfileIntro` / `StatRow` / `ProjectCard`）で描画する。連続する `skills` ブロックは 1 つのコンテナへグループ化する。本文は `activeId` に依存しないよう `MarkdownContent` を `memo` 化し、スクロールごとの再描画を避けている。
 
+**空ブロックの扱い**: `groupBlocks()`（`skill-sheet-viewer.tsx`）は `isBlockInputEmpty()` で中身が空のブロックを描画対象から除く。DB は空ブロックも保持する（保存時に drop しない、issue #128）ため、この描画時のスキップが「テンプレの空スカフォールドは見出しだけ残らず、何も描画しない」を担保する唯一の場所になる。空 `skills` ブロック（category も空）は `isBlockInputEmpty` に加えて `skills.length === 0` の別チェックもあり、両方必要（`isBlockInputEmpty` は「category 空 **かつ** skills 0 件」でしか空と判定しないため）。
+
 ---
 
 ## Part 4: PDF 出力（@react-pdf/renderer）

--- a/packages/db/scripts/import-skill-sheet.ts
+++ b/packages/db/scripts/import-skill-sheet.ts
@@ -10,7 +10,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { splitMarkdownIntoBlocks } from '../src/blocks';
+import { isBlockInputEmpty, splitMarkdownIntoBlocks } from '../src/blocks';
 import { createSheet, deleteSheet, fetchMarkdownFromGitHub, getGitHubSeedConfig, listSheets } from '../src/skillsheet';
 
 function loadWebEnvLocal(): void {
@@ -43,7 +43,9 @@ async function main() {
 
   console.log(`Fetching ${config.owner}/${config.repo}/skillsheet.md ...`);
   const markdown = await fetchMarkdownFromGitHub({ ...config, filePath: 'skillsheet.md' });
-  const segments = splitMarkdownIntoBlocks(markdown);
+  // 分割で生じる空白のみのセグメントは分割ノイズなので除く（createSheet はもう
+  // 空ブロックを落とさないため、ここで意図的にフィルタする必要がある。issue #128）。
+  const segments = splitMarkdownIntoBlocks(markdown).filter((data) => !isBlockInputEmpty({ type: 'markdown', data }));
   console.log(`Split into ${segments.length} markdown blocks`);
 
   const blockInputs = segments.map((data) => ({ type: 'markdown' as const, data }));

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -256,6 +256,38 @@ describe('blocksToMarkdown — type 別 dispatch', () => {
     expect(md).toContain('### 株式会社サンプル');
     expect(md).toContain('フロントエンドエンジニア');
   });
+
+  it('中身が空のブロックは連結対象から除く（issue #128: 空 experience が「（現在）」を出さない）', () => {
+    const blocks: Block[] = [
+      { id: 'm', type: 'markdown', order: 0, data: { markdown: '## 職務経歴' } },
+      {
+        id: 'e',
+        type: 'experience',
+        order: 1,
+        data: { company: '', startDate: '', endDate: '', role: '', description: '' },
+      },
+    ];
+    const md = blocksToMarkdown(blocks);
+    expect(md).toBe('## 職務経歴');
+    expect(md).not.toContain('現在');
+  });
+
+  it('空ブロックを除いても、直前ブロック判定（先頭 / セパレータ）が壊れない', () => {
+    // 空ブロックが先頭に来ても、残る先頭要素が正しく i===0 として扱われることを確認する
+    // （filter を sort の前・ループの外でやる必要があることの回帰テスト）。
+    const blocks: Block[] = [
+      {
+        id: 'e',
+        type: 'experience',
+        order: 0,
+        data: { company: '', startDate: '', endDate: '', role: '', description: '' },
+      },
+      { id: 'm1', type: 'markdown', order: 1, data: { markdown: '## 見出し' } },
+      { id: 't', type: 'table', order: 2, data: TABLE },
+    ];
+    const md = blocksToMarkdown(blocks);
+    expect(md).toBe(['## 見出し', '', '| 左 | 中 | 右 |', '| :--- | :---: | ---: |', '| a | b | c |'].join('\n'));
+  });
 });
 
 describe('blockJoinSeparator — 連結セパレータの単一の真実', () => {

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -366,9 +366,20 @@ export function normalizeTableBlockData(data: TableBlockData): TableBlockData {
 }
 
 /**
- * 「空ブロック」判定（保存時の drop と、全消し保存ガードで共有する単一の真実）。
+ * 「中身が空のブロック」判定。**永続化フィルタではない**（ここ重要）。
+ *
+ * ブロックの存在と順序はテンプレやユーザーの「追加」操作が作った構造であり、
+ * 中身が空かどうかは描画の都合でしかない。両者を混同して保存前に drop すると、
+ * テンプレの入力用スカフォールドが消えて見出しだけが残る（issue #128 / PR#60）。
+ * `.gemini/styleguide.md` の [K] 過剰フィルタによるデータ脱落 を参照。
+ *
+ * 用途は 2 つだけ:
+ * 1. 描画時のスキップ（blocksToMarkdown / viewer の groupBlocks / builder プレビュー）
+ * 2. 「シート全体に中身がない」ガード（自動保存スキップ・手動保存の confirm）
+ *
  * markdown: trim して空 / table: 列ゼロ、または（全列 label 空 かつ 全セル空）。
  * skills: カテゴリ空 かつ スキル 0 件。experience: 会社名・職種・業務内容が全て空。
+ * 未知 type は空とみなす（DB 由来の壊れた行で描画を落とさないため）。
  */
 export function isBlockInputEmpty(block: BlockInput): boolean {
   if (block.type === 'markdown') return block.data.markdown.trim().length === 0;
@@ -395,11 +406,14 @@ export function isBlockInputEmpty(block: BlockInput): boolean {
   if (block.type === 'project') {
     return block.data.companies.length === 0 && block.data.items.length === 0;
   }
-  const { columns, rows } = block.data;
-  if (columns.length === 0) return true;
-  const allLabelsEmpty = columns.every((c) => c.label.trim() === '');
-  const allCellsEmpty = rows.every((row) => row.every((cell) => cell.trim() === ''));
-  return allLabelsEmpty && allCellsEmpty;
+  if (block.type === 'table') {
+    const { columns, rows } = block.data;
+    if (columns.length === 0) return true;
+    const allLabelsEmpty = columns.every((c) => c.label.trim() === '');
+    const allCellsEmpty = rows.every((row) => row.every((cell) => cell.trim() === ''));
+    return allLabelsEmpty && allCellsEmpty;
+  }
+  return true;
 }
 
 // --- markdown 変換 ---------------------------------------------------------
@@ -571,7 +585,8 @@ const BLOCK_BOUNDARY = /^(?:#{2,4}\s|<details[\s>])/;
 
 /**
  * Markdown 文書を構造境界でブロック配列へ分割する（テキストは無損失）。
- * 連結（blocksToMarkdown）すると元の文書と一致する。シードは markdown ブロックのみ生成。
+ * シードは markdown ブロックのみ生成。連結（blocksToMarkdown）は中身が空のセグメントを
+ * 除いて元の文書とおおむね一致する（空白のみの区間は復元されない）。
  */
 export function splitMarkdownIntoBlocks(markdown: string): MarkdownBlockData[] {
   const lines = markdown.split('\n');
@@ -650,9 +665,13 @@ export function blockJoinSeparator(prevType: BlockType, curType: BlockType, curM
 /**
  * ブロック配列を order 昇順で 1 つの Markdown 文書へ連結する（type 別に変換）。
  * 連結規則は blockJoinSeparator に一元化している（クライアントの assembleMarkdown と共有）。
+ *
+ * 中身が空のブロック（isBlockInputEmpty）は連結前に除く。並べ替え前に filter することで、
+ * 直前ブロック判定（blockJoinSeparator / i === 0 の先頭判定）がスキップされた要素を
+ * 指さないようにしている（ループ内 continue だとこれが壊れる）。
  */
 export function blocksToMarkdown(blocks: Block[]): string {
-  const sorted = [...blocks].sort((a, b) => a.order - b.order);
+  const sorted = [...blocks].filter((b) => !isBlockInputEmpty(b)).sort((a, b) => a.order - b.order);
   let result = '';
   for (let i = 0; i < sorted.length; i++) {
     const markdown = blockToMarkdown(sorted[i]);

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -413,6 +413,11 @@ export function isBlockInputEmpty(block: BlockInput): boolean {
     const allCellsEmpty = rows.every((row) => row.every((cell) => cell.trim() === ''));
     return allLabelsEmpty && allCellsEmpty;
   }
+  // ここに到達するのは (a) BlockInput に新しい type を足したのに分岐を書き忘れた場合
+  // （このコンパイル時 never 代入が型エラーで検知する）、(b) DB 由来の壊れた/未知の type
+  // （実行時は型を素通りするため、この行が実際に走って false スロー無しで空扱いにする）。
+  const exhaustiveCheck: never = block;
+  void exhaustiveCheck;
   return true;
 }
 

--- a/packages/db/src/skillsheet.create.test.ts
+++ b/packages/db/src/skillsheet.create.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let dbHolder: unknown;
+vi.mock('./client', () => ({ getDb: () => dbHolder }));
+
+import { createSheet } from './skillsheet';
+
+// drizzle のクエリビルダは chainable かつ await 可能（thenable）。実 DB 無しで
+// その挙動を模すため、意図的に then を持つフェイクを返す（noThenProperty は許容する）。
+const thenable = (result: unknown) => ({
+  // biome-ignore lint/suspicious/noThenProperty: drizzle ビルダの await 可能な挙動を模すフェイク
+  then: (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) => Promise.resolve(result).then(res, rej),
+});
+
+function createFakeDb(insertedSheetId: string) {
+  const insertValues = vi.fn((_values: unknown[]) => thenable(undefined));
+  const tx = {
+    insert: vi.fn(() => {
+      // 最初の insert は skillSheets（returning が要る）、2 回目以降は blocks（values のみ）。
+      if (tx.insert.mock.calls.length === 1) {
+        return { values: () => ({ returning: () => thenable([{ id: insertedSheetId }]) }) };
+      }
+      return { values: insertValues };
+    }),
+  };
+  const db = { transaction: vi.fn(async (cb: (t: typeof tx) => unknown) => cb(tx)) };
+  return { db, insertValues };
+}
+
+let savedOwner: string | undefined;
+
+beforeEach(() => {
+  savedOwner = process.env.SKILLSHEET_OWNER_ID;
+  process.env.SKILLSHEET_OWNER_ID = 'owner-1';
+});
+
+afterEach(() => {
+  if (savedOwner === undefined) delete process.env.SKILLSHEET_OWNER_ID;
+  else process.env.SKILLSHEET_OWNER_ID = savedOwner;
+});
+
+describe('createSheet', () => {
+  it('テンプレ由来の空ブロックも drop せず insert する（issue #128）', async () => {
+    const f = createFakeDb('sheet-new');
+    dbHolder = f.db;
+    const initialBlocks = [
+      { type: 'markdown' as const, data: { markdown: '## 職務経歴' } },
+      { type: 'experience' as const, data: { company: '', startDate: '', endDate: '', role: '', description: '' } },
+    ];
+    const sheetId = await createSheet('フルスキルシート', initialBlocks);
+    expect(sheetId).toBe('sheet-new');
+    expect(f.insertValues).toHaveBeenCalledTimes(1);
+    const inserted = f.insertValues.mock.calls[0][0];
+    expect(inserted).toHaveLength(2);
+  });
+
+  it('initialBlocks が空配列なら blocks insert を呼ばない', async () => {
+    const f = createFakeDb('sheet-blank');
+    dbHolder = f.db;
+    const sheetId = await createSheet('空白', []);
+    expect(sheetId).toBe('sheet-blank');
+    expect(f.insertValues).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/skillsheet.save.test.ts
+++ b/packages/db/src/skillsheet.save.test.ts
@@ -66,13 +66,13 @@ describe('saveSkillSheetBlocks', () => {
     await expect(saveSkillSheetBlocks('T', [MD], 'sheet-x', older)).rejects.toBeInstanceOf(ConflictError);
   });
 
-  it('空ブロックのみのときは insert を呼ばずに drop し、updatedAt を返す', async () => {
+  it('空ブロックのみでも drop せず insert する（issue #128: テンプレの空スカフォールドを残す）', async () => {
     const saved = new Date('2026-03-01T00:00:00.000Z');
     const f = createFakeDb({ selectResults: [[{ id: 'sheet-x' }]], updateReturning: [{ updatedAt: saved }] });
     dbHolder = f.db;
     const res = await saveSkillSheetBlocks('T', [{ type: 'markdown', data: { markdown: '   ' } }], 'sheet-x');
     expect(res.updatedAt).toBe(saved);
-    expect(f.insertValues).not.toHaveBeenCalled();
+    expect(f.insertValues).toHaveBeenCalledTimes(1);
   });
 
   it('非空ブロックは insert され、サーバー時刻の updatedAt を返す', async () => {

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -169,7 +169,11 @@ async function ensureSeeded(db: Database): Promise<string> {
     const config = getGitHubSeedConfig();
     if (config) {
       const markdown = await fetchMarkdownFromGitHub(config);
-      const segments = splitMarkdownIntoBlocks(markdown);
+      // 分割で生じる空白のみのセグメントは「著者が置いた構造」ではなく分割ノイズなので、
+      // ここは意図的に isBlockInputEmpty で除く（テンプレの空ブロックとは別物）。
+      const segments = splitMarkdownIntoBlocks(markdown).filter(
+        (data) => !isBlockInputEmpty({ type: 'markdown', data }),
+      );
       if (segments.length > 0) {
         await db
           .insert(blocks)
@@ -265,7 +269,9 @@ export async function createSheet(title: string, initialBlocks?: BlockInput[]): 
       throw new Error('Failed to create sheet: INSERT returned no id');
     }
     if (initialBlocks && initialBlocks.length > 0) {
-      const cleaned = initialBlocks.map(normalizeBlockInput).filter((b) => !isBlockInputEmpty(b));
+      // 空ブロックはここで落とさない — テンプレの入力用スカフォールドが消えて
+      // 見出しだけが残る不具合になる（issue #128）。空判定は描画時に行う。
+      const cleaned = initialBlocks.map(normalizeBlockInput);
       if (cleaned.length > 0) {
         await tx
           .insert(blocks)
@@ -324,7 +330,8 @@ export async function saveSkillSheetBlocks(
   const db = getDb();
   const ownerId = getOwnerId();
 
-  const cleaned = blocksInput.map(normalizeBlockInput).filter((b) => !isBlockInputEmpty(b));
+  // 空ブロックはここで落とさない（createSheet と同じ理由。issue #128）。
+  const cleaned = blocksInput.map(normalizeBlockInput);
   const resolvedTitle = title.trim().length > 0 ? title.trim() : TITLE;
 
   return db.transaction(async (tx) => {

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -271,12 +271,12 @@ export async function createSheet(title: string, initialBlocks?: BlockInput[]): 
     if (initialBlocks && initialBlocks.length > 0) {
       // 空ブロックはここで落とさない — テンプレの入力用スカフォールドが消えて
       // 見出しだけが残る不具合になる（issue #128）。空判定は描画時に行う。
-      const cleaned = initialBlocks.map(normalizeBlockInput);
-      if (cleaned.length > 0) {
-        await tx
-          .insert(blocks)
-          .values(cleaned.map((block, order) => ({ sheetId, type: block.type, order, data: block.data })));
-      }
+      // ユーザーが「追加」を連打して埋めずに放置した空ブロックも同様に残り続けるが、
+      // これは編集画面上で見えて削除もできる（閲覧側にだけ出ない）ので許容する。
+      const normalized = initialBlocks.map(normalizeBlockInput);
+      await tx
+        .insert(blocks)
+        .values(normalized.map((block, order) => ({ sheetId, type: block.type, order, data: block.data })));
     }
     return sheetId;
   });
@@ -331,7 +331,7 @@ export async function saveSkillSheetBlocks(
   const ownerId = getOwnerId();
 
   // 空ブロックはここで落とさない（createSheet と同じ理由。issue #128）。
-  const cleaned = blocksInput.map(normalizeBlockInput);
+  const normalized = blocksInput.map(normalizeBlockInput);
   const resolvedTitle = title.trim().length > 0 ? title.trim() : TITLE;
 
   return db.transaction(async (tx) => {
@@ -373,12 +373,15 @@ export async function saveSkillSheetBlocks(
     }
 
     await tx.delete(blocks).where(eq(blocks.sheetId, resolvedSheetId));
-    if (cleaned.length > 0) {
-      await tx
-        .insert(blocks)
-        .values(
-          cleaned.map((block, order) => ({ sheetId: resolvedSheetId, type: block.type, order, data: block.data })),
-        );
+    if (normalized.length > 0) {
+      await tx.insert(blocks).values(
+        normalized.map((block, order) => ({
+          sheetId: resolvedSheetId,
+          type: block.type,
+          order,
+          data: block.data,
+        })),
+      );
     }
     const [updated] = await tx
       .update(skillSheets)


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #128
関連 #158（同じ根本原因で発生した重複バグ。コメントで方針差分を説明済み: https://github.com/kouiso/skillsheet-viewer/issues/158#issuecomment-5191018378）

### 概要

`isBlockInputEmpty()`（`packages/db/src/blocks.ts`）が**保存時のフィルタ**として使われており、テンプレートの入力用スカフォールド（空の `experience` / `profile` / `stats` / `project` ブロック）が insert 前に drop されていた。フルスキルシートテンプレでは「職務経歴」の見出しだけが残り、入力フォームが出ない不具合になっていた。

直近の PR #131 は `full` テンプレから職務経歴ブロック自体を削除して症状だけ消しており、根本原因（過剰フィルタ）は残ったまま。`console-dashboard` テンプレも同じ原因で `profile`/`stats`/`project` が今も落ちている（この症状は issue #158 として独立に報告されており、PR #163 が `isBlockInputEmpty` を profile/stats/project について常に false 扱いにする狭いパッチで対応していたが、本 PR とのマージコンフリクトの際に、より根本的な本 PR の方式へ統合した）。

これは同じ規約違反の再発でもある。リポジトリ自身のレビュー規約 `.gemini/styleguide.md` に **[K] 過剰フィルタによるデータ脱落** として明記済み（根拠: PR#60 で `isBlockInputEmpty` がテンプレ空ブロックを除外していた問題）。

**方針**: ブロックの存在/順序は著者が作った構造（テンプレ or ユーザーの「追加」操作）、中身が空かどうかは描画の都合 — この2つを混同していたのが原因。永続化フィルタを撤廃し、空判定を描画時（viewer の `groupBlocks` / `blocksToMarkdown`）へ移した。

### 変更内容

- **packages/db**
  - `createSheet` / `saveSkillSheetBlocks` から空ブロックフィルタを削除
  - `isBlockInputEmpty` を堅牢化（`table` 分岐を明示化し、未知 type でも throw しない。最後の分岐は `never` 代入によるコンパイル時網羅性チェック付き — 将来 `BlockInput` に type を足して分岐を書き忘れると type-check が落ちる）
  - `blocksToMarkdown` で空ブロックを連結前に filter → **PDF・`/view/db` 経路も同時に直る**（PDF は flatten 済み markdown しか見ないため）
  - seed 経路（`ensureSeeded` / `import-skill-sheet.ts`）は「分割ノイズ」である空白のみセグメントだけ引き続き除外（著者が置いた構造ではないため、こちらは正当な永続化フィルタ）
- **viewer**（`skill-sheet-viewer.tsx`）
  - `groupBlocks` に空ブロックスキップを追加。空 `profile` の迷子 &#34;SKILL SHEET&#34; kicker、空 `experience` の「（現在）」見出し+ToC汚染、空 `table` の空枠線グリッドを解消
  - `isDashboard` は raw blocks 判定のまま維持（意図的。`sheet-view-client.tsx` と揃えるコメントを両方に追加）
- **builder**（`builder-client.tsx`）
  - `ensureProjectBlock` を削除。`ProjectEditor` 側に `{companies:[],items:[]}` フォールバックが既にあり、案件タブを開いただけで空ブロックが混入して保存されるのを防ぐ
  - `snapshot()` / `assembleMarkdown` も空ブロックを保存 payload と一致させる
- **templates.ts**: `full` テンプレに職務経歴ブロック（見出し + 空 experience）を復元
- **doc**: `doc/03-github-api.md` / `doc/04-markdown-display.md` を新しいセマンティクスに合わせて更新

### なぜ `saveSkillSheetBlocks` 側のフィルタも撤廃したか（issue #158 との方針差分）

issue #158 は「`createSheet` だけフィルタを外し、`saveSkillSheetBlocks`（ユーザー編集の保存）側はユーザー編集由来の幽霊ブロック防止のため残す」という狭い方針を提案していた。実測で確認したところ、この狭い方針では **issue #128 が別経路で再発する**:

1. `full` テンプレで新規作成（作成直後は職務経歴ブロックあり）
2. ユーザーが職務経歴と無関係な項目（例: 氏名欄）を1文字編集
3. 自動保存（`builder-client.tsx` の `runAutosave`）は編集箇所に関わらず**その時点の全ブロックをまとめて**送信する
4. `saveSkillSheetBlocks` にフィルタが残っていると、この時点でまだ空の職務経歴ブロックが DB から消える
5. リロードすると職務経歴の入力フォームが消えている

つまり「作成直後は直っているが、無関係な項目を1つ編集した瞬間に再発する」形になり、`createSheet` 側だけの修正では issue #128 を完全には解決できない。両方からフィルタを撤廃するのが必須。

### 意図的に直していないこと

1. 未入力の `full` シートは、埋めるまで「## 職務経歴」の見出しが（技術者プロファイル・スキルの見出しと同様に）中身なしで表示される。markdown 見出しブロックは「空」ではないため。見出し孤立の抑制は別機能として扱う
2. 未入力の `console-dashboard` シートは、埋めるまで viewer がスカイルマトリクスだけの寂しい見た目になる（`isDashboard` はダッシュボード用チrome を出すために raw blocks で判定する一方、`groupBlocks` は中身が空の profile/stats/project を描画しない。builder では 4 ブロックとも編集フォームとして見えるので入力すれば埋まる）
3. 空ブロックの上限・自動掃除は作らない。「追加」を連打して埋めずに放置したブロックも保存され続けるが、編集画面上では見えて削除もできる（閲覧側にだけ出ない）ので、単一オーナー運用のこのツールでは許容範囲と判断した
4. 既存シートのバックフィルはしない。データは壊れていない（insert されなかっただけ）。「テンプレが落とした」のか「ユーザーが意図的に消した」のか区別する印がないため、バックフィルは推測になる。修正前に `console-dashboard` から作成したシートは `profile`/`stats`/`project` が欠けたままなので、再作成するか手動で追加が必要

### 動作確認

自動テストに加えて、実ブラウザ・実DBでの手動確認も完了している。

- `pnpm -r type-check` / `pnpm -r --if-present test`（db 157件・web 180件、全て pass）/ `pnpm lint` / `pnpm build` は全て green
- **実DB永続化パス**: ローカル Postgres + Neon websocket プロキシ（wsproxy）を自前で構築し、モックなしで `createSheet` / `saveSkillSheetBlocks` / `blocksToMarkdown` の実処理を実行。DB の生の行も `psql` で直接確認し、`full` テンプレの7ブロック（職務経歴の空 experience 含む）・`console-dashboard` の4ブロック（profile/stats/project 含む）が全て永続化されることを確認
- **実ブラウザ操作**: Better Auth のオーナーアカウントを作成し、実際に `pnpm build` の本番ビルドを起動してログイン→テンプレートから新規シート作成→エディタに「職務経歴」見出し + 会社名/期間/職種/業務内容の入力フォームが表示されることを確認→**リロードして DB 往復後も同じ状態を維持**することを確認→`/view/db/:id` で「（現在）」の孤立セクションが出ないこと、ダッシュボードテンプレで迷子の &#34;SKILL SHEET&#34; kicker が出ないことをスクリーンショットで確認。コンソールエラーなし
- **敵対的セルフレビュー**: 独立した code-reviewer エージェントによるレビュー（APPROVE、blocker 0）と自己レビューを突き合わせ、妥当と判断した指摘（コンパイル時網羅性チェック・doc 文言・変数名/デッドコード）は追加コミットで反映済み。スコープ外と判断した指摘（空ブロックの上限機能の新規実装）は理由を添えて見送り、上記「意図的に直していないこと」に明記
- **マージコンフリクト2回を解決**: main に独立して着地した PR #163（Devin AI, 同じ #158 の狭いパッチ）・PR #165（プレースホルダー文言）との衝突を解決。#163 との衝突は上記「issue #158 との方針差分」のとおり本 PR の方式を採用し、実測で優位性を確認。マージ後に再度 type-check/test/lint/build 全 green を確認し、独立エージェントによる2回目の敵対レビュー（マージ統合そのものへのフォーカス）も実施中

### 見て欲しいポイント

- [ ] `packages/db/src/blocks.ts` の `isBlockInputEmpty` の `never` 網羅性チェックと `blocksToMarkdown` の filter 位置（sort の前、ループ外）
- [ ] `builder-client.tsx` の `updateProjectData` — `ensureProjectBlock` 廃止に伴う履歴（history）の初回エントリ保持のためのフォールバック
- [ ] 上記「issue #158 との方針差分」— ユーザー編集由来の空ブロックも保存され続ける仕様変更に異論がないか

### 見なくてもよいポイント

- [ ] doc の文言調整

### その他(あれば)

なし

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [ ] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか（該当なし）
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（該当なし）

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)