### PR TITLE
feat(trpc): 互換アダプタの tRPC 移行と public procedure の認可解決の遅延化

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -70,7 +70,7 @@ cp .env.example .env
 | `GITHUB_FILE_PATH` / `GITHUB_BRANCH` | シード元ファイル・ブランチ（既定 `skillsheet.md` / `main`） |
 | `BETTER_AUTH_URL` | デプロイ先 URL（省略時はリクエスト origin から推定） |
 | `APP_ENV` | 非 Vercel 環境での cookie Secure 判定補助（`production` / `preview` で Secure 付与。Vercel では `VERCEL_ENV` を優先） |
-| `REVALIDATE_SECRET` | GitHub 読み経路のキャッシュを `/api/revalidate` から手動失効させるためのシークレット |
+| `REVALIDATE_SECRET` | tRPC の `maintenance.revalidate` でキャッシュを手動失効させるためのシークレット |
 
 > DB 接続文字列は、実行時はプール用（`-pooler` ホスト）、マイグレーションは非プール文字列を使うと安定します。
 
@@ -97,9 +97,9 @@ pnpm dev
 
 ### 1. 閲覧コード（HMAC / `VIEWER_CODE`）
 
-- `/viewer-auth` で共有コードを入力 → `POST /api/auth` が `VIEWER_CODE` を `timingSafeEqual` で照合し、HMAC 署名付きセッション cookie を発行（`apps/web/src/server/session.ts`）
+- `/viewer-auth` で共有コードを入力 → tRPC の `auth.login` が `VIEWER_CODE` を `timingSafeEqual` で照合し、HMAC 署名付きセッション cookie を発行（`apps/web/src/server/session.ts`）
 - `/view` 配下の閲覧のみ許可。**編集はできない**（判定は `apps/web/src/server/viewer-gate.ts`）
-- ログアウトは `POST /api/logout`
+- ログアウトは tRPC の `auth.logout`。旧クライアント向けの `POST /api/logout` も同じ procedure へ委譲
 
 ### 2. 編集者ログイン（Better Auth）
 
@@ -152,7 +152,7 @@ pnpm dev
 
 ### 認証コードが通らない
 
-- 入力コードと `.env` の `VIEWER_CODE` が一致するか確認（`POST /api/auth` が 401 を返す場合は不一致）
+- 入力コードと `.env` の `VIEWER_CODE` が一致するか確認（`auth.login` が `UNAUTHORIZED` を返す場合は不一致）
 
 ### ビルド・依存エラー
 

--- a/apps/web/app/api/auth/route.test.ts
+++ b/apps/web/app/api/auth/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { POST } from './route';
 
@@ -42,16 +42,22 @@ describe('POST /api/auth', () => {
     expect(res.status).toBe(403);
   });
 
-  it('VIEWER_CODE 未設定なら 500', async () => {
+  it('VIEWER_CODE 未設定なら 500 で console.error に記録する（互換アダプタの catch は元々何もログしていなかった）', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     delete process.env.VIEWER_CODE;
     delete process.env.VITE_VIEWER_CODE;
     const res = await POST(makeReq(JSON.stringify({ code: 'x' })));
     expect(res.status).toBe(500);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('POST /api/auth: unexpected error:', expect.anything());
+    consoleErrorSpy.mockRestore();
   });
 
-  it('不正な JSON body は 400', async () => {
+  it('不正な JSON body は 400 で console.error に記録する', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const res = await POST(makeReq('not-json'));
     expect(res.status).toBe(400);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('POST /api/auth: failed to parse request body:', expect.any(Error));
+    consoleErrorSpy.mockRestore();
   });
 
   it('code が文字列でなければ 400', async () => {

--- a/apps/web/app/api/auth/route.ts
+++ b/apps/web/app/api/auth/route.ts
@@ -1,55 +1,49 @@
-import { createHash, timingSafeEqual } from 'node:crypto';
-
+import { TRPCError } from '@trpc/server';
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { createSessionToken, getSessionCookieOptions } from '@/server/session';
+import { createTRPCContext } from '@/server/trpc/context';
+import { createCallerFactory } from '@/server/trpc/init';
+import { shouldLogTRPCError } from '@/server/trpc/log-error';
+import { appRouter } from '@/server/trpc/router';
+
+const createCaller = createCallerFactory(appRouter);
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-function isSameOrigin(req: NextRequest): boolean {
-  const origin = req.headers.get('origin');
-  const host = req.headers.get('host');
-  if (!origin || !host) return true;
-
-  try {
-    return new URL(origin).host === host;
-  } catch {
-    return false;
-  }
-}
-
+/**
+ * 既存クライアント向けの互換アダプタ。
+ * 新しい画面は auth.login procedure を直接使い、認証ロジックは tRPC 側だけが持つ。
+ */
 export async function POST(req: NextRequest) {
-  if (!isSameOrigin(req)) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const viewerCode = process.env.VIEWER_CODE ?? process.env.VITE_VIEWER_CODE;
-  if (!viewerCode) {
-    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-  }
-
-  let code: unknown;
+  let input: unknown;
   try {
-    const body = (await req.json()) as { code?: unknown };
-    code = body.code;
-  } catch {
+    input = await req.json();
+  } catch (err) {
+    console.error('POST /api/auth: failed to parse request body:', err);
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  if (typeof code !== 'string') {
-    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  const responseHeaders = new Headers();
+  const caller = createCaller(createTRPCContext({ req, resHeaders: responseHeaders }));
+  try {
+    const result = await caller.auth.login(input as { code: string });
+    return NextResponse.json(result, { headers: responseHeaders });
+  } catch (error) {
+    if (error instanceof TRPCError) {
+      if (error.code === 'FORBIDDEN') {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+      if (error.code === 'BAD_REQUEST') {
+        return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+      }
+      if (error.code === 'UNAUTHORIZED') {
+        return NextResponse.json({ error: 'Invalid code' }, { status: 401 });
+      }
+    }
+    if (!(error instanceof TRPCError) || shouldLogTRPCError(error.code)) {
+      console.error('POST /api/auth: unexpected error:', error);
+    }
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
   }
-
-  const codeHash = createHash('sha256').update(code, 'utf-8').digest();
-  const validHash = createHash('sha256').update(viewerCode, 'utf-8').digest();
-
-  if (!timingSafeEqual(codeHash, validHash)) {
-    return NextResponse.json({ error: 'Invalid code' }, { status: 401 });
-  }
-
-  const res = NextResponse.json({ ok: true });
-  const { name, ...options } = getSessionCookieOptions();
-  res.cookies.set(name, createSessionToken(), options);
-  return res;
 }

--- a/apps/web/app/api/logout/route.test.ts
+++ b/apps/web/app/api/logout/route.test.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from 'next/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const appendExpiredSessionCookie = vi.hoisted(() => vi.fn());
+vi.mock('@/server/session', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/server/session')>();
+  appendExpiredSessionCookie.mockImplementation(actual.appendExpiredSessionCookie);
+  return { ...actual, appendExpiredSessionCookie };
+});
+
+import { POST } from './route';
+
+afterEach(() => {
+  appendExpiredSessionCookie.mockClear();
+});
+
+describe('POST /api/logout compatibility adapter', () => {
+  it('auth.logout の cookie 失効ヘッダーをそのまま返す', async () => {
+    const req = new NextRequest('http://localhost:3000/api/logout', {
+      method: 'POST',
+      headers: { origin: 'http://localhost:3000', host: 'localhost:3000' },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(res.headers.get('set-cookie')).toContain('session=; Max-Age=0');
+  });
+
+  it('cross-origin request は 403', async () => {
+    const req = new NextRequest('http://localhost:3000/api/logout', {
+      method: 'POST',
+      headers: { origin: 'https://evil.example', host: 'localhost:3000' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('想定外のエラーは 500 を返し console.error でログする（互換アダプタの catch は元々何もログしていなかった）', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    appendExpiredSessionCookie.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const req = new NextRequest('http://localhost:3000/api/logout', {
+      method: 'POST',
+      headers: { origin: 'http://localhost:3000', host: 'localhost:3000' },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Server configuration error' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith('POST /api/logout: unexpected error:', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/app/api/logout/route.ts
+++ b/apps/web/app/api/logout/route.ts
@@ -1,17 +1,30 @@
-import { NextResponse } from 'next/server';
+import { TRPCError } from '@trpc/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
-import { SESSION_COOKIE_NAME } from '@/server/session';
+import { createTRPCContext } from '@/server/trpc/context';
+import { createCallerFactory } from '@/server/trpc/init';
+import { shouldLogTRPCError } from '@/server/trpc/log-error';
+import { appRouter } from '@/server/trpc/router';
+
+const createCaller = createCallerFactory(appRouter);
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function POST() {
-  const res = NextResponse.json({ ok: true });
-  res.cookies.set(SESSION_COOKIE_NAME, '', {
-    httpOnly: true,
-    maxAge: 0,
-    path: '/',
-    sameSite: 'strict',
-  });
-  return res;
+/** 旧 URL を auth.logout procedure へ委譲する後方互換アダプタ。 */
+export async function POST(req: NextRequest) {
+  const responseHeaders = new Headers();
+  const caller = createCaller(createTRPCContext({ req, resHeaders: responseHeaders }));
+  try {
+    const result = await caller.auth.logout();
+    return NextResponse.json(result, { headers: responseHeaders });
+  } catch (error) {
+    if (error instanceof TRPCError && error.code === 'FORBIDDEN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (!(error instanceof TRPCError) || shouldLogTRPCError(error.code)) {
+      console.error('POST /api/logout: unexpected error:', error);
+    }
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+  }
 }

--- a/apps/web/app/api/revalidate/route.test.ts
+++ b/apps/web/app/api/revalidate/route.test.ts
@@ -3,9 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { POST } from './route';
 
 const revalidateTag = vi.hoisted(() => vi.fn());
-vi.mock('next/cache', () => ({
-  revalidateTag,
-}));
+vi.mock('next/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/cache')>();
+  return { ...actual, revalidateTag };
+});
 
 describe('POST /api/revalidate', () => {
   afterEach(() => {
@@ -13,7 +14,7 @@ describe('POST /api/revalidate', () => {
     vi.unstubAllEnvs();
   });
 
-  it('revalidateTag を { expire: 0 } 付きで呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）', async () => {
+  it('revalidateTag を { expire: 0 } 付きで sheets と db-sheet の両方に呼ぶ（空の {} は即時失効を保証せず本番で無効化されない不具合があった）', async () => {
     vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
     const req = new NextRequest('https://example.com/api/revalidate', {
       method: 'POST',
@@ -22,7 +23,9 @@ describe('POST /api/revalidate', () => {
     const res = await POST(req);
 
     expect(res.status).toBe(200);
-    expect(revalidateTag).toHaveBeenCalledWith('sheets', { expire: 0 });
+    expect(revalidateTag).toHaveBeenNthCalledWith(1, 'sheets', { expire: 0 });
+    expect(revalidateTag).toHaveBeenNthCalledWith(2, 'db-sheet', { expire: 0 });
+    await expect(res.json()).resolves.toEqual({ ok: true, revalidated: ['sheets', 'db-sheet'] });
   });
 
   it('secret が不一致なら 401 を返し revalidateTag を呼ばない', async () => {
@@ -35,5 +38,21 @@ describe('POST /api/revalidate', () => {
 
     expect(res.status).toBe(401);
     expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('REVALIDATE_SECRET 未設定なら 500 を返し、原因を断定しない本文を返す', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubEnv('REVALIDATE_SECRET', '');
+    const req = new NextRequest('https://example.com/api/revalidate', {
+      method: 'POST',
+      headers: { authorization: 'Bearer anything' },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to revalidate' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('POST /api/revalidate: unexpected error:', expect.anything());
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/web/app/api/revalidate/route.ts
+++ b/apps/web/app/api/revalidate/route.ts
@@ -1,42 +1,34 @@
-import { createHash, timingSafeEqual } from 'node:crypto';
-
-import { revalidateTag } from 'next/cache';
+import { TRPCError } from '@trpc/server';
 import { type NextRequest, NextResponse } from 'next/server';
+
+import { createTRPCContext } from '@/server/trpc/context';
+import { createCallerFactory } from '@/server/trpc/init';
+import { shouldLogTRPCError } from '@/server/trpc/log-error';
+import { appRouter } from '@/server/trpc/router';
+
+const createCaller = createCallerFactory(appRouter);
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 /**
- * GitHub 読み経路（unstable_cache の tag 'sheets'）の on-demand 無効化。
- * DB 中心運用のため webhook ではなく手動トリガ route で簡素化（P0-4）。
- *
- * 認証: `REVALIDATE_SECRET` を `Authorization: Bearer <secret>` か `?secret=` で照合。
+ * webhook・運用スクリプト向けの互換アダプタ。
+ * secret 検証とタグ失効は maintenance.revalidate procedure だけが実装する。
  */
-function safeEqual(a: string, b: string): boolean {
-  // 長さの早期returnはタイミング攻撃で秘密の長さを漏らすため、
-  // 両方を固定長のSHA-256ハッシュにしてから比較する。
-  const ha = createHash('sha256').update(a, 'utf-8').digest();
-  const hb = createHash('sha256').update(b, 'utf-8').digest();
-  return timingSafeEqual(ha, hb);
-}
-
 export async function POST(req: NextRequest) {
-  const secret = process.env.REVALIDATE_SECRET;
-  if (!secret) {
-    return NextResponse.json({ error: 'REVALIDATE_SECRET is not configured' }, { status: 500 });
+  const caller = createCaller(createTRPCContext({ req }));
+  try {
+    const result = await caller.maintenance.revalidate();
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof TRPCError && error.code === 'UNAUTHORIZED') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (!(error instanceof TRPCError) || shouldLogTRPCError(error.code)) {
+      console.error('POST /api/revalidate: unexpected error:', error);
+    }
+    // REVALIDATE_SECRET 未設定・revalidateTag 失敗のどちらでもここに落ちるため、
+    // 原因を断定する文言は返さない（詳細はサーバーログを見る）。
+    return NextResponse.json({ error: 'Failed to revalidate' }, { status: 500 });
   }
-
-  const provided =
-    req.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ?? req.nextUrl.searchParams.get('secret') ?? '';
-
-  if (!provided || !safeEqual(provided, secret)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  // Route Handler は Server Action ではないため updateTag は使えない。
-  // { expire: 0 } で即時失効（次リクエストはブロッキング再検証）を明示する。
-  // 空の {} は expire 未指定＝即時失効の保証が無く、本番で無効化されない不具合があった。
-  revalidateTag('sheets', { expire: 0 });
-  revalidateTag('db-sheet', { expire: 0 });
-  return NextResponse.json({ ok: true, revalidated: ['sheets', 'db-sheet'] });
 }

--- a/apps/web/app/api/trpc/[trpc]/route.test.ts
+++ b/apps/web/app/api/trpc/[trpc]/route.test.ts
@@ -5,14 +5,20 @@ import { POST, shouldLogTRPCError } from './route';
 describe('shouldLogTRPCError', () => {
   it.each([
     'UNAUTHORIZED',
-    'FORBIDDEN',
     'NOT_FOUND',
     'CONFLICT',
   ])('%s は procedure 側で意図的に投げる想定内の分岐のためログしない', (code) => {
     expect(shouldLogTRPCError(code)).toBe(false);
   });
 
-  it.each(['BAD_REQUEST', 'INTERNAL_SERVER_ERROR', 'TIMEOUT'])('%s は想定外のエラーのためログする', (code) => {
+  // FORBIDDEN（requireHttpMutationContext の cross-origin 拒否）は CSRF 試行の唯一の
+  // サーバー側シグナルなので、想定内扱いにして握り潰さない。
+  it.each([
+    'BAD_REQUEST',
+    'FORBIDDEN',
+    'INTERNAL_SERVER_ERROR',
+    'TIMEOUT',
+  ])('%s は想定外のエラーのためログする', (code) => {
     expect(shouldLogTRPCError(code)).toBe(true);
   });
 });
@@ -83,6 +89,27 @@ describe('POST /api/trpc', () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('auth.login'), expect.anything());
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('FORBIDDEN（cross-origin 拒否）は CSRF 試行の唯一のサーバー側シグナルなので console.error を呼ぶ', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubEnv('SESSION_SECRET', 'test-session-secret');
+    vi.stubEnv('VIEWER_CODE', 'correct-code');
+    const req = new Request('http://localhost:3000/api/trpc/auth.login?batch=1', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'https://evil.example',
+        host: 'localhost:3000',
+      },
+      body: JSON.stringify({ 0: { json: { code: 'correct-code' } } }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('auth.login'), expect.anything());
     consoleErrorSpy.mockRestore();
   });

--- a/apps/web/app/api/trpc/[trpc]/route.test.ts
+++ b/apps/web/app/api/trpc/[trpc]/route.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { shouldLogTRPCError } from './route';
+import { POST, shouldLogTRPCError } from './route';
 
 describe('shouldLogTRPCError', () => {
   it.each([
     'UNAUTHORIZED',
+    'FORBIDDEN',
     'NOT_FOUND',
     'CONFLICT',
   ])('%s は procedure 側で意図的に投げる想定内の分岐のためログしない', (code) => {
@@ -13,5 +14,76 @@ describe('shouldLogTRPCError', () => {
 
   it.each(['BAD_REQUEST', 'INTERNAL_SERVER_ERROR', 'TIMEOUT'])('%s は想定外のエラーのためログする', (code) => {
     expect(shouldLogTRPCError(code)).toBe(true);
+  });
+});
+
+describe('POST /api/trpc', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('httpBatchLink 形式の auth.login が Set-Cookie を返す', async () => {
+    vi.stubEnv('SESSION_SECRET', 'test-session-secret');
+    vi.stubEnv('VIEWER_CODE', 'correct-code');
+    const req = new Request('http://localhost:3000/api/trpc/auth.login?batch=1', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost:3000',
+        host: 'localhost:3000',
+      },
+      body: JSON.stringify({ 0: { json: { code: 'correct-code' } } }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie')).toContain('session=');
+    const body = (await res.json()) as Array<{ result?: { data?: { json?: unknown } } }>;
+    expect(body[0]?.result?.data?.json).toEqual({ ok: true });
+  });
+
+  // onError の結線自体（handler の生成物）は shouldLogTRPCError の純関数テストだけでは
+  // 検証できない。実際に fetchRequestHandler を通し、想定内/想定外それぞれで
+  // console.error の呼び出し有無を固定する。
+  it('UNAUTHORIZED（想定内）は console.error を呼ばない', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubEnv('SESSION_SECRET', 'test-session-secret');
+    vi.stubEnv('VIEWER_CODE', 'correct-code');
+    const req = new Request('http://localhost:3000/api/trpc/auth.login?batch=1', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost:3000',
+        host: 'localhost:3000',
+      },
+      body: JSON.stringify({ 0: { json: { code: 'wrong-code' } } }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('BAD_REQUEST（zod 検証失敗・想定外）は console.error を呼ぶ', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const req = new Request('http://localhost:3000/api/trpc/auth.login?batch=1', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost:3000',
+        host: 'localhost:3000',
+      },
+      // code は必須の string だが未指定 → zod 検証失敗で BAD_REQUEST
+      body: JSON.stringify({ 0: { json: {} } }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('auth.login'), expect.anything());
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/web/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/app/api/trpc/[trpc]/route.ts
@@ -1,18 +1,13 @@
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 
 import { createTRPCContext } from '@/server/trpc/context';
+import { shouldLogTRPCError } from '@/server/trpc/log-error';
 import { appRouter } from '@/server/trpc/router';
 
 // DATABASE_URL 等はランタイム専用のため、このルートは常に動的に実行する。
 export const dynamic = 'force-dynamic';
 
-// UNAUTHORIZED/NOT_FOUND/CONFLICT は procedure 側で意図的に投げている想定内の分岐なので
-// ログ不要。それ以外（入力検証失敗や想定外の例外）だけ根本原因が追えるよう記録する。
-// 単体テストで直接検証できるよう、判定ロジックを純粋関数として切り出す。
-const EXPECTED_ERROR_CODES: ReadonlySet<string> = new Set(['UNAUTHORIZED', 'NOT_FOUND', 'CONFLICT']);
-export function shouldLogTRPCError(code: string): boolean {
-  return !EXPECTED_ERROR_CODES.has(code);
-}
+export { shouldLogTRPCError };
 
 function handler(req: Request) {
   return fetchRequestHandler({

--- a/apps/web/app/builder/page.tsx
+++ b/apps/web/app/builder/page.tsx
@@ -1,9 +1,9 @@
-import { type Block, listSheets, type SheetSummary } from '@skillsheet/db';
+import type { Block, SheetSummary } from '@skillsheet/db';
+import { TRPCError } from '@trpc/server';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { connection } from 'next/server';
 
-import { isEditor } from '@/server/auth-gate';
 import { createServerCaller } from '@/server/trpc/caller';
 
 import BuilderClient from './builder-client';
@@ -15,10 +15,6 @@ export const metadata: Metadata = {
 // DATABASE_URL はランタイム専用のため connection() で動的レンダリングを明示する。
 export default async function BuilderPage({ searchParams }: { searchParams: Promise<{ sheet?: string }> }) {
   await connection();
-  if (!(await isEditor())) {
-    redirect('/login?next=/builder');
-  }
-
   const { sheet: sheetIdParam } = await searchParams;
 
   let initialBlocks: Block[] = [];
@@ -28,29 +24,15 @@ export default async function BuilderPage({ searchParams }: { searchParams: Prom
 
   try {
     const caller = await createServerCaller();
-    sheets = await caller.sheet.list();
-
-    if (sheetIdParam && sheets.some((s) => s.id === sheetIdParam)) {
-      // URL パラメータで指定されたシートを読む
-      const sheet = await caller.sheet.byId({ id: sheetIdParam });
-      initialBlocks = sheet.blocks;
-      initialTitle = sheet.title;
-      activeSheetId = sheetIdParam;
-    } else {
-      // デフォルト: 最初のシート（シードも実行される）
-      const sheet = await caller.sheet.getDefault();
-      initialBlocks = sheet.blocks;
-      initialTitle = sheet.title;
-      // getDefault はシードで作成されることがある。sheet.list はキャッシュ経由
-      // （getCachedDbSheets, revalidate: 60s）なので、直前の sheet.list 呼び出しで
-      // 空配列がキャッシュされていた場合はこの再取得でも同じ空配列が返ってしまう
-      // （シード後もキャッシュタグは無効化されない）。ここは正本を直接読む。
-      if (sheets.length === 0) {
-        sheets = await listSheets();
-      }
-      activeSheetId = sheets[0]?.id ?? '';
-    }
+    const state = await caller.sheet.builderState({ sheetId: sheetIdParam });
+    initialBlocks = state.sheet.blocks;
+    initialTitle = state.sheet.title;
+    activeSheetId = state.activeSheetId;
+    sheets = state.sheets;
   } catch (err) {
+    if (err instanceof TRPCError && err.code === 'UNAUTHORIZED') {
+      redirect('/login?next=/builder');
+    }
     // DB/GitHub 未設定や疎通失敗時は空のビルダーから開始する（保存で作成できる）。
     console.error('Failed to load sheet for builder:', err);
   }

--- a/apps/web/app/builder/preview/page.tsx
+++ b/apps/web/app/builder/preview/page.tsx
@@ -13,8 +13,18 @@ export const metadata: Metadata = {
 // /builder と同じ認可（DAL）を踏襲する。DATABASE_URL 参照があるため connection() で動的化。
 export default async function BuilderPreviewPage() {
   await connection();
-  const caller = await createServerCaller();
-  const { canEdit } = await caller.auth.status();
+
+  let canEdit: boolean;
+  try {
+    const caller = await createServerCaller();
+    ({ canEdit } = await caller.auth.status());
+  } catch (err) {
+    // auth.status() は publicProcedure だが、SESSION_SECRET 未設定など想定外の設定不備で
+    // 例外を投げうる（旧実装の isEditor() は同じ状況でも null を返すだけで例外を投げなかった）。
+    // 未認可扱いにしてログインへ送るのが builder/page.tsx の UNAUTHORIZED 分岐と一貫する。
+    console.error('Failed to resolve auth status for builder preview:', err);
+    redirect('/login?next=/builder/preview');
+  }
   if (!canEdit) {
     redirect('/login?next=/builder/preview');
   }

--- a/apps/web/app/builder/preview/page.tsx
+++ b/apps/web/app/builder/preview/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { connection } from 'next/server';
 
-import { isEditor } from '@/server/auth-gate';
+import { createServerCaller } from '@/server/trpc/caller';
 
 import PreviewClient from './preview-client';
 
@@ -13,7 +13,9 @@ export const metadata: Metadata = {
 // /builder と同じ認可（DAL）を踏襲する。DATABASE_URL 参照があるため connection() で動的化。
 export default async function BuilderPreviewPage() {
   await connection();
-  if (!(await isEditor())) {
+  const caller = await createServerCaller();
+  const { canEdit } = await caller.auth.status();
+  if (!canEdit) {
     redirect('/login?next=/builder/preview');
   }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -30,7 +30,7 @@ const ibmPlexMono = IBM_Plex_Mono({
 });
 
 // URL に Basic 認証情報が埋まってるトンネルなどで document.baseURI から認証情報を外す。
-// さもないと fetch('/api/...') が「URL に認証情報を含む」として拒否される。
+// さもないと tRPC の同一オリジン fetch が「URL に認証情報を含む」として拒否される。
 const baseInitScript = `(function(){try{var b=document.querySelector('base');if(!b){b=document.createElement('base');document.head.prepend(b)}b.href=window.location.origin+'/';}catch(e){}})()`;
 
 // FOUC 防止: ハイドレーション前に localStorage → .dark クラスを適用する

--- a/apps/web/app/view/[path]/page.tsx
+++ b/apps/web/app/view/[path]/page.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { ConfigErrorNotice, GITHUB_CONFIG_NOTICE } from '@/component/config-error-notice';
-import { isEditor } from '@/server/auth-gate';
 import { isSheetFileName, isValidSheetPath, type SheetContent } from '@/server/github-sheets';
 import { createServerCaller } from '@/server/trpc/caller';
 import { isConfigError } from '@/util/is-config-error';
@@ -36,8 +35,10 @@ export default async function SheetViewPage({ params }: PageProps) {
   if (!isValidSheetPath(path) || !isSheetFileName(path)) notFound();
 
   let sheet: SheetContent;
+  let canEdit = false;
   try {
     const caller = await createServerCaller();
+    ({ canEdit } = await caller.auth.status());
     sheet = await caller.githubSheet.byPath({ path });
   } catch (err) {
     // tRPC procedure は throw を無条件で TRPCError にラップするため、元の SheetNotFoundError
@@ -57,5 +58,5 @@ export default async function SheetViewPage({ params }: PageProps) {
 
   // key={path}: 別シートへ遷移してもコンポーネントを再マウントし、ビュー
   // ON/OFF トグルの state（初回マウント時に決まる）を新しいシートへ持ち越さない。
-  return <SheetViewClient key={path} title={sheet.title} content={sheet.content} canEdit={await isEditor()} />;
+  return <SheetViewClient key={path} title={sheet.title} content={sheet.content} canEdit={canEdit} />;
 }

--- a/apps/web/app/view/[path]/page.tsx
+++ b/apps/web/app/view/[path]/page.tsx
@@ -38,8 +38,10 @@ export default async function SheetViewPage({ params }: PageProps) {
   let canEdit = false;
   try {
     const caller = await createServerCaller();
-    ({ canEdit } = await caller.auth.status());
-    sheet = await caller.githubSheet.byPath({ path });
+    // auth.status() はシート取得の入力に使わないため、直列待機せず並列で開始する。
+    const [authStatus, loadedSheet] = await Promise.all([caller.auth.status(), caller.githubSheet.byPath({ path })]);
+    canEdit = authStatus.canEdit;
+    sheet = loadedSheet;
   } catch (err) {
     // tRPC procedure は throw を無条件で TRPCError にラップするため、元の SheetNotFoundError
     // ではなく code: 'NOT_FOUND' で判定する（githubSheet.byPath 側のコメント参照）。

--- a/apps/web/app/view/db/[id]/page.tsx
+++ b/apps/web/app/view/db/[id]/page.tsx
@@ -31,8 +31,8 @@ export default async function DbSheetByIdPage({ params }: Props) {
 
   try {
     const caller = await createServerCaller();
-    const { canEdit } = await caller.auth.status();
-    const sheet = await caller.sheet.byId({ id });
+    // auth.status() はシート取得の入力に使わないため、直列待機せず並列で開始する。
+    const [{ canEdit }, sheet] = await Promise.all([caller.auth.status(), caller.sheet.byId({ id })]);
     // key={id}: 別シートへ遷移してもコンポーネントを再マウントし、ビュー
     // ON/OFF トグルの state（初回マウント時に決まる）を新しいシートへ持ち越さない。
     return (

--- a/apps/web/app/view/db/[id]/page.tsx
+++ b/apps/web/app/view/db/[id]/page.tsx
@@ -4,7 +4,6 @@ import { notFound } from 'next/navigation';
 import { connection } from 'next/server';
 
 import { ConfigErrorNotice, DB_CONFIG_NOTICE } from '@/component/config-error-notice';
-import { isEditor } from '@/server/auth-gate';
 import { createServerCaller } from '@/server/trpc/caller';
 import { isConfigError } from '@/util/is-config-error';
 
@@ -32,17 +31,12 @@ export default async function DbSheetByIdPage({ params }: Props) {
 
   try {
     const caller = await createServerCaller();
+    const { canEdit } = await caller.auth.status();
     const sheet = await caller.sheet.byId({ id });
     // key={id}: 別シートへ遷移してもコンポーネントを再マウントし、ビュー
     // ON/OFF トグルの state（初回マウント時に決まる）を新しいシートへ持ち越さない。
     return (
-      <SheetViewClient
-        key={id}
-        title={sheet.title}
-        content={sheet.content}
-        blocks={sheet.blocks}
-        canEdit={await isEditor()}
-      />
+      <SheetViewClient key={id} title={sheet.title} content={sheet.content} blocks={sheet.blocks} canEdit={canEdit} />
     );
   } catch (err) {
     // tRPC procedure は throw を無条件で TRPCError にラップするため、元の

--- a/apps/web/app/view/db/page.tsx
+++ b/apps/web/app/view/db/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import { connection } from 'next/server';
 
 import { ConfigErrorNotice, DB_CONFIG_NOTICE } from '@/component/config-error-notice';
-import { isEditor } from '@/server/auth-gate';
 import { createServerCaller } from '@/server/trpc/caller';
 import { isConfigError } from '@/util/is-config-error';
 
@@ -22,10 +21,9 @@ export default async function DbSheetPage() {
   // 生の 500 を出さず、対処手順を案内するフォールバック UI を表示する。
   try {
     const caller = await createServerCaller();
+    const { canEdit } = await caller.auth.status();
     const sheet = await caller.sheet.getDefault();
-    return (
-      <SheetViewClient title={sheet.title} content={sheet.content} blocks={sheet.blocks} canEdit={await isEditor()} />
-    );
+    return <SheetViewClient title={sheet.title} content={sheet.content} blocks={sheet.blocks} canEdit={canEdit} />;
   } catch (err) {
     // #157: 待っても直らない設定不備（未設定・未マイグレーション）は 200 ＋ 原因と対処を返す。
     if (isConfigError(err)) {

--- a/apps/web/app/view/db/page.tsx
+++ b/apps/web/app/view/db/page.tsx
@@ -21,8 +21,8 @@ export default async function DbSheetPage() {
   // 生の 500 を出さず、対処手順を案内するフォールバック UI を表示する。
   try {
     const caller = await createServerCaller();
-    const { canEdit } = await caller.auth.status();
-    const sheet = await caller.sheet.getDefault();
+    // auth.status() はシート取得の入力に使わないため、直列待機せず並列で開始する。
+    const [{ canEdit }, sheet] = await Promise.all([caller.auth.status(), caller.sheet.getDefault()]);
     return <SheetViewClient title={sheet.title} content={sheet.content} blocks={sheet.blocks} canEdit={canEdit} />;
   } catch (err) {
     // #157: 待っても直らない設定不備（未設定・未マイグレーション）は 200 ＋ 原因と対処を返す。

--- a/apps/web/app/view/page.tsx
+++ b/apps/web/app/view/page.tsx
@@ -2,7 +2,6 @@ import type { SheetSummary } from '@skillsheet/db';
 import type { Metadata } from 'next';
 import { connection } from 'next/server';
 
-import { isEditor } from '@/server/auth-gate';
 import { createServerCaller } from '@/server/trpc/caller';
 import { isConfigError } from '@/util/is-config-error';
 
@@ -18,8 +17,10 @@ export default async function SheetsListPage() {
 
   let sheets: SheetSummary[] = [];
   let hasError = false;
+  let canEdit = false;
   try {
     const caller = await createServerCaller();
+    ({ canEdit } = await caller.auth.status());
     sheets = await caller.sheet.list();
   } catch (err) {
     // #157: 待っても直らない設定不備（未設定・未マイグレーション）は 200 ＋ 原因と対処を返す。
@@ -32,5 +33,5 @@ export default async function SheetsListPage() {
     }
     hasError = true;
   }
-  return <DbSheetsListClient initialSheets={sheets} hasError={hasError} canEdit={await isEditor()} />;
+  return <DbSheetsListClient initialSheets={sheets} hasError={hasError} canEdit={canEdit} />;
 }

--- a/apps/web/app/viewer-auth/page.tsx
+++ b/apps/web/app/viewer-auth/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { TRPCClientError } from '@trpc/client';
 import { motion } from 'framer-motion';
 import { LockKeyhole } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -8,44 +9,31 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { trpc } from '@/lib/trpc-client';
 import { resolveNextPath } from '@/util/resolve-next-path';
 
 const ViewerAuthPage = () => {
   const router = useRouter();
   const [code, setCode] = useState('');
   const [error, setError] = useState('');
-  const [isVerifying, setIsVerifying] = useState(false);
+  const loginMutation = trpc.auth.login.useMutation();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    setIsVerifying(true);
 
     try {
-      const res = await fetch('/api/auth', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ code }),
-      });
-
-      if (res.ok) {
-        // 認証後の遷移先。?next= が内部パスのときのみ許可（オープンリダイレクト防止）。
-        const next = new URLSearchParams(window.location.search).get('next');
-        const dest = resolveNextPath(next, '/view', window.location.origin);
-        router.push(dest);
-        return;
-      }
-
-      if (res.status === 401) {
+      await loginMutation.mutateAsync({ code });
+      // 認証後の遷移先。?next= が内部パスのときのみ許可（オープンリダイレクト防止）。
+      const next = new URLSearchParams(window.location.search).get('next');
+      const dest = resolveNextPath(next, '/view', window.location.origin);
+      router.push(dest);
+    } catch (err) {
+      if (err instanceof TRPCClientError && err.data?.code === 'UNAUTHORIZED') {
         setError('認証コードが正しくありません');
       } else {
         setError('認証に失敗しました。もう一度お試しください。');
       }
-    } catch {
-      setError('認証に失敗しました。もう一度お試しください。');
-    } finally {
-      setIsVerifying(false);
     }
   };
 
@@ -138,8 +126,8 @@ const ViewerAuthPage = () => {
                   autoComplete="off"
                 />
               </div>
-              <Button type="submit" variant="gradient" size="lg" className="w-full" disabled={isVerifying}>
-                {isVerifying ? '認証中...' : '認証'}
+              <Button type="submit" variant="gradient" size="lg" className="w-full" disabled={loginMutation.isPending}>
+                {loginMutation.isPending ? '認証中...' : '認証'}
               </Button>
             </motion.form>
           </CardContent>

--- a/apps/web/src/server/auth-gate.test.ts
+++ b/apps/web/src/server/auth-gate.test.ts
@@ -69,3 +69,73 @@ describe('getEditorUserId / isEditor', () => {
     expect(await isEditor()).toBe(false);
   });
 });
+
+// React cache() は実際のレンダーコンテキスト外（vitest 環境）ではメモ化せず、呼び出すたびに
+// 関数を再実行する（caller.test.ts で実測済み）。そのため「1リクエストで getSession が1回」を
+// 素の vitest で直接は再現できない。ここでは cache() を「実際に効く」契約どおりに振る舞う
+// フェイク実装へ差し替え、その契約が満たされたときに auth-gate.ts の配線が正しく1回に
+// 閉じることだけを検証する（実際に cache() が効くこと自体は React 自身の契約）。
+describe('getEditorUserId の RSC 経路メモ化配線（cache() が契約どおり動く前提）', () => {
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    process.env.BETTER_AUTH_SECRET = 'secret';
+    process.env.DATABASE_URL = 'postgres://x';
+    process.env.SKILLSHEET_OWNER_ID = 'owner-1';
+  });
+
+  afterEach(() => {
+    vi.doUnmock('react');
+    vi.resetModules();
+  });
+
+  it('引数なし呼び出しを何度重ねても getSession は1回だけ（cache() を経由するのは無引数呼び出しだけ）', async () => {
+    vi.doMock('react', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('react')>();
+      const memoize = <T extends (...args: never[]) => unknown>(fn: T): T => {
+        let hasCached = false;
+        let cached: ReturnType<T>;
+        return ((...args: Parameters<T>) => {
+          if (!hasCached) {
+            hasCached = true;
+            cached = fn(...args) as ReturnType<T>;
+          }
+          return cached;
+        }) as T;
+      };
+      return { ...actual, cache: memoize };
+    });
+    vi.resetModules();
+    getSessionMock.mockResolvedValue({ user: { id: 'owner-1' } });
+
+    const { getEditorUserId: freshGetEditorUserId } = await import('./auth-gate');
+    await Promise.all([freshGetEditorUserId(), freshGetEditorUserId(), freshGetEditorUserId()]);
+
+    expect(getSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('requestHeaders を渡す HTTP 経路は cache() を経由しないため、毎回 getSession を呼ぶ', async () => {
+    vi.doMock('react', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('react')>();
+      const memoize = <T extends (...args: never[]) => unknown>(fn: T): T => {
+        let hasCached = false;
+        let cached: ReturnType<T>;
+        return ((...args: Parameters<T>) => {
+          if (!hasCached) {
+            hasCached = true;
+            cached = fn(...args) as ReturnType<T>;
+          }
+          return cached;
+        }) as T;
+      };
+      return { ...actual, cache: memoize };
+    });
+    vi.resetModules();
+    getSessionMock.mockResolvedValue({ user: { id: 'owner-1' } });
+
+    const { getEditorUserId: freshGetEditorUserId } = await import('./auth-gate');
+    const h = new Headers({ cookie: 'better-auth.session_token=http-token' });
+    await Promise.all([freshGetEditorUserId(h), freshGetEditorUserId(h)]);
+
+    expect(getSessionMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/server/auth-gate.test.ts
+++ b/apps/web/src/server/auth-gate.test.ts
@@ -88,51 +88,49 @@ describe('getEditorUserId の RSC 経路メモ化配線（cache() が契約ど�
     vi.resetModules();
   });
 
-  it('引数なし呼び出しを何度重ねても getSession は1回だけ（cache() を経由するのは無引数呼び出しだけ）', async () => {
+  // 素のフェイクを差し替えるだけでは「何らかのメモ化が起きた」ことしか固定できず、
+  // auth-gate.ts がモジュールスコープ変数で自前メモ化するよう書き換えられても
+  // （＝ React の request scope 保証を失い、別リクエスト間でユーザーの編集者判定が
+  // 漏れる cross-user leak になっても）このテストは気付かず通ってしまう。
+  // cacheSpy で「実際に react の cache() を経由したか」まで固定する。
+  function mockCacheAndImport() {
+    const cacheSpy = vi.fn(<T extends (...args: never[]) => unknown>(fn: T): T => {
+      let hasCached = false;
+      let cached: ReturnType<T>;
+      return ((...args: Parameters<T>) => {
+        if (!hasCached) {
+          hasCached = true;
+          cached = fn(...args) as ReturnType<T>;
+        }
+        return cached;
+      }) as T;
+    });
     vi.doMock('react', async (importOriginal) => {
       const actual = await importOriginal<typeof import('react')>();
-      const memoize = <T extends (...args: never[]) => unknown>(fn: T): T => {
-        let hasCached = false;
-        let cached: ReturnType<T>;
-        return ((...args: Parameters<T>) => {
-          if (!hasCached) {
-            hasCached = true;
-            cached = fn(...args) as ReturnType<T>;
-          }
-          return cached;
-        }) as T;
-      };
-      return { ...actual, cache: memoize };
+      return { ...actual, cache: cacheSpy };
     });
     vi.resetModules();
+    return { cacheSpy, importFresh: () => import('./auth-gate') };
+  }
+
+  it('引数なし呼び出しを何度重ねても getSession は1回だけ、かつ react の cache() を実際に経由する', async () => {
+    const { cacheSpy, importFresh } = mockCacheAndImport();
     getSessionMock.mockResolvedValue({ user: { id: 'owner-1' } });
 
-    const { getEditorUserId: freshGetEditorUserId } = await import('./auth-gate');
+    const { getEditorUserId: freshGetEditorUserId } = await importFresh();
     await Promise.all([freshGetEditorUserId(), freshGetEditorUserId(), freshGetEditorUserId()]);
 
     expect(getSessionMock).toHaveBeenCalledTimes(1);
+    // モジュールスコープ変数などの自前メモ化に退行していないことの固定。
+    // これが無いと request scope を失う退行（別リクエスト間のセッション漏れ）を検知できない。
+    expect(cacheSpy).toHaveBeenCalled();
   });
 
   it('requestHeaders を渡す HTTP 経路は cache() を経由しないため、毎回 getSession を呼ぶ', async () => {
-    vi.doMock('react', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('react')>();
-      const memoize = <T extends (...args: never[]) => unknown>(fn: T): T => {
-        let hasCached = false;
-        let cached: ReturnType<T>;
-        return ((...args: Parameters<T>) => {
-          if (!hasCached) {
-            hasCached = true;
-            cached = fn(...args) as ReturnType<T>;
-          }
-          return cached;
-        }) as T;
-      };
-      return { ...actual, cache: memoize };
-    });
-    vi.resetModules();
+    const { importFresh } = mockCacheAndImport();
     getSessionMock.mockResolvedValue({ user: { id: 'owner-1' } });
 
-    const { getEditorUserId: freshGetEditorUserId } = await import('./auth-gate');
+    const { getEditorUserId: freshGetEditorUserId } = await importFresh();
     const h = new Headers({ cookie: 'better-auth.session_token=http-token' });
     await Promise.all([freshGetEditorUserId(h), freshGetEditorUserId(h)]);
 

--- a/apps/web/src/server/auth-gate.test.ts
+++ b/apps/web/src/server/auth-gate.test.ts
@@ -36,6 +36,14 @@ describe('getEditorUserId / isEditor', () => {
     expect(await isEditor()).toBe(true);
   });
 
+  it('HTTP Request headers が渡された場合は Next.js global より優先する', async () => {
+    const requestHeaders = new Headers({ cookie: 'better-auth.session_token=http-token' });
+    getSessionMock.mockResolvedValue({ user: { id: 'owner-1' } });
+
+    await expect(getEditorUserId(requestHeaders)).resolves.toBe('owner-1');
+    expect(getSessionMock).toHaveBeenCalledWith({ headers: requestHeaders });
+  });
+
   it('owner と一致しない id は null / false', async () => {
     getSessionMock.mockResolvedValue({ user: { id: 'someone-else' } });
     expect(await getEditorUserId()).toBeNull();

--- a/apps/web/src/server/auth-gate.ts
+++ b/apps/web/src/server/auth-gate.ts
@@ -1,4 +1,5 @@
 import { headers } from 'next/headers';
+import { cache } from 'react';
 
 import { getAuth } from '@/lib/auth';
 
@@ -7,8 +8,8 @@ import { getAuth } from '@/lib/auth';
  * 編集者ログインは Better Auth セッション必須。HMAC（VIEWER_CODE / /viewer-auth）の
  * 閲覧用 cookie は閲覧専用で、編集権限は一切持たない（権限分離）。
  */
-export async function isEditor(): Promise<boolean> {
-  return (await getEditorUserId()) !== null;
+export async function isEditor(requestHeaders?: Headers): Promise<boolean> {
+  return (await getEditorUserId(requestHeaders)) !== null;
 }
 
 /**
@@ -19,13 +20,13 @@ export async function isEditor(): Promise<boolean> {
  * オーナー以外のアカウントがセッションを持っても編集者とは見なさない。書き込み系は
  * この関数（および isEditor）が唯一のチェックポイント。
  */
-export async function getEditorUserId(): Promise<string | null> {
+async function resolveEditorUserId(requestHeaders?: Headers): Promise<string | null> {
   const ownerId = process.env.SKILLSHEET_OWNER_ID;
   if (!process.env.BETTER_AUTH_SECRET || !process.env.DATABASE_URL || !ownerId) {
     return null;
   }
   try {
-    const session = await getAuth().api.getSession({ headers: await headers() });
+    const session = await getAuth().api.getSession({ headers: requestHeaders ?? (await headers()) });
     const userId = session?.user?.id;
     if (!userId || userId !== ownerId) {
       return null;
@@ -35,4 +36,21 @@ export async function getEditorUserId(): Promise<string | null> {
     console.error('Better Auth session check failed:', err);
     return null;
   }
+}
+
+/**
+ * RSC 経路（引数なし呼び出し）専用のメモ化ラッパー。
+ * React cache() は引数で keying するため、引数なしのときだけを通す別関数に
+ * 分離しないとメモ化が効かない。/view レイアウトの requireViewer() と、各ページの
+ * tRPC server caller が同一リクエストでそれぞれ編集者判定を行っても、Better Auth
+ * セッション参照は 1 回に閉じる。requestHeaders を明示的に渡す HTTP 経路は
+ * RSC レンダー外（1 リクエスト 1 回しか呼ばれない）なので対象外。
+ */
+const resolveEditorUserIdForRSC = cache((): Promise<string | null> => resolveEditorUserId());
+
+export async function getEditorUserId(requestHeaders?: Headers): Promise<string | null> {
+  if (requestHeaders) {
+    return resolveEditorUserId(requestHeaders);
+  }
+  return resolveEditorUserIdForRSC();
 }

--- a/apps/web/src/server/session.ts
+++ b/apps/web/src/server/session.ts
@@ -67,4 +67,23 @@ export function getSessionCookieOptions() {
   };
 }
 
+/** tRPC の Fetch adapter が返す Headers へ閲覧セッション cookie を追加する。 */
+export function appendSessionCookie(headers: Headers): void {
+  const { name, ...options } = getSessionCookieOptions();
+  const parts = [
+    `${name}=${createSessionToken()}`,
+    `Max-Age=${options.maxAge}`,
+    `Path=${options.path}`,
+    'HttpOnly',
+    'SameSite=Strict',
+  ];
+  if (options.secure) parts.push('Secure');
+  headers.append('set-cookie', parts.join('; '));
+}
+
+/** 閲覧セッション cookie を同じ Path で失効させる。 */
+export function appendExpiredSessionCookie(headers: Headers): void {
+  headers.append('set-cookie', `${SESSION_COOKIE_NAME}=; Max-Age=0; Path=/; HttpOnly; SameSite=Strict`);
+}
+
 export { SESSION_COOKIE_NAME };

--- a/apps/web/src/server/trpc/caller.test.ts
+++ b/apps/web/src/server/trpc/caller.test.ts
@@ -15,6 +15,7 @@ vi.mock('@skillsheet/db', async (importOriginal) => {
 });
 
 import { createServerCaller } from './caller';
+import { createTestContext } from './test-context';
 
 beforeEach(() => {
   createTRPCContextMock.mockReset();
@@ -26,7 +27,9 @@ beforeEach(() => {
 // （メモ化そのものは Next.js の RSC レンダー内でのみ成立する挙動で、単体テストの対象外）。
 describe('createServerCaller', () => {
   it('createTRPCContext の結果を使って appRouter の caller を組み立てる', async () => {
-    createTRPCContextMock.mockResolvedValue({ editorUserId: null, isViewer: true });
+    createTRPCContextMock.mockResolvedValue(
+      createTestContext({ editorUserId: null, isViewer: true, request: null, responseHeaders: null }),
+    );
     const caller = await createServerCaller();
     expect(typeof caller.sheet.list).toBe('function');
     expect(typeof caller.githubSheet.byPath).toBe('function');
@@ -34,13 +37,17 @@ describe('createServerCaller', () => {
   });
 
   it('editorUserId を持つ context なら editorProcedure を通過できる', async () => {
-    createTRPCContextMock.mockResolvedValue({ editorUserId: 'owner', isViewer: true });
+    createTRPCContextMock.mockResolvedValue(
+      createTestContext({ editorUserId: 'owner', isViewer: true, request: null, responseHeaders: null }),
+    );
     const caller = await createServerCaller();
     await expect(caller.sheet.delete({ sheetId: 's1' })).resolves.toEqual({ ok: true });
   });
 
   it('editorUserId が無い context では editorProcedure が UNAUTHORIZED になる', async () => {
-    createTRPCContextMock.mockResolvedValue({ editorUserId: null, isViewer: true });
+    createTRPCContextMock.mockResolvedValue(
+      createTestContext({ editorUserId: null, isViewer: true, request: null, responseHeaders: null }),
+    );
     const caller = await createServerCaller();
     await expect(caller.sheet.delete({ sheetId: 's1' })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });

--- a/apps/web/src/server/trpc/context.integration.test.ts
+++ b/apps/web/src/server/trpc/context.integration.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// context.test.ts は @/server/auth-gate と @/server/viewer-gate の両方をモックし、
+// createTRPCContext() 自身のメモ化ロジックだけを検証する。だが、それだと
+// 「HTTP 経路で渡した requestHeaders が実際に viewer-gate の cookie 読み取りへ届くか」
+// という配線そのものは、モックが記録した引数を見ているだけで実物では確認できない。
+// ここでは auth-gate/viewer-gate を一切モックせず、Better Auth 呼び出しの最下層
+// （@/lib/auth）だけをモックして、実物の cookie パース・HMAC 検証を通す。
+const getSessionMock = vi.fn();
+vi.mock('@/lib/auth', () => ({ getAuth: () => ({ api: { getSession: getSessionMock } }) }));
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers()),
+  cookies: vi.fn(async () => ({ get: () => undefined })),
+}));
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  saved = {
+    SESSION_SECRET: process.env.SESSION_SECRET,
+    BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+    DATABASE_URL: process.env.DATABASE_URL,
+    SKILLSHEET_OWNER_ID: process.env.SKILLSHEET_OWNER_ID,
+  };
+  process.env.SESSION_SECRET = 'integration-test-session-secret';
+  delete process.env.BETTER_AUTH_SECRET;
+  delete process.env.DATABASE_URL;
+  delete process.env.SKILLSHEET_OWNER_ID;
+  getSessionMock.mockReset();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('createTRPCContext と実物の auth-gate/viewer-gate の結線（context.test.ts はここをモックする）', () => {
+  it('HTTP 経路: request の Cookie ヘッダーに載った有効な閲覧セッションを実際に検証して isViewer=true になる', async () => {
+    const { createSessionToken } = await import('@/server/session');
+    const token = createSessionToken();
+    const req = new Request('https://example.com/api/trpc/auth.status', {
+      headers: { cookie: `session=${token}` },
+    });
+
+    const { createTRPCContext } = await import('./context');
+    const ctx = createTRPCContext({ req });
+
+    await expect(ctx.getIsViewer()).resolves.toBe(true);
+    await expect(ctx.getEditorUserId()).resolves.toBeNull();
+    // 編集者判定用の Better Auth 環境変数を意図的に外しているので getSession は呼ばれない。
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('HTTP 経路: Cookie が無い/不正なら isViewer=false になる（実物の cookie パース経由）', async () => {
+    const req = new Request('https://example.com/api/trpc/auth.status', {
+      headers: { cookie: 'other=unrelated' },
+    });
+
+    const { createTRPCContext } = await import('./context');
+    const ctx = createTRPCContext({ req });
+
+    await expect(ctx.getIsViewer()).resolves.toBe(false);
+  });
+
+  it('HTTP 経路: 改ざんされた署名は実物の timingSafeEqual 検証で弾かれる', async () => {
+    const { createSessionToken } = await import('@/server/session');
+    const token = createSessionToken();
+    const tamperedToken = `${token.split('.')[0]}.tampered-signature-xxxxxxxxxxxxxxxx`;
+    const req = new Request('https://example.com/api/trpc/auth.status', {
+      headers: { cookie: `session=${tamperedToken}` },
+    });
+
+    const { createTRPCContext } = await import('./context');
+    const ctx = createTRPCContext({ req });
+
+    await expect(ctx.getIsViewer()).resolves.toBe(false);
+  });
+
+  it('RSC 経路（req 無し）: 実物の isEditor が Better Auth のセッションを解決して editorUserId を返す', async () => {
+    process.env.BETTER_AUTH_SECRET = 'secret';
+    process.env.DATABASE_URL = 'postgres://x';
+    process.env.SKILLSHEET_OWNER_ID = 'owner-1';
+    getSessionMock.mockResolvedValue({ user: { id: 'owner-1' } });
+
+    const { createTRPCContext } = await import('./context');
+    const ctx = createTRPCContext();
+
+    await expect(ctx.getEditorUserId()).resolves.toBe('owner-1');
+    await expect(ctx.getIsViewer()).resolves.toBe(true);
+  });
+});

--- a/apps/web/src/server/trpc/context.test.ts
+++ b/apps/web/src/server/trpc/context.test.ts
@@ -1,38 +1,90 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getEditorUserIdMock = vi.fn();
-const isViewerMock = vi.fn();
+const hasViewerSessionMock = vi.fn();
 
-vi.mock('@/server/auth-gate', () => ({ getEditorUserId: () => getEditorUserIdMock() }));
-vi.mock('@/server/viewer-gate', () => ({ isViewer: () => isViewerMock() }));
+vi.mock('@/server/auth-gate', () => ({
+  getEditorUserId: (requestHeaders?: Headers) => getEditorUserIdMock(requestHeaders),
+}));
+vi.mock('@/server/viewer-gate', () => ({
+  hasViewerSession: (requestHeaders?: Headers) => hasViewerSessionMock(requestHeaders),
+}));
 
 import { createTRPCContext } from './context';
 
 beforeEach(() => {
   getEditorUserIdMock.mockReset();
-  isViewerMock.mockReset();
+  hasViewerSessionMock.mockReset();
 });
 
 describe('createTRPCContext', () => {
-  it('編集者なら isViewer() を呼ばずに isViewer: true を返す（二重セッション参照の回避）', async () => {
+  // publicProcedure（auth.login/auth.logout/maintenance.revalidate）は認可判定を
+  // 必要としないため、context を生成しただけでは Better Auth セッションも閲覧 cookie も
+  // 解決してはいけない（DB 障害時に閲覧コード認証まで巻き込まれるのを防ぐための回帰テスト）。
+  it('生成しただけでは getEditorUserId / hasViewerSession のどちらも呼ばない', () => {
+    createTRPCContext();
+    expect(getEditorUserIdMock).not.toHaveBeenCalled();
+    expect(hasViewerSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('ctx.getEditorUserId() を呼んで初めて解決する', async () => {
     getEditorUserIdMock.mockResolvedValue('owner');
-    const ctx = await createTRPCContext();
-    expect(ctx).toEqual({ editorUserId: 'owner', isViewer: true });
-    expect(isViewerMock).not.toHaveBeenCalled();
+    const ctx = createTRPCContext();
+    expect(getEditorUserIdMock).not.toHaveBeenCalled();
+    await expect(ctx.getEditorUserId()).resolves.toBe('owner');
+    expect(getEditorUserIdMock).toHaveBeenCalledTimes(1);
   });
 
-  it('編集者でなく閲覧 cookie も無効なら isViewer: false を返す', async () => {
-    getEditorUserIdMock.mockResolvedValue(null);
-    isViewerMock.mockResolvedValue(false);
-    const ctx = await createTRPCContext();
-    expect(ctx).toEqual({ editorUserId: null, isViewer: false });
-    expect(isViewerMock).toHaveBeenCalled();
+  it('ctx.getEditorUserId() を複数回呼んでも解決は 1 回だけ（メモ化）', async () => {
+    getEditorUserIdMock.mockResolvedValue('owner');
+    const ctx = createTRPCContext();
+    await Promise.all([ctx.getEditorUserId(), ctx.getEditorUserId(), ctx.getEditorUserId()]);
+    expect(getEditorUserIdMock).toHaveBeenCalledTimes(1);
   });
 
-  it('編集者でなくても閲覧 cookie が有効なら isViewer: true を返す', async () => {
+  it('編集者なら ctx.getIsViewer() は閲覧 cookie を調べずに true を返す', async () => {
+    getEditorUserIdMock.mockResolvedValue('owner');
+    const ctx = createTRPCContext();
+    await expect(ctx.getIsViewer()).resolves.toBe(true);
+    expect(hasViewerSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('編集者でなく閲覧 cookie も無効なら ctx.getIsViewer() は false を返す', async () => {
     getEditorUserIdMock.mockResolvedValue(null);
-    isViewerMock.mockResolvedValue(true);
-    const ctx = await createTRPCContext();
-    expect(ctx).toEqual({ editorUserId: null, isViewer: true });
+    hasViewerSessionMock.mockResolvedValue(false);
+    const ctx = createTRPCContext();
+    await expect(ctx.getIsViewer()).resolves.toBe(false);
+  });
+
+  it('編集者でなくても閲覧 cookie が有効なら ctx.getIsViewer() は true を返す', async () => {
+    getEditorUserIdMock.mockResolvedValue(null);
+    hasViewerSessionMock.mockResolvedValue(true);
+    const ctx = createTRPCContext();
+    await expect(ctx.getIsViewer()).resolves.toBe(true);
+  });
+
+  it('ctx.getIsViewer() を複数回呼んでも getEditorUserId / hasViewerSession の解決は 1 回だけ', async () => {
+    getEditorUserIdMock.mockResolvedValue(null);
+    hasViewerSessionMock.mockResolvedValue(true);
+    const ctx = createTRPCContext();
+    await Promise.all([ctx.getIsViewer(), ctx.getIsViewer()]);
+    expect(getEditorUserIdMock).toHaveBeenCalledTimes(1);
+    expect(hasViewerSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('HTTP 経路では同じ Request headers を認証判定と context に渡す', async () => {
+    getEditorUserIdMock.mockResolvedValue(null);
+    hasViewerSessionMock.mockResolvedValue(true);
+    const req = new Request('https://example.com/api/trpc/auth.status', {
+      headers: { cookie: 'session=token' },
+    });
+    const resHeaders = new Headers();
+    const ctx = createTRPCContext({ req, resHeaders });
+
+    expect(ctx.request).toBe(req);
+    expect(ctx.responseHeaders).toBe(resHeaders);
+    await expect(ctx.getIsViewer()).resolves.toBe(true);
+    expect(getEditorUserIdMock).toHaveBeenCalledWith(req.headers);
+    expect(hasViewerSessionMock).toHaveBeenCalledWith(req.headers);
   });
 });

--- a/apps/web/src/server/trpc/context.ts
+++ b/apps/web/src/server/trpc/context.ts
@@ -1,5 +1,5 @@
 import { getEditorUserId } from '@/server/auth-gate';
-import { isViewer } from '@/server/viewer-gate';
+import { hasViewerSession } from '@/server/viewer-gate';
 
 /**
  * tRPC の全 procedure に渡るリクエストコンテキスト。
@@ -7,16 +7,48 @@ import { isViewer } from '@/server/viewer-gate';
  * 同じ形になるよう、認可判定の解決をここに閉じる
  * （実際の cookies()/headers() 読み取りは auth-gate / viewer-gate 側が持つ）。
  */
-export async function createTRPCContext() {
-  // isViewer() は閲覧 cookie が無効なとき内部で isEditor()（= getEditorUserId()）を
-  // 呼ぶため、並列に両方叩くと編集者リクエストで Better Auth の getSession() が
-  // 二重に走る。先に editorUserId を解決し、編集者ならその時点で isViewer() 呼び出し
-  // 自体を短絡で省く（編集者は閲覧も常に許可される＝ requireViewer() の (b) 分岐と同じ仕様）。
-  const editorUserId = await getEditorUserId();
+interface TRPCContextOptions {
+  req?: Request;
+  resHeaders?: Headers;
+}
+
+/**
+ * context 生成時点では認可判定を一切実行しない。
+ * `auth.login` / `auth.logout` / `maintenance.revalidate` のような publicProcedure は
+ * 編集者判定（Better Auth セッション + DB 参照）を必要としないため、無条件 await すると
+ * DB 障害時に閲覧コード認証まで巻き込まれて遅延・失敗する。
+ * 各リゾルバは初回呼び出し時にだけ実行し、以降は同じ Promise を返して
+ * 同一リクエスト内での重複解決（例: viewerProcedure と editorProcedure の両方に
+ * 触れる呼び出し）を防ぐ。
+ */
+export function createTRPCContext(options?: TRPCContextOptions) {
+  const requestHeaders = options?.req?.headers;
+
+  let editorUserIdPromise: Promise<string | null> | null = null;
+  const resolveEditorUserId = (): Promise<string | null> => {
+    if (!editorUserIdPromise) {
+      editorUserIdPromise = getEditorUserId(requestHeaders);
+    }
+    return editorUserIdPromise;
+  };
+
+  let isViewerPromise: Promise<boolean> | null = null;
+  const resolveIsViewer = (): Promise<boolean> => {
+    if (!isViewerPromise) {
+      isViewerPromise = (async () => {
+        if ((await resolveEditorUserId()) !== null) return true;
+        return hasViewerSession(requestHeaders);
+      })();
+    }
+    return isViewerPromise;
+  };
+
   return {
-    editorUserId,
-    isViewer: editorUserId !== null || (await isViewer()),
+    getEditorUserId: resolveEditorUserId,
+    getIsViewer: resolveIsViewer,
+    request: options?.req ?? null,
+    responseHeaders: options?.resHeaders ?? null,
   };
 }
 
-export type TRPCContext = Awaited<ReturnType<typeof createTRPCContext>>;
+export type TRPCContext = ReturnType<typeof createTRPCContext>;

--- a/apps/web/src/server/trpc/init.ts
+++ b/apps/web/src/server/trpc/init.ts
@@ -15,17 +15,19 @@ export const createCallerFactory = t.createCallerFactory;
 export const publicProcedure = t.procedure;
 
 /** 閲覧可（HMAC 閲覧 cookie または編集者セッション）のみ通す。 */
-export const viewerProcedure = t.procedure.use(({ ctx, next }) => {
-  if (!ctx.isViewer) {
+export const viewerProcedure = t.procedure.use(async ({ ctx, next }) => {
+  const isViewer = await ctx.getIsViewer();
+  if (!isViewer) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'viewer authentication required' });
   }
-  return next({ ctx });
+  return next({ ctx: { ...ctx, isViewer } });
 });
 
 /** 編集者（Better Auth セッション + SKILLSHEET_OWNER_ID 一致）のみ通す。 */
-export const editorProcedure = t.procedure.use(({ ctx, next }) => {
-  if (!ctx.editorUserId) {
+export const editorProcedure = t.procedure.use(async ({ ctx, next }) => {
+  const editorUserId = await ctx.getEditorUserId();
+  if (!editorUserId) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'editor authentication required' });
   }
-  return next({ ctx: { ...ctx, editorUserId: ctx.editorUserId } });
+  return next({ ctx: { ...ctx, editorUserId } });
 });

--- a/apps/web/src/server/trpc/log-error.ts
+++ b/apps/web/src/server/trpc/log-error.ts
@@ -1,0 +1,10 @@
+// UNAUTHORIZED/NOT_FOUND/CONFLICT は procedure 側で意図的に投げている想定内の分岐なので
+// ログ不要。それ以外（入力検証失敗や想定外の例外）だけ根本原因が追えるよう記録する。
+// tRPC の Fetch adapter（/api/trpc）と後方互換 REST アダプタ（/api/auth・/api/logout・
+// /api/revalidate）の両方が同じ判定を使うことで、互換アダプタだけ想定外エラーが
+// 一切ログされずに握り潰される事態を防ぐ。
+const EXPECTED_ERROR_CODES: ReadonlySet<string> = new Set(['UNAUTHORIZED', 'FORBIDDEN', 'NOT_FOUND', 'CONFLICT']);
+
+export function shouldLogTRPCError(code: string): boolean {
+  return !EXPECTED_ERROR_CODES.has(code);
+}

--- a/apps/web/src/server/trpc/log-error.ts
+++ b/apps/web/src/server/trpc/log-error.ts
@@ -1,9 +1,11 @@
 // UNAUTHORIZED/NOT_FOUND/CONFLICT は procedure 側で意図的に投げている想定内の分岐なので
 // ログ不要。それ以外（入力検証失敗や想定外の例外）だけ根本原因が追えるよう記録する。
+// FORBIDDEN（requireHttpMutationContext の cross-origin 拒否）は CSRF 試行の唯一のサーバー側
+// シグナルなので、ここには含めない。握り潰すと攻撃の痕跡が一切残らなくなる。
 // tRPC の Fetch adapter（/api/trpc）と後方互換 REST アダプタ（/api/auth・/api/logout・
 // /api/revalidate）の両方が同じ判定を使うことで、互換アダプタだけ想定外エラーが
 // 一切ログされずに握り潰される事態を防ぐ。
-const EXPECTED_ERROR_CODES: ReadonlySet<string> = new Set(['UNAUTHORIZED', 'FORBIDDEN', 'NOT_FOUND', 'CONFLICT']);
+const EXPECTED_ERROR_CODES: ReadonlySet<string> = new Set(['UNAUTHORIZED', 'NOT_FOUND', 'CONFLICT']);
 
 export function shouldLogTRPCError(code: string): boolean {
   return !EXPECTED_ERROR_CODES.has(code);

--- a/apps/web/src/server/trpc/router/auth.test.ts
+++ b/apps/web/src/server/trpc/router/auth.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createCallerFactory } from '../init';
+import { createTestContext } from '../test-context';
+import { authRouter } from './auth';
+
+const createCaller = createCallerFactory(authRouter);
+
+function callerFor(request: Request | null, responseHeaders: Headers | null = request ? new Headers() : null) {
+  return {
+    caller: createCaller(
+      createTestContext({
+        editorUserId: null,
+        isViewer: false,
+        request,
+        responseHeaders,
+      }),
+    ),
+    responseHeaders,
+  };
+}
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {
+    SESSION_SECRET: process.env.SESSION_SECRET,
+    VIEWER_CODE: process.env.VIEWER_CODE,
+    VITE_VIEWER_CODE: process.env.VITE_VIEWER_CODE,
+  };
+  process.env.SESSION_SECRET = 'test-session-secret';
+  process.env.VIEWER_CODE = 'correct-code';
+  delete process.env.VITE_VIEWER_CODE;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('auth.status', () => {
+  it('context の閲覧・編集権限だけを公開する', async () => {
+    const caller = createCaller(
+      createTestContext({
+        editorUserId: 'owner',
+        isViewer: true,
+        request: null,
+        responseHeaders: null,
+      }),
+    );
+    await expect(caller.status()).resolves.toEqual({ canEdit: true, canView: true });
+  });
+});
+
+describe('auth.login', () => {
+  it('正しいコードなら署名 cookie を response headers へ追加する', async () => {
+    const request = new Request('http://localhost:3000/api/trpc/auth.login', {
+      method: 'POST',
+      headers: { origin: 'http://localhost:3000', host: 'localhost:3000' },
+    });
+    const { caller, responseHeaders } = callerFor(request);
+
+    await expect(caller.login({ code: 'correct-code' })).resolves.toEqual({ ok: true });
+    expect(responseHeaders?.get('set-cookie')).toContain('session=');
+    expect(responseHeaders?.get('set-cookie')).toContain('HttpOnly');
+    expect(responseHeaders?.get('set-cookie')).toContain('SameSite=Strict');
+  });
+
+  it('origin と host が不一致なら FORBIDDEN で cookie を発行しない', async () => {
+    const request = new Request('http://localhost:3000/api/trpc/auth.login', {
+      method: 'POST',
+      headers: { origin: 'https://evil.example', host: 'localhost:3000' },
+    });
+    const { caller, responseHeaders } = callerFor(request);
+
+    await expect(caller.login({ code: 'correct-code' })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(responseHeaders?.has('set-cookie')).toBe(false);
+  });
+
+  it('誤ったコードは UNAUTHORIZED で cookie を発行しない', async () => {
+    const request = new Request('http://localhost:3000/api/trpc/auth.login', { method: 'POST' });
+    const { caller, responseHeaders } = callerFor(request);
+
+    await expect(caller.login({ code: 'wrong-code' })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(responseHeaders?.has('set-cookie')).toBe(false);
+  });
+
+  it('VIEWER_CODE 未設定は INTERNAL_SERVER_ERROR', async () => {
+    delete process.env.VIEWER_CODE;
+    delete process.env.VITE_VIEWER_CODE;
+    const request = new Request('http://localhost:3000/api/trpc/auth.login', { method: 'POST' });
+    const { caller } = callerFor(request);
+
+    await expect(caller.login({ code: 'x' })).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+  });
+
+  it('HTTP response context が無い server caller からは実行できない', async () => {
+    const { caller } = callerFor(null);
+    await expect(caller.login({ code: 'correct-code' })).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+  });
+});
+
+describe('auth.logout', () => {
+  it('同一 origin の HTTP 経路で閲覧 cookie を失効させる', async () => {
+    const request = new Request('http://localhost:3000/api/trpc/auth.logout', {
+      method: 'POST',
+      headers: { origin: 'http://localhost:3000', host: 'localhost:3000' },
+    });
+    const { caller, responseHeaders } = callerFor(request);
+
+    await expect(caller.logout()).resolves.toEqual({ ok: true });
+    expect(responseHeaders?.get('set-cookie')).toContain('session=; Max-Age=0');
+  });
+});

--- a/apps/web/src/server/trpc/router/auth.ts
+++ b/apps/web/src/server/trpc/router/auth.ts
@@ -1,0 +1,65 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import { TRPCError } from '@trpc/server';
+
+import { appendExpiredSessionCookie, appendSessionCookie } from '@/server/session';
+
+import { publicProcedure, router } from '../init';
+import { viewerLoginInputSchema } from '../schema';
+
+function isSameOrigin(request: Request): boolean {
+  const origin = request.headers.get('origin');
+  const host = request.headers.get('host');
+  if (!origin || !host) return true;
+
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
+function requireHttpMutationContext(
+  request: Request | null,
+  responseHeaders: Headers | null,
+): { request: Request; responseHeaders: Headers } {
+  if (!request || !responseHeaders) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'HTTP response context is required' });
+  }
+  if (!isSameOrigin(request)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'cross-origin request is not allowed' });
+  }
+  return { request, responseHeaders };
+}
+
+export const authRouter = router({
+  // publicProcedure なので viewerProcedure/editorProcedure の middleware は通らない。
+  // login/logout とは異なりここでは実際に認可状態を必要とするため、明示的に await する。
+  status: publicProcedure.query(async ({ ctx }) => {
+    const [editorUserId, canView] = await Promise.all([ctx.getEditorUserId(), ctx.getIsViewer()]);
+    return { canEdit: editorUserId !== null, canView };
+  }),
+
+  login: publicProcedure.input(viewerLoginInputSchema).mutation(({ ctx, input }) => {
+    const { responseHeaders } = requireHttpMutationContext(ctx.request, ctx.responseHeaders);
+    const viewerCode = process.env.VIEWER_CODE ?? process.env.VITE_VIEWER_CODE;
+    if (!viewerCode) {
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'viewer authentication is not configured' });
+    }
+
+    const codeHash = createHash('sha256').update(input.code, 'utf-8').digest();
+    const validHash = createHash('sha256').update(viewerCode, 'utf-8').digest();
+    if (!timingSafeEqual(codeHash, validHash)) {
+      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid viewer code' });
+    }
+
+    appendSessionCookie(responseHeaders);
+    return { ok: true as const };
+  }),
+
+  logout: publicProcedure.mutation(({ ctx }) => {
+    const { responseHeaders } = requireHttpMutationContext(ctx.request, ctx.responseHeaders);
+    appendExpiredSessionCookie(responseHeaders);
+    return { ok: true as const };
+  }),
+});

--- a/apps/web/src/server/trpc/router/github-sheet.test.ts
+++ b/apps/web/src/server/trpc/router/github-sheet.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/server/sheets-cache', () => ({
 import { getCachedSheet, getCachedSheets } from '@/server/sheets-cache';
 
 import { createCallerFactory } from '../init';
+import { createTestContext } from '../test-context';
 import { appRouter } from './index';
 
 const createCaller = createCallerFactory(appRouter);
@@ -23,11 +24,11 @@ const getCachedSheetMock = vi.mocked(getCachedSheet);
 const getCachedSheetsMock = vi.mocked(getCachedSheets);
 
 function callerAsViewer() {
-  return createCaller({ editorUserId: null, isViewer: true });
+  return createCaller(createTestContext({ editorUserId: null, isViewer: true, request: null, responseHeaders: null }));
 }
 
 function callerAsNonViewer() {
-  return createCaller({ editorUserId: null, isViewer: false });
+  return createCaller(createTestContext({ editorUserId: null, isViewer: false, request: null, responseHeaders: null }));
 }
 
 beforeEach(() => {
@@ -67,7 +68,7 @@ describe('githubSheet.byPath', () => {
       code: 'NOT_FOUND',
     });
   });
-  // /view/[path] と /compare は isValidSheetPath / isSheetFileName で notFound() にしていたが、
+  // /view/[path] は isValidSheetPath / isSheetFileName で notFound() にしていたが、
   // これは元々ページ側だけの防御だった。/api/trpc は URL を直叩きできるため、router 側でも
   // 同じ検証を通さないと .. トラバーサルや CLAUDE.md 等の AI 指示系ファイルが
   // GitHub API へそのまま渡ってしまう（Codex レビュー指摘）。

--- a/apps/web/src/server/trpc/router/index.ts
+++ b/apps/web/src/server/trpc/router/index.ts
@@ -1,10 +1,14 @@
 import { router } from '../init';
+import { authRouter } from './auth';
 import { githubSheetRouter } from './github-sheet';
+import { maintenanceRouter } from './maintenance';
 import { sheetRouter } from './sheet';
 
 export const appRouter = router({
+  auth: authRouter,
   sheet: sheetRouter,
   githubSheet: githubSheetRouter,
+  maintenance: maintenanceRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/src/server/trpc/router/maintenance.test.ts
+++ b/apps/web/src/server/trpc/router/maintenance.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const revalidateTag = vi.hoisted(() => vi.fn());
+vi.mock('next/cache', () => ({ revalidateTag }));
+
+import { createCallerFactory } from '../init';
+import { createTestContext } from '../test-context';
+import { maintenanceRouter } from './maintenance';
+
+const createCaller = createCallerFactory(maintenanceRouter);
+
+function callerWith(request: Request | null) {
+  return createCaller(
+    createTestContext({
+      editorUserId: null,
+      isViewer: false,
+      request,
+      responseHeaders: request ? new Headers() : null,
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.stubEnv('REVALIDATE_SECRET', 'test-secret');
+  revalidateTag.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('maintenance.revalidate', () => {
+  it('Bearer secret が一致すれば両方のタグを即時失効させる', async () => {
+    const caller = callerWith(
+      new Request('https://example.com/api/trpc/maintenance.revalidate', {
+        headers: { authorization: 'Bearer test-secret' },
+      }),
+    );
+
+    await expect(caller.revalidate()).resolves.toEqual({
+      ok: true,
+      revalidated: ['sheets', 'db-sheet'],
+    });
+    expect(revalidateTag).toHaveBeenNthCalledWith(1, 'sheets', { expire: 0 });
+    expect(revalidateTag).toHaveBeenNthCalledWith(2, 'db-sheet', { expire: 0 });
+  });
+
+  it('互換用 query secret も受け付ける', async () => {
+    const caller = callerWith(new Request('https://example.com/api/trpc/maintenance.revalidate?secret=test-secret'));
+    await expect(caller.revalidate()).resolves.toMatchObject({ ok: true });
+  });
+
+  it('secret が不一致なら UNAUTHORIZED でタグを失効させない', async () => {
+    const caller = callerWith(
+      new Request('https://example.com/api/trpc/maintenance.revalidate', {
+        headers: { authorization: 'Bearer wrong-secret' },
+      }),
+    );
+    await expect(caller.revalidate()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('REVALIDATE_SECRET 未設定は INTERNAL_SERVER_ERROR', async () => {
+    vi.stubEnv('REVALIDATE_SECRET', '');
+    const caller = callerWith(new Request('https://example.com/api/trpc/maintenance.revalidate'));
+    await expect(caller.revalidate()).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+  });
+});

--- a/apps/web/src/server/trpc/router/maintenance.ts
+++ b/apps/web/src/server/trpc/router/maintenance.ts
@@ -1,0 +1,39 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import { TRPCError } from '@trpc/server';
+import { revalidateTag } from 'next/cache';
+
+import { publicProcedure, router } from '../init';
+
+function safeEqual(a: string, b: string): boolean {
+  const aHash = createHash('sha256').update(a, 'utf-8').digest();
+  const bHash = createHash('sha256').update(b, 'utf-8').digest();
+  return timingSafeEqual(aHash, bHash);
+}
+
+function getProvidedSecret(request: Request | null): string {
+  if (!request) return '';
+  return (
+    request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
+    new URL(request.url).searchParams.get('secret') ??
+    ''
+  );
+}
+
+export const maintenanceRouter = router({
+  revalidate: publicProcedure.mutation(({ ctx }) => {
+    const secret = process.env.REVALIDATE_SECRET;
+    if (!secret) {
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'REVALIDATE_SECRET is not configured' });
+    }
+
+    const provided = getProvidedSecret(ctx.request);
+    if (!provided || !safeEqual(provided, secret)) {
+      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid revalidation secret' });
+    }
+
+    revalidateTag('sheets', { expire: 0 });
+    revalidateTag('db-sheet', { expire: 0 });
+    return { ok: true as const, revalidated: ['sheets', 'db-sheet'] as const };
+  }),
+});

--- a/apps/web/src/server/trpc/router/sheet.test.ts
+++ b/apps/web/src/server/trpc/router/sheet.test.ts
@@ -14,6 +14,7 @@ vi.mock('@skillsheet/db', async (importOriginal) => {
     saveSkillSheetBlocks: vi.fn(),
     createSheet: vi.fn(),
     deleteSheet: vi.fn(),
+    listSheets: vi.fn(),
   };
 });
 
@@ -27,28 +28,39 @@ vi.mock('@/server/sheets-cache', () => ({
   getCachedDbSheet: vi.fn(),
 }));
 
-import { ConflictError, createSheet, deleteSheet, SkillSheetNotFoundError, saveSkillSheetBlocks } from '@skillsheet/db';
+import {
+  ConflictError,
+  createSheet,
+  deleteSheet,
+  listSheets,
+  SkillSheetNotFoundError,
+  saveSkillSheetBlocks,
+} from '@skillsheet/db';
 import { revalidateTag } from 'next/cache';
 
 import { getCachedDbSheet, getCachedDbSheetById, getCachedDbSheets } from '@/server/sheets-cache';
 
 import { createCallerFactory } from '../init';
+import { createTestContext } from '../test-context';
 import { appRouter } from './index';
 
 const createCaller = createCallerFactory(appRouter);
 const saveMock = vi.mocked(saveSkillSheetBlocks);
 const createSheetMock = vi.mocked(createSheet);
 const deleteSheetMock = vi.mocked(deleteSheet);
+const listSheetsMock = vi.mocked(listSheets);
 const getCachedDbSheetsMock = vi.mocked(getCachedDbSheets);
 const getCachedDbSheetByIdMock = vi.mocked(getCachedDbSheetById);
 const getCachedDbSheetMock = vi.mocked(getCachedDbSheet);
 const revalidateTagMock = vi.mocked(revalidateTag);
 const MD = { type: 'markdown' as const, data: { markdown: 'x' } };
 
-// editorProcedure は ctx.editorUserId のみで判定するため、createTRPCContext()（cookies/headers 読み取り）
-// を経由せずコンテキストを直接組み立てられる。auth-gate/viewer-gate のモックが不要になる。
+// editorProcedure/viewerProcedure は middleware が ctx.getEditorUserId() / ctx.getIsViewer() を
+// 解決するだけなので、createTRPCContext()（cookies/headers 読み取り）を経由せず
+// createTestContext() で既知の値をコンテキストへ直接組み立てられる。
+// auth-gate/viewer-gate のモックが不要になる。
 function callerAs(editorUserId: string | null, isViewer = editorUserId !== null) {
-  return createCaller({ editorUserId, isViewer });
+  return createCaller(createTestContext({ editorUserId, isViewer, request: null, responseHeaders: null }));
 }
 
 beforeEach(() => {
@@ -68,6 +80,55 @@ describe('sheet.list', () => {
     const caller = callerAs(null, true);
     const result = await caller.sheet.list();
     expect(result).toEqual(summaries);
+  });
+});
+
+describe('sheet.builderState', () => {
+  it('非編集者は UNAUTHORIZED を返す', async () => {
+    const caller = callerAs(null, true);
+    await expect(caller.sheet.builderState({})).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(getCachedDbSheetsMock).not.toHaveBeenCalled();
+  });
+
+  it('指定 sheetId が一覧にあればそのシートを返す', async () => {
+    const sheets = [{ id: 's2', title: 'T2', updatedAt: new Date('2026-01-01T00:00:00.000Z') }];
+    const sheet = { title: 'T2', blocks: [MD] };
+    getCachedDbSheetsMock.mockResolvedValue(sheets as never);
+    getCachedDbSheetByIdMock.mockResolvedValue(sheet as never);
+
+    const result = await callerAs('owner').sheet.builderState({ sheetId: 's2' });
+    expect(result).toEqual({ sheet, sheets, activeSheetId: 's2' });
+    expect(getCachedDbSheetByIdMock).toHaveBeenCalledWith('s2');
+    expect(getCachedDbSheetMock).not.toHaveBeenCalled();
+  });
+
+  it('sheetId 未指定なら一覧の先頭を active にしてデフォルトシートを返す', async () => {
+    const sheets = [{ id: 's1', title: 'T1', updatedAt: new Date('2026-01-01T00:00:00.000Z') }];
+    const sheet = { title: 'T1', blocks: [MD] };
+    getCachedDbSheetsMock.mockResolvedValue(sheets as never);
+    getCachedDbSheetMock.mockResolvedValue(sheet as never);
+
+    await expect(callerAs('owner').sheet.builderState({})).resolves.toEqual({
+      sheet,
+      sheets,
+      activeSheetId: 's1',
+    });
+  });
+
+  it('空一覧がキャッシュ済みでも seed 後の正本を一度だけ再取得する', async () => {
+    const sheet = { title: 'Seeded', blocks: [MD] };
+    const seededSheets = [{ id: 'seeded', title: 'Seeded', updatedAt: new Date('2026-01-01T00:00:00.000Z') }];
+    getCachedDbSheetsMock.mockResolvedValue([]);
+    getCachedDbSheetMock.mockResolvedValue(sheet as never);
+    listSheetsMock.mockResolvedValue(seededSheets as never);
+
+    await expect(callerAs('owner').sheet.builderState({})).resolves.toEqual({
+      sheet,
+      sheets: seededSheets,
+      activeSheetId: 'seeded',
+    });
+    expect(listSheetsMock).toHaveBeenCalledOnce();
+    expect(revalidateTagMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/server/trpc/router/sheet.ts
+++ b/apps/web/src/server/trpc/router/sheet.ts
@@ -1,4 +1,11 @@
-import { ConflictError, createSheet, deleteSheet, SkillSheetNotFoundError, saveSkillSheetBlocks } from '@skillsheet/db';
+import {
+  ConflictError,
+  createSheet,
+  deleteSheet,
+  listSheets as listDbSheets,
+  SkillSheetNotFoundError,
+  saveSkillSheetBlocks,
+} from '@skillsheet/db';
 import { TRPCError } from '@trpc/server';
 import { revalidateTag } from 'next/cache';
 
@@ -6,12 +13,18 @@ import { getCachedDbSheet, getCachedDbSheetById, getCachedDbSheets } from '@/ser
 
 import { getTemplate } from '../../../../app/builder/templates';
 import { editorProcedure, router, viewerProcedure } from '../init';
-import { createSheetInputSchema, deleteSheetInputSchema, saveSheetInputSchema, sheetIdInputSchema } from '../schema';
+import {
+  builderStateInputSchema,
+  createSheetInputSchema,
+  deleteSheetInputSchema,
+  saveSheetInputSchema,
+  sheetIdInputSchema,
+} from '../schema';
 
 // Route Handler は Server Action ではないため next/cache の updateTag は使えない
 // （Next.js 16 公式: "It cannot be used in Route Handlers"）。tRPC mutation は必ず
 // Route Handler 経由で実行されるため、代わりに revalidateTag(tag, { expire: 0 }) で
-// 即時失効させる。同じ問題を app/api/revalidate/route.ts が既に解決しており、
+// 即時失効させる。同じ問題を maintenance.revalidate が解決しており、
 // { expire: 0 } を指定しないと即時失効が保証されない（本番で無効化されない不具合実績あり）。
 function invalidateDbSheetCache(): void {
   revalidateTag('db-sheet', { expire: 0 });
@@ -19,6 +32,25 @@ function invalidateDbSheetCache(): void {
 
 export const sheetRouter = router({
   list: viewerProcedure.query(() => getCachedDbSheets()),
+
+  builderState: editorProcedure.input(builderStateInputSchema).query(async ({ input }) => {
+    let sheets = await getCachedDbSheets();
+
+    if (input.sheetId && sheets.some((sheet) => sheet.id === input.sheetId)) {
+      const sheet = await getCachedDbSheetById(input.sheetId);
+      return { sheet, sheets, activeSheetId: input.sheetId };
+    }
+
+    const sheet = await getCachedDbSheet();
+    if (sheets.length === 0) {
+      // getCachedDbSheet() は初回アクセス時にデフォルトシートを作成し得る。
+      // 直前に空配列をキャッシュしていても作成済み ID を返せるよう、この一度だけ
+      // 正本を直接読む。RSC の render 中は revalidateTag を呼べないため、
+      // 一覧キャッシュは従来どおり最大 60 秒で自然更新させる。
+      sheets = await listDbSheets();
+    }
+    return { sheet, sheets, activeSheetId: sheets[0]?.id ?? '' };
+  }),
 
   // tRPC procedure は throw された値を無条件で TRPCError にラップする（server caller 経由でも
   // 同様）ため、SkillSheetNotFoundError の instanceof チェックを呼び出し元に残す設計は使えない。

--- a/apps/web/src/server/trpc/schema.ts
+++ b/apps/web/src/server/trpc/schema.ts
@@ -25,3 +25,7 @@ export const createSheetInputSchema = z.object({
 export const deleteSheetInputSchema = z.object({ sheetId: z.string() });
 
 export const githubSheetPathInputSchema = z.object({ path: z.string() });
+
+export const builderStateInputSchema = z.object({ sheetId: z.string().optional() });
+
+export const viewerLoginInputSchema = z.object({ code: z.string() });

--- a/apps/web/src/server/trpc/test-context.ts
+++ b/apps/web/src/server/trpc/test-context.ts
@@ -1,0 +1,24 @@
+import type { TRPCContext } from './context';
+
+interface TestContextInput {
+  editorUserId: string | null;
+  isViewer: boolean;
+  request: Request | null;
+  responseHeaders: Headers | null;
+}
+
+/**
+ * テストで ctx を手組みするためのファクトリ。
+ * 実運用の createTRPCContext は「初回アクセス時にだけ解決するメモ化リゾルバ」の形で
+ * editorUserId / isViewer を持つ（DB 障害時に public procedure まで巻き込まれるのを防ぐため）。
+ * テストは認可状態を既知の値として固定したいだけなので、同じ形へ即値をラップして返す。
+ * procedure 本体・middleware の実装は本番と完全に同じものを通す。
+ */
+export function createTestContext(input: TestContextInput): TRPCContext {
+  return {
+    getEditorUserId: async () => input.editorUserId,
+    getIsViewer: async () => input.isViewer,
+    request: input.request,
+    responseHeaders: input.responseHeaders,
+  };
+}

--- a/apps/web/src/server/viewer-gate.test.ts
+++ b/apps/web/src/server/viewer-gate.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/server/session', () => ({
 }));
 vi.mock('@/server/auth-gate', () => ({ isEditor: () => isEditorMock() }));
 
-import { isViewer, requireViewer } from './viewer-gate';
+import { hasViewerSession, isViewer, requireViewer } from './viewer-gate';
 
 beforeEach(() => {
   cookiesGet.mockReset();
@@ -51,6 +51,17 @@ describe('isViewer', () => {
     isEditorMock.mockResolvedValue(false);
     await expect(isViewer()).resolves.toBe(false);
     expect(redirectMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('hasViewerSession', () => {
+  it('HTTP Request headers の cookie から session を検証する', async () => {
+    verifyMock.mockReturnValue(true);
+    const requestHeaders = new Headers({ cookie: 'other=x; session=http-token; theme=dark' });
+
+    await expect(hasViewerSession(requestHeaders)).resolves.toBe(true);
+    expect(verifyMock).toHaveBeenCalledWith('http-token');
+    expect(cookiesGet).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/server/viewer-gate.ts
+++ b/apps/web/src/server/viewer-gate.ts
@@ -1,5 +1,6 @@
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { cache } from 'react';
 
 import { isEditor } from '@/server/auth-gate';
 import { SESSION_COOKIE_NAME, verifySessionToken } from '@/server/session';
@@ -25,12 +26,46 @@ const INTERNAL_ORIGIN = 'http://skillsheet-viewer.internal';
  * （tRPC の実行コンテキストには Server Action/RSC 専用の redirect() 例外制御が無い）。
  */
 export async function isViewer(): Promise<boolean> {
-  const cookieStore = await cookies();
-  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
-  if (verifySessionToken(token)) {
+  if (await hasViewerSession()) {
     return true;
   }
   return isEditor();
+}
+
+function cookieValue(cookieHeader: string, name: string): string | undefined {
+  for (const part of cookieHeader.split(';')) {
+    const [key, ...valueParts] = part.trim().split('=');
+    if (key === name) return valueParts.join('=');
+  }
+  return undefined;
+}
+
+/**
+ * 閲覧 cookie だけを検証する。tRPC context は編集者判定を先に一度だけ行い、
+ * 非編集者の場合にこの関数を呼ぶことで Better Auth の二重参照を避ける。
+ */
+async function resolveHasViewerSession(requestHeaders?: Headers): Promise<boolean> {
+  const token = requestHeaders
+    ? cookieValue(requestHeaders.get('cookie') ?? '', SESSION_COOKIE_NAME)
+    : (await cookies()).get(SESSION_COOKIE_NAME)?.value;
+  if (verifySessionToken(token)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * RSC 経路（引数なし呼び出し）専用のメモ化ラッパー。auth-gate.ts の
+ * resolveEditorUserIdForRSC と同じパターン。requestHeaders を明示的に渡す
+ * HTTP 経路は RSC レンダー外なので対象外。
+ */
+const resolveHasViewerSessionForRSC = cache((): Promise<boolean> => resolveHasViewerSession());
+
+export async function hasViewerSession(requestHeaders?: Headers): Promise<boolean> {
+  if (requestHeaders) {
+    return resolveHasViewerSession(requestHeaders);
+  }
+  return resolveHasViewerSessionForRSC();
 }
 
 /**

--- a/doc/01-setup-and-routing.md
+++ b/doc/01-setup-and-routing.md
@@ -93,11 +93,11 @@ Next.js App Router では `apps/web/app` 配下のディレクトリ構造がそ
 | `/builder` | `app/builder/page.tsx` | Server → Client | 編集者向けブロックビルダー |
 | `/login` | `app/login/page.tsx` | Client | 編集者ログイン（Better Auth） |
 | `/viewer-auth` | `app/viewer-auth/page.tsx` | Client | 閲覧コード認証（HMAC） |
-| `/api/auth` | `app/api/auth/route.ts` | Route Handler | 閲覧コード検証＋ cookie 発行 |
+| `/api/auth` | `app/api/auth/route.ts` | 互換 Route Handler | `auth.login` procedure への旧クライアント用アダプタ |
 | `/api/auth/[...all]` | `app/api/auth/[...all]/route.ts` | Route Handler | Better Auth の全エンドポイント |
-| `/api/logout` | `app/api/logout/route.ts` | Route Handler | 閲覧 cookie の失効 |
-| `/api/revalidate` | `app/api/revalidate/route.ts` | Route Handler | GitHub 読み経路のキャッシュ失効 |
-| `/api/trpc/[trpc]` | `app/api/trpc/[trpc]/route.ts` | Route Handler | tRPC の HTTP エンドポイント（`fetchRequestHandler`）。クライアントコンポーネントの `@trpc/react-query` フックのみが叩く |
+| `/api/logout` | `app/api/logout/route.ts` | 互換 Route Handler | `auth.logout` procedure への旧クライアント用アダプタ |
+| `/api/revalidate` | `app/api/revalidate/route.ts` | 互換 Route Handler | `maintenance.revalidate` procedure への運用用アダプタ |
+| `/api/trpc/[trpc]` | `app/api/trpc/[trpc]/route.ts` | Route Handler | tRPC の HTTP エンドポイント（`fetchRequestHandler`）。画面の読み書き・閲覧認証・権限状態を集約 |
 
 `[path]` や `[id]` は動的セグメントで、`params` は `Promise` として渡る（`const { id } = await params`）。
 

--- a/doc/02-authentication.md
+++ b/doc/02-authentication.md
@@ -75,7 +75,7 @@ export async function isEditor(): Promise<boolean> {
 
 - セッションの `user.id` が環境変数 `SKILLSHEET_OWNER_ID` と一致する場合のみ編集者とみなす。
 - 多層防御: 公開サインアップは無効化済みだが、万一オーナー以外のアカウントがセッションを持っても編集者とは扱わない。
-- 書き込み系 Server Action（`app/builder/actions.ts`）は proxy 任せにせず、アクション内でも先頭で `isEditor()` を再検証する。
+- 書き込み系は `src/server/trpc/router/sheet.ts` の `editorProcedure`（`init.ts` の middleware が `getEditorUserId()` を検証）だけを唯一のチェックポイントにする。
 
 ---
 
@@ -84,29 +84,29 @@ export async function isEditor(): Promise<boolean> {
 ### フロー
 
 1. 閲覧者は `/viewer-auth`（`app/viewer-auth/page.tsx`、クライアント）で共有された閲覧コードを入力する。
-2. フォーム送信で `POST /api/auth` に `{ code }` を送る（`credentials: 'include'`）。
+2. フォーム送信で tRPC の `auth.login` mutation に `{ code }` を送る。
 3. サーバーがコードを検証し、正しければ HMAC 署名 cookie を発行する。
 4. 成功後、`?next=`（内部パスのみ許可・オープンリダイレクト防止）か既定の `/view` へ遷移する。
 
 ### コード検証（timingSafeEqual）
 
-`app/api/auth/route.ts`（Node ランタイム）:
+`src/server/trpc/router/auth.ts`（Node ランタイム）:
 
 ```ts
-// app/api/auth/route.ts（抜粋）
+// src/server/trpc/router/auth.ts（抜粋）
 const viewerCode = process.env.VIEWER_CODE ?? process.env.VITE_VIEWER_CODE;
 const codeHash  = createHash('sha256').update(code, 'utf-8').digest();
 const validHash = createHash('sha256').update(viewerCode, 'utf-8').digest();
 if (!timingSafeEqual(codeHash, validHash)) {
-  return NextResponse.json({ error: 'Invalid code' }, { status: 401 });
+  throw new TRPCError({ code: 'UNAUTHORIZED' });
 }
-const res = NextResponse.json({ ok: true });
-const { name, ...options } = getSessionCookieOptions();
-res.cookies.set(name, createSessionToken(), options);
+appendSessionCookie(ctx.responseHeaders);
 ```
 
 - コードは平文比較せず、SHA-256 ハッシュ同士を `timingSafeEqual` で比較する（タイミング攻撃対策）。
 - リクエストは `isSameOrigin` チェックで CSRF 由来のクロスオリジン POST を弾く。
+- Fetch adapter の `resHeaders` に `Set-Cookie` を追加するため、ブラウザへ秘密値を返さない。
+- 旧 `POST /api/auth` は互換アダプタとして残り、同じ `auth.login` procedure を呼ぶ。
 
 ### セッショントークンの署名と検証
 
@@ -131,7 +131,8 @@ export function getSessionCookieOptions() {
 
 ### ログアウト
 
-`POST /api/logout`（`app/api/logout/route.ts`）が `session` cookie を `maxAge: 0` で失効させる。
+tRPC の `auth.logout` が `session` cookie を `maxAge: 0` で失効させる。
+旧 `POST /api/logout` は互換アダプタとして同じ procedure を呼ぶ。
 
 ---
 
@@ -159,7 +160,7 @@ export async function requireViewer(): Promise<void> {
 
 - 閲覧できても編集はできない: 閲覧 cookie は `requireViewer()` を通すだけで、`isEditor()` は Better Auth セッション必須なので書き込みは通らない。
 - 編集者は閲覧もできる: `requireViewer()` は編集者セッションでも通る。
-- 認可の入口を DAL（`auth-gate.ts` / `viewer-gate.ts`）に集約し、Server Action 側でも再検証する多層防御を採る。
+- 認可の入口を DAL（`auth-gate.ts` / `viewer-gate.ts`）に集約し、tRPC の `viewerProcedure` / `editorProcedure` でも同じ判定を再検証する多層防御を採る。
 
 ---
 

--- a/doc/03-github-api.md
+++ b/doc/03-github-api.md
@@ -176,7 +176,7 @@ GitHub 系の環境変数は任意扱いで、`assertServerEnv()` は欠けて�
 
 - `sheet.save` / `create` / `delete` の各 tRPC mutation は保存/作成/削除後に `revalidateTag('db-sheet', { expire: 0 })` を呼び、`db-sheet` タグを即時失効させる。
   - **`next/cache` の `updateTag` は使えない**: `updateTag` は Server Action 専用の API で Route Handler から呼ぶと実行時エラーになる（Next.js 16 公式ドキュメント）。tRPC の mutation は必ず Route Handler（`/api/trpc/[trpc]`）経由で実行されるため、代わりに `revalidateTag(tag, { expire: 0 })` で即時失効させる。空の `{}` は expire 未指定＝即時失効の保証が無いため、明示的に `{ expire: 0 }` を指定する（`app/api/revalidate/route.ts` が先に解決していた同じ問題のパターンを踏襲）。
-- GitHub 読み経路（`sheets` タグ）は `POST /api/revalidate`（`app/api/revalidate/route.ts`）で手動失効できる。`REVALIDATE_SECRET` を `Authorization: Bearer` か `?secret=` で照合し、`timingSafeEqual` で比較する。
+- GitHub 読み経路（`sheets` タグ）は tRPC の `maintenance.revalidate` で手動失効できる。`REVALIDATE_SECRET` を `Authorization: Bearer` か `?secret=` で照合し、`timingSafeEqual` で比較する。既存の webhook や運用スクリプト向けに `POST /api/revalidate` を互換アダプタとして残している。
 
 ---
 

--- a/packages/db/src/skillsheet.ts
+++ b/packages/db/src/skillsheet.ts
@@ -368,8 +368,8 @@ export async function saveSkillSheetBlocks(
         .where(eq(skillSheets.id, resolvedSheetId))
         .for('update')
         .limit(1);
-      // Server Actions 経由のシリアライズで Date が string 化される可能性に備え、
-      // 比較前に必ず Date へ正規化してから getTime() で比較する。
+      // tRPC + superjson 経由なら Date のまま渡るが、呼び出し元を問わず安全に
+      // 比較できるよう、比較前に必ず Date へ正規化してから getTime() で比較する。
       const expectedTime = new Date(expectedUpdatedAt).getTime();
       if (current && current.updatedAt.getTime() > expectedTime) {
         throw new ConflictError();


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #

<!-- no-sbi: Codex セッションからの引き継ぎ作業で、紐づく GitHub Issue が存在しないため -->

### 概要

tRPC 移行の残課題（P1指摘含む）を解消し、コミットから PR 作成まで完走させた。

コミット未実施のまま前セッションが停止していたため、今回はその続きとして着手した。

対応内容は3点。

1. tRPC の context 生成が、閲覧コード認証まで毎回 Better Auth のセッションを参照していた問題を修正した。認可の確認を遅延化し、必要な procedure だけが解決するようにした。
2. `/view` 配下でレイアウトとページが別々にセッションを確認しており、1リクエストで参照が2回走っていた。`cache()` でまとめた。
3. 旧 URL 互換の `/api/auth`・`/api/logout`・`/api/revalidate` が、想定外のエラーを一切ログしていなかった。`/api/trpc` と共通のロジックでログするようにした。あわせて不要になった `public-http-caller.ts` を削除した。

### 見て欲しいポイント

- [ ] `apps/web/src/server/trpc/context.ts` の遅延解決（メモ化含む）
- [ ] `apps/web/src/server/trpc/init.ts` の middleware での解決タイミング
- [ ] `apps/web/src/server/auth-gate.ts` / `viewer-gate.ts` の `cache()` 適用範囲
- [ ] `createTestContext()` の新設（テストの ctx 手組みを差し替え）

### 見なくてもよいポイント

- [ ] doc 配下の文言修正のみの差分

### その他(あれば)

`pnpm run lint`・`type-check`・`test`（701件）・`build` は通過を確認した。

`pnpm run test:e2e`（ヘッドレス CDP）は `/login`・`/viewer-auth` の2シナリオが成功。

Playwright（`test:e2e:playwright`）は `.env.local` が無く未実施。CI の `e2e` ジョブを正本とする。

比較元: ヘッドレス CDP e2e と自動テスト・build・type-check。

判定: UNCERTAIN

照合していない場合の理由: `/builder`・`/view` 系画面のブラウザ見た目照合は未実施。CI の Playwright e2e を正本として扱う。

---

### PR チェックポイント

- [ ] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * tRPCによる閲覧者ログイン、認証状態確認、ログアウトに対応しました。
  * ビルダー画面でシート情報をまとめて取得できるようになりました。
  * 管理用のキャッシュ再検証機能を追加しました。
* **改善**
  * 画面ごとの編集権限判定と認証処理を統一し、未認証時のログイン画面への遷移を改善しました。
  * 既存の認証・ログアウト・キャッシュ再検証APIは互換性のため引き続き利用できます。
* **ドキュメント**
  * 認証、APIルート、キャッシュ再検証の利用方法を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->