### PR TITLE
ci: Semgrep SAST を追加し、ci-failure-notify の参照切れを解消

### DIFF
--- a/.github/workflows/ci-failure-notify.yml
+++ b/.github/workflows/ci-failure-notify.yml
@@ -3,13 +3,9 @@ name: CI Failure Slack Notify
 on:
   workflow_run:
     workflows:
-      - "Blacksmith Probe (temporary diagnostic - safe to delete)"
       - "CI"
-      - "Dependency Review"
       - "Merge Quality Gate"
-      - "PR Label"
       - "PR Labeler"
-      - "PR Setting"
       - "Security Audit"
       - "Security Scan"
       - "Semgrep"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -34,6 +34,13 @@ jobs:
 
       # 依存脆弱性は security-scan.yml の pnpm audit と security-audit.yml の audit-ci が
       # 見ているため、ここは SAST に専念する。
-      # --config auto はメトリクス送信が必須で無効化できず、private 化した際に
-      # リポジトリのメタデータが外部へ出る。明示的なルールパックなら送信なしで動く。
+      # --metrics=off は使用状況メトリクスの送信のみを無効化する。ルール自体は
+      # p/default 指定時に Semgrep Registry から取得するため通信は残る。
+      # --config auto は metrics=off と併用できずエラーになるため、private 化に
+      # 備えて明示的なルールパック指定に変更している。
+      #
+      # --error は付けていない。導入時点でこのルールセットは既存コードに対して
+      # 21件の findings（ERROR severity 1件を含む）を出すため、即座に付けると
+      # 本PRと無関係な既存コードでCIが赤くなる。まず findings を triage
+      # （修正 or nosemgrep/.semgrepignoreで除外）してから、別PRでハードゲート化する。
       - run: semgrep scan --config p/default --metrics=off

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,39 @@
+name: Semgrep
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.js"
+      - "**/*.mjs"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Code Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: semgrep/semgrep@sha256:2b33f46ba66cf8cc2ad59ccfa7d22951fd00c632c38f1339e84ec8e6e641a942
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      # 依存脆弱性は security-scan.yml の pnpm audit と security-audit.yml の audit-ci が
+      # 見ているため、ここは SAST に専念する。
+      # --config auto はメトリクス送信が必須で無効化できず、private 化した際に
+      # リポジトリのメタデータが外部へ出る。明示的なルールパックなら送信なしで動く。
+      - run: semgrep scan --config p/default --metrics=off


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #

### 概要

CodeQL の削除を依頼されて調査した結果、CodeQL はこのリポジトリに一度も存在していないことが判明しました。対話の中で本当の要求は「private でも無料で使えるセキュリティ構成にする」ことだと分かったため、その観点で見直しました。

このリポジトリには依存脆弱性スキャン（pnpm audit / audit-ci）とシークレットスキャン（gitleaks / TruffleHog）はありましたが、SAST（静的コード解析）が抜けていました。designdiff で実績のある Semgrep OSS 設定を移植します。

### 見て欲しいポイント

- [ ] `semgrep.yml`: `--config auto` ではなく `p/default --metrics=off` を使っている点（auto はテレメトリ送信が必須で無効化できず、private 化した際にリポジトリのメタデータが外部送信されるため）
- [ ] `ci-failure-notify.yml`: 存在しないワークフロー（Blacksmith Probe, Dependency Review, PR Label, PR Setting）への参照を削除し、新設した Semgrep を追加

### 見なくてもよいポイント

- [ ]

### その他(あれば)

- Trivy は追加していません。依存脆弱性は既存の pnpm audit（ハードゲート）+ audit-ci で二重にカバー済みで、三重目は冗長と判断しました
- ローカルで `semgrep scan --config p/default --metrics=off .` を実行し、21件の findings（ERROR 1件、`doc/` 配下の検証用スクリプト）が出ることを確認済みです。exit code は 0 なので CI は落ちません
- actionlint でこのリポジトリの全ワークフローを検証し、指摘ゼロを確認済みです
- ブランチ名 `claude/remove-codeql-18n6w5` は当初の依頼に基づいていますが、CodeQL が存在しなかったため実際の変更内容は private 互換のセキュリティ強化です

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外） → 該当チケットなし
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか → 環境変数追加なし
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例） → 該当なし

### レビュー観点

- [x] 想定通りに動作するか → ローカルで semgrep 実行済み、actionlint 通過済み
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ → designdiff の semgrep.yml と揃えています
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Vdj4vornmbry2hHAobonhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vdj4vornmbry2hHAobonhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * JavaScript／TypeScriptの変更時やメインブランチ更新時に、自動コードスキャンを実行します。
  * 手動実行にも対応し、セキュリティ上の問題を早期に検出できます。

* **改善**
  * CI失敗通知の対象を主要な品質チェックに限定し、不要な通知を削減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->