### PR TITLE
fix(trpc)：認可・入力境界と閲覧遅延を修正

### DIFF
--- a/apps/web/app/api/auth/route.test.ts
+++ b/apps/web/app/api/auth/route.test.ts
@@ -42,12 +42,32 @@ describe('POST /api/auth', () => {
     expect(res.status).toBe(403);
   });
 
+  it('cross-origin の不正 JSON は body を解析せず 403', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await POST(makeReq('not-json', { origin: 'http://evil.example', host: 'localhost:3000' }));
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Forbidden' });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
   it('VIEWER_CODE 未設定なら 500 で console.error に記録する（互換アダプタの catch は元々何もログしていなかった）', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     delete process.env.VIEWER_CODE;
     delete process.env.VITE_VIEWER_CODE;
     const res = await POST(makeReq(JSON.stringify({ code: 'x' })));
     expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Server configuration error' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith('POST /api/auth: unexpected error:', expect.anything());
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('session cookie 発行の想定外エラーは認証失敗として 500 を返す', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env.SESSION_SECRET;
+    const res = await POST(makeReq(JSON.stringify({ code: 'correct-code' })));
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to authenticate' });
     expect(consoleErrorSpy).toHaveBeenCalledWith('POST /api/auth: unexpected error:', expect.anything());
     consoleErrorSpy.mockRestore();
   });

--- a/apps/web/app/api/auth/route.ts
+++ b/apps/web/app/api/auth/route.ts
@@ -5,6 +5,7 @@ import { createTRPCContext } from '@/server/trpc/context';
 import { createCallerFactory } from '@/server/trpc/init';
 import { shouldLogTRPCError } from '@/server/trpc/log-error';
 import { appRouter } from '@/server/trpc/router';
+import { isSameOriginRequest, VIEWER_AUTH_NOT_CONFIGURED_MESSAGE } from '@/server/trpc/router/auth';
 
 const createCaller = createCallerFactory(appRouter);
 
@@ -16,6 +17,12 @@ export const dynamic = 'force-dynamic';
  * 新しい画面は auth.login procedure を直接使い、認証ロジックは tRPC 側だけが持つ。
  */
 export async function POST(req: NextRequest) {
+  // 旧 Route Handler も tRPC procedure と同じ順序で origin を検証する。
+  // body を先に読むと cross-origin の不正 JSON が 403 ではなく 400 になる。
+  if (!isSameOriginRequest(req)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   let input: unknown;
   try {
     input = await req.json();
@@ -40,10 +47,14 @@ export async function POST(req: NextRequest) {
       if (error.code === 'UNAUTHORIZED') {
         return NextResponse.json({ error: 'Invalid code' }, { status: 401 });
       }
+      if (error.code === 'INTERNAL_SERVER_ERROR' && error.message === VIEWER_AUTH_NOT_CONFIGURED_MESSAGE) {
+        console.error('POST /api/auth: unexpected error:', error);
+        return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+      }
     }
     if (!(error instanceof TRPCError) || shouldLogTRPCError(error.code)) {
       console.error('POST /api/auth: unexpected error:', error);
     }
-    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to authenticate' }, { status: 500 });
   }
 }

--- a/apps/web/app/api/logout/route.test.ts
+++ b/apps/web/app/api/logout/route.test.ts
@@ -49,7 +49,7 @@ describe('POST /api/logout compatibility adapter', () => {
     const res = await POST(req);
 
     expect(res.status).toBe(500);
-    await expect(res.json()).resolves.toEqual({ error: 'Server configuration error' });
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to log out' });
     expect(consoleErrorSpy).toHaveBeenCalledWith('POST /api/logout: unexpected error:', expect.any(Error));
     consoleErrorSpy.mockRestore();
   });

--- a/apps/web/app/api/logout/route.ts
+++ b/apps/web/app/api/logout/route.ts
@@ -25,6 +25,6 @@ export async function POST(req: NextRequest) {
     if (!(error instanceof TRPCError) || shouldLogTRPCError(error.code)) {
       console.error('POST /api/logout: unexpected error:', error);
     }
-    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to log out' }, { status: 500 });
   }
 }

--- a/apps/web/app/builder/builder-client.test.tsx
+++ b/apps/web/app/builder/builder-client.test.tsx
@@ -85,6 +85,13 @@ describe('BuilderClient', () => {
     );
   });
 
+  it('DB 取得失敗後の空ビルダーは sheetId を省略して新規保存する', async () => {
+    const user = userEvent.setup();
+    render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="マイシート" sheets={[]} activeSheetId="" />);
+    await user.click(screen.getByRole('button', { name: /保存/ }));
+    expect(mockSave).toHaveBeenCalledWith(expect.objectContaining({ sheetId: undefined }));
+  });
+
   // headless E2E で再現した実バグの回帰テスト: unstable_cache のキャッシュ命中時は内部で
   // JSON.stringify/JSON.parse を通すため、RSC が渡す sheets[].updatedAt が Date ではなく
   // ISO 文字列になることがある（既存シートを開いて保存するたびに再現）。expectedUpdatedAt は
@@ -409,6 +416,15 @@ describe('BuilderClient 自動保存', () => {
       vi.advanceTimersByTime(5000);
     });
     expect(mockSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('空ビルダーの自動保存は sheetId を省略して新規保存する', async () => {
+    render(<BuilderClient initialBlocks={mdBlocks(['## A'])} initialTitle="t" sheets={[]} activeSheetId="" />);
+    typeMarkdown('## B');
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(mockSave).toHaveBeenCalledWith(expect.objectContaining({ sheetId: undefined }));
   });
 
   // Codex 指摘の回帰テスト（手動保存側と同じ理由）。自動保存でタイトルが変わった場合も

--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -1229,7 +1229,7 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
       const result = await saveMutation.mutateAsync({
         title: currentTitle,
         blocks: currentItems.map(itemToBlockInput),
-        sheetId: activeSheetId,
+        sheetId: activeSheetId || undefined,
         expectedUpdatedAt: savedUpdatedAtRef.current,
       });
       savedRef.current = true;
@@ -1498,7 +1498,7 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
     const payload = {
       title,
       blocks: items.map(itemToBlockInput),
-      sheetId: activeSheetId,
+      sheetId: activeSheetId || undefined,
       expectedUpdatedAt: savedUpdatedAtRef.current,
     };
     const savedSnapshot = snapshot(items, title);

--- a/apps/web/app/view/[path]/deferred-edit-sheet-view.test.tsx
+++ b/apps/web/app/view/[path]/deferred-edit-sheet-view.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const useAuthStatusQuery = vi.fn();
+const useAuthStatusQuery = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/trpc-client', () => ({
   trpc: { auth: { status: { useQuery: useAuthStatusQuery } } },

--- a/apps/web/app/view/[path]/deferred-edit-sheet-view.test.tsx
+++ b/apps/web/app/view/[path]/deferred-edit-sheet-view.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useAuthStatusQuery = vi.fn();
+
+vi.mock('@/lib/trpc-client', () => ({
+  trpc: { auth: { status: { useQuery: useAuthStatusQuery } } },
+}));
+
+vi.mock('./sheet-view-client', () => ({
+  default: ({
+    title,
+    content,
+    canEdit,
+    reserveEditSlot,
+  }: {
+    title: string;
+    content: string;
+    canEdit: boolean;
+    reserveEditSlot: boolean;
+  }) => (
+    <article data-can-edit={String(canEdit)} data-reserve-edit-slot={String(reserveEditSlot)}>
+      <h1>{title}</h1>
+      <p>{content}</p>
+    </article>
+  ),
+}));
+
+import DeferredEditSheetView from './deferred-edit-sheet-view';
+
+describe('DeferredEditSheetView', () => {
+  beforeEach(() => {
+    useAuthStatusQuery.mockReset();
+  });
+
+  it('編集者判定の待機中でも本文を表示し、編集導線は出さない', () => {
+    useAuthStatusQuery.mockReturnValue({ data: undefined });
+    render(<DeferredEditSheetView title="T" content="本文" />);
+    expect(screen.getByRole('heading', { name: 'T' })).toBeInTheDocument();
+    expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-can-edit', 'false');
+    expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-reserve-edit-slot', 'true');
+  });
+
+  it('編集者判定の失敗時も本文を表示し、編集導線は出さない', () => {
+    useAuthStatusQuery.mockReturnValue({ data: undefined, error: new Error('db down') });
+    render(<DeferredEditSheetView title="T" content="本文" />);
+    expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-can-edit', 'false');
+  });
+
+  it('編集者判定の成功後は編集導線を有効にする', () => {
+    useAuthStatusQuery.mockReturnValue({ data: { canEdit: true, canView: true } });
+    render(<DeferredEditSheetView title="T" content="本文" />);
+    expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-can-edit', 'true');
+  });
+});

--- a/apps/web/app/view/[path]/deferred-edit-sheet-view.tsx
+++ b/apps/web/app/view/[path]/deferred-edit-sheet-view.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+
+import { trpc } from '@/lib/trpc-client';
+
+import SheetViewClient from './sheet-view-client';
+
+type Props = Omit<ComponentProps<typeof SheetViewClient>, 'canEdit' | 'reserveEditSlot'>;
+
+/** 本文を先に描画し、編集者判定の完了後だけ編集導線を追加する。 */
+export default function DeferredEditSheetView(props: Props) {
+  const { data } = trpc.auth.status.useQuery();
+  return <SheetViewClient {...props} canEdit={data?.canEdit ?? false} reserveEditSlot />;
+}

--- a/apps/web/app/view/[path]/page.tsx
+++ b/apps/web/app/view/[path]/page.tsx
@@ -7,7 +7,7 @@ import { isSheetFileName, isValidSheetPath, type SheetContent } from '@/server/g
 import { createServerCaller } from '@/server/trpc/caller';
 import { classifyConfigError } from '@/util/is-config-error';
 
-import SheetViewClient from './sheet-view-client';
+import DeferredEditSheetView from './deferred-edit-sheet-view';
 
 interface PageProps {
   params: Promise<{ path: string }>;
@@ -35,13 +35,12 @@ export default async function SheetViewPage({ params }: PageProps) {
   if (!isValidSheetPath(path) || !isSheetFileName(path)) notFound();
 
   let sheet: SheetContent;
-  let canEdit = false;
   try {
     const caller = await createServerCaller();
-    // auth.status() はシート取得の入力に使わないため、直列待機せず並列で開始する。
-    const [authStatus, loadedSheet] = await Promise.all([caller.auth.status(), caller.githubSheet.byPath({ path })]);
-    canEdit = authStatus.canEdit;
-    sheet = loadedSheet;
+    // HMAC cookie を持つ閲覧者は、本文表示をローカル検証だけで進める。
+    // 編集者判定はクライアント側で遅延し、Better Auth / DB の遅延や障害で
+    // 閲覧者向けの本文まで待たせない。
+    sheet = await caller.githubSheet.byPath({ path });
   } catch (err) {
     // tRPC procedure は throw を無条件で TRPCError にラップするため、元の SheetNotFoundError
     // ではなく code: 'NOT_FOUND' で判定する（githubSheet.byPath 側のコメント参照）。
@@ -64,5 +63,5 @@ export default async function SheetViewPage({ params }: PageProps) {
 
   // key={path}: 別シートへ遷移してもコンポーネントを再マウントし、ビュー
   // ON/OFF トグルの state（初回マウント時に決まる）を新しいシートへ持ち越さない。
-  return <SheetViewClient key={path} title={sheet.title} content={sheet.content} canEdit={canEdit} />;
+  return <DeferredEditSheetView key={path} title={sheet.title} content={sheet.content} />;
 }

--- a/apps/web/app/view/[path]/sheet-view-client.tsx
+++ b/apps/web/app/view/[path]/sheet-view-client.tsx
@@ -13,6 +13,8 @@ interface SheetViewClientProps {
   blocks?: Block[];
   /** 編集者ログイン済みか。false（閲覧コードのみ等）のときは編集導線を出さない。 */
   canEdit?: boolean;
+  /** 編集者判定の前後で編集ボタン分の幅を固定し、レイアウトずれを防ぐ。 */
+  reserveEditSlot?: boolean;
   /**
    * true のとき、DB への再接続に失敗して古いキャッシュを表示している可能性があることを
    * 画面上部に案内する（Issue #204）。sheets-cache.ts の isDbContentStale() で判定する。
@@ -22,7 +24,14 @@ interface SheetViewClientProps {
 
 const REVOKE_OBJECT_URL_DELAY_MS = 100;
 
-const SheetViewClient = ({ title, content, blocks, canEdit = false, stale = false }: SheetViewClientProps) => {
+const SheetViewClient = ({
+  title,
+  content,
+  blocks,
+  canEdit = false,
+  reserveEditSlot = false,
+  stale = false,
+}: SheetViewClientProps) => {
   const [pdfLoading, setPdfLoading] = useState(false);
   // project ブロックを含むシートはダッシュボード扱いにし、Console トップバー＋ビュートグルを出す。
   // 意図的に raw blocks（中身が空でも）で判定する — skill-sheet-viewer.tsx の isDashboard と
@@ -90,9 +99,16 @@ const SheetViewClient = ({ title, content, blocks, canEdit = false, stale = fals
           onDownloadPdf={handleDownloadPdf}
           pdfLoading={pdfLoading}
           canEdit={canEdit}
+          reserveEditSlot={reserveEditSlot}
         />
       ) : (
-        <Header onDownloadPdf={handleDownloadPdf} pdfLoading={pdfLoading} canEdit={canEdit} backHref="/view" />
+        <Header
+          onDownloadPdf={handleDownloadPdf}
+          pdfLoading={pdfLoading}
+          canEdit={canEdit}
+          reserveEditSlot={reserveEditSlot}
+          backHref="/view"
+        />
       )}
       <SkillSheetViewer skillSheet={{ title, content }} blocks={blocks} views={isDashboard ? views : undefined} />
     </div>

--- a/apps/web/src/component/header.test.tsx
+++ b/apps/web/src/component/header.test.tsx
@@ -111,6 +111,17 @@ describe('Header', () => {
       expect(screen.queryByLabelText('編集／ビルダー')).not.toBeInTheDocument();
     });
 
+    it('固定slotは閲覧者・編集者の両状態で44pxを維持する', () => {
+      const { unmount } = renderHeader({ canEdit: false, reserveEditSlot: true });
+      expect(screen.getByTestId('edit-slot')).toHaveClass('size-11', 'shrink-0');
+      expect(screen.queryByLabelText('編集／ビルダー')).not.toBeInTheDocument();
+      unmount();
+
+      renderHeader({ canEdit: true, reserveEditSlot: true });
+      expect(screen.getByTestId('edit-slot')).toHaveClass('size-11', 'shrink-0');
+      expect(screen.getByLabelText('編集／ビルダー')).toBeInTheDocument();
+    });
+
     it('backHref 未指定では一覧へ戻るリンクが出ない', () => {
       renderHeader();
       expect(screen.queryByLabelText('シート一覧へ戻る')).not.toBeInTheDocument();

--- a/apps/web/src/component/header.tsx
+++ b/apps/web/src/component/header.tsx
@@ -14,6 +14,8 @@ interface HeaderProps {
   pdfLoading?: boolean;
   /** 編集者ログイン済みか。false のときは編集導線（ビルダーリンク）を出さない。 */
   canEdit?: boolean;
+  /** 編集者判定の前後で編集ボタン分の幅を固定する。 */
+  reserveEditSlot?: boolean;
   /** 指定時、タイトル左に一覧などへ戻るリンクを出す（例: "/view"）。 */
   backHref?: string;
 }
@@ -23,9 +25,22 @@ const Header = ({
   onDownloadPdf,
   pdfLoading = false,
   canEdit = true,
+  reserveEditSlot = false,
   backHref,
 }: HeaderProps) => {
   const { mode, toggleTheme } = useThemeMode();
+  const editButton = canEdit ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" asChild aria-label="編集／ビルダー">
+          <Link href="/builder">
+            <PencilLine />
+          </Link>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>編集／ビルダー</TooltipContent>
+    </Tooltip>
+  ) : null;
 
   return (
     <motion.header
@@ -53,17 +68,12 @@ const Header = ({
         )}
 
         <div className="flex items-center gap-1">
-          {canEdit && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" asChild aria-label="編集／ビルダー">
-                  <Link href="/builder">
-                    <PencilLine />
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>編集／ビルダー</TooltipContent>
-            </Tooltip>
+          {reserveEditSlot ? (
+            <span data-testid="edit-slot" className="size-11 shrink-0">
+              {editButton}
+            </span>
+          ) : (
+            editButton
           )}
 
           {onDownloadPdf && (

--- a/apps/web/src/component/viewer-topbar.test.tsx
+++ b/apps/web/src/component/viewer-topbar.test.tsx
@@ -57,4 +57,15 @@ describe('ViewerTopbar', () => {
     renderTopbar({ canEdit: false });
     expect(screen.queryByLabelText('編集／ビルダー')).not.toBeInTheDocument();
   });
+
+  it('固定slotは閲覧者・編集者の両状態で44pxを維持する', () => {
+    const { unmount } = renderTopbar({ canEdit: false, reserveEditSlot: true });
+    expect(screen.getByTestId('edit-slot')).toHaveClass('size-11', 'shrink-0');
+    expect(screen.queryByLabelText('編集／ビルダー')).not.toBeInTheDocument();
+    unmount();
+
+    renderTopbar({ canEdit: true, reserveEditSlot: true });
+    expect(screen.getByTestId('edit-slot')).toHaveClass('size-11', 'shrink-0');
+    expect(screen.getByLabelText('編集／ビルダー')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/component/viewer-topbar.tsx
+++ b/apps/web/src/component/viewer-topbar.tsx
@@ -35,6 +35,8 @@ interface ViewerTopbarProps {
   pdfLoading?: boolean;
   /** 編集者ログイン済みか。false のときは編集導線（ビルダーリンク）を出さない。 */
   canEdit?: boolean;
+  /** 編集者判定の前後で編集ボタン分の幅を固定する。 */
+  reserveEditSlot?: boolean;
 }
 
 // ダッシュボードシート用の Console トップバー（redesign2 の topbar 変種）。
@@ -48,8 +50,21 @@ export function ViewerTopbar({
   onDownloadPdf,
   pdfLoading = false,
   canEdit = true,
+  reserveEditSlot = false,
 }: ViewerTopbarProps) {
   const { mode, toggleTheme } = useThemeMode();
+  const editButton = canEdit ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" asChild aria-label="編集／ビルダー" className="min-h-11 min-w-11">
+          <Link href="/builder">
+            <PencilLine />
+          </Link>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>編集／ビルダー</TooltipContent>
+    </Tooltip>
+  ) : null;
 
   return (
     <motion.header
@@ -94,17 +109,12 @@ export function ViewerTopbar({
         </fieldset>
 
         <div className="flex items-center gap-1">
-          {canEdit && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" asChild aria-label="編集／ビルダー" className="min-h-11 min-w-11">
-                  <Link href="/builder">
-                    <PencilLine />
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>編集／ビルダー</TooltipContent>
-            </Tooltip>
+          {reserveEditSlot ? (
+            <span data-testid="edit-slot" className="size-11 shrink-0">
+              {editButton}
+            </span>
+          ) : (
+            editButton
           )}
 
           {onDownloadPdf && (

--- a/apps/web/src/server/trpc/caller.test.ts
+++ b/apps/web/src/server/trpc/caller.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createTRPCContextMock = vi.fn();
+const SHEET_ID = '00000000-0000-4000-8000-000000000001';
 
 vi.mock('./context', () => ({ createTRPCContext: () => createTRPCContextMock() }));
 
@@ -41,7 +42,7 @@ describe('createServerCaller', () => {
       createTestContext({ editorUserId: 'owner', isViewer: true, request: null, responseHeaders: null }),
     );
     const caller = await createServerCaller();
-    await expect(caller.sheet.delete({ sheetId: 's1' })).resolves.toEqual({ ok: true });
+    await expect(caller.sheet.delete({ sheetId: SHEET_ID })).resolves.toEqual({ ok: true });
   });
 
   it('editorUserId が無い context では editorProcedure が UNAUTHORIZED になる', async () => {
@@ -49,6 +50,6 @@ describe('createServerCaller', () => {
       createTestContext({ editorUserId: null, isViewer: true, request: null, responseHeaders: null }),
     );
     const caller = await createServerCaller();
-    await expect(caller.sheet.delete({ sheetId: 's1' })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    await expect(caller.sheet.delete({ sheetId: SHEET_ID })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 });

--- a/apps/web/src/server/trpc/context.integration.test.ts
+++ b/apps/web/src/server/trpc/context.integration.test.ts
@@ -54,6 +54,40 @@ describe('createTRPCContext と実物の auth-gate/viewer-gate の結線（conte
     expect(getSessionMock).not.toHaveBeenCalled();
   });
 
+  it('HTTP auth.status: 閲覧 cookie だけなら canView=true / canEdit=false を返す', async () => {
+    const { createSessionToken } = await import('@/server/session');
+    const token = createSessionToken();
+    const req = new Request('https://example.com/api/trpc/auth.status', {
+      headers: { cookie: `session=${token}` },
+    });
+    const { createTRPCContext } = await import('./context');
+    const { createCallerFactory } = await import('./init');
+    const { authRouter } = await import('./router/auth');
+    const caller = createCallerFactory(authRouter)(createTRPCContext({ req }));
+
+    await expect(caller.status()).resolves.toEqual({ canEdit: false, canView: true });
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('HTTP auth.status: 閲覧 cookie と編集者 session の併存時も canEdit=true を維持する', async () => {
+    process.env.BETTER_AUTH_SECRET = 'secret';
+    process.env.DATABASE_URL = 'postgres://x';
+    process.env.SKILLSHEET_OWNER_ID = 'owner-1';
+    getSessionMock.mockResolvedValue({ user: { id: 'owner-1' } });
+    const { createSessionToken } = await import('@/server/session');
+    const token = createSessionToken();
+    const req = new Request('https://example.com/api/trpc/auth.status', {
+      headers: { cookie: `session=${token}; better-auth.session_token=cached-session` },
+    });
+    const { createTRPCContext } = await import('./context');
+    const { createCallerFactory } = await import('./init');
+    const { authRouter } = await import('./router/auth');
+    const caller = createCallerFactory(authRouter)(createTRPCContext({ req }));
+
+    await expect(caller.status()).resolves.toEqual({ canEdit: true, canView: true });
+    expect(getSessionMock).toHaveBeenCalledOnce();
+  });
+
   it('HTTP 経路: Cookie が無い/不正なら isViewer=false になる（実物の cookie パース経由）', async () => {
     const req = new Request('https://example.com/api/trpc/auth.status', {
       headers: { cookie: 'other=unrelated' },

--- a/apps/web/src/server/trpc/context.test.ts
+++ b/apps/web/src/server/trpc/context.test.ts
@@ -42,11 +42,12 @@ describe('createTRPCContext', () => {
     expect(getEditorUserIdMock).toHaveBeenCalledTimes(1);
   });
 
-  it('編集者なら ctx.getIsViewer() は閲覧 cookie を調べずに true を返す', async () => {
+  it('閲覧 cookie が無効でも編集者なら ctx.getIsViewer() は true を返す', async () => {
     getEditorUserIdMock.mockResolvedValue('owner');
+    hasViewerSessionMock.mockResolvedValue(false);
     const ctx = createTRPCContext();
     await expect(ctx.getIsViewer()).resolves.toBe(true);
-    expect(hasViewerSessionMock).not.toHaveBeenCalled();
+    expect(hasViewerSessionMock).toHaveBeenCalledTimes(1);
   });
 
   it('編集者でなく閲覧 cookie も無効なら ctx.getIsViewer() は false を返す', async () => {
@@ -56,19 +57,18 @@ describe('createTRPCContext', () => {
     await expect(ctx.getIsViewer()).resolves.toBe(false);
   });
 
-  it('編集者でなくても閲覧 cookie が有効なら ctx.getIsViewer() は true を返す', async () => {
-    getEditorUserIdMock.mockResolvedValue(null);
+  it('閲覧 cookie が有効なら編集者判定を行わず ctx.getIsViewer() は true を返す', async () => {
     hasViewerSessionMock.mockResolvedValue(true);
     const ctx = createTRPCContext();
     await expect(ctx.getIsViewer()).resolves.toBe(true);
+    expect(getEditorUserIdMock).not.toHaveBeenCalled();
   });
 
-  it('ctx.getIsViewer() を複数回呼んでも getEditorUserId / hasViewerSession の解決は 1 回だけ', async () => {
-    getEditorUserIdMock.mockResolvedValue(null);
+  it('ctx.getIsViewer() を複数回呼んでも有効な閲覧 cookie の解決は 1 回だけ', async () => {
     hasViewerSessionMock.mockResolvedValue(true);
     const ctx = createTRPCContext();
     await Promise.all([ctx.getIsViewer(), ctx.getIsViewer()]);
-    expect(getEditorUserIdMock).toHaveBeenCalledTimes(1);
+    expect(getEditorUserIdMock).not.toHaveBeenCalled();
     expect(hasViewerSessionMock).toHaveBeenCalledTimes(1);
   });
 
@@ -84,7 +84,7 @@ describe('createTRPCContext', () => {
     expect(ctx.request).toBe(req);
     expect(ctx.responseHeaders).toBe(resHeaders);
     await expect(ctx.getIsViewer()).resolves.toBe(true);
-    expect(getEditorUserIdMock).toHaveBeenCalledWith(req.headers);
+    expect(getEditorUserIdMock).not.toHaveBeenCalled();
     expect(hasViewerSessionMock).toHaveBeenCalledWith(req.headers);
   });
 });

--- a/apps/web/src/server/trpc/context.ts
+++ b/apps/web/src/server/trpc/context.ts
@@ -36,8 +36,11 @@ export function createTRPCContext(options?: TRPCContextOptions) {
   const resolveIsViewer = (): Promise<boolean> => {
     if (!isViewerPromise) {
       isViewerPromise = (async () => {
-        if ((await resolveEditorUserId()) !== null) return true;
-        return hasViewerSession(requestHeaders);
+        // 閲覧 cookie は HMAC のローカル検証だけで完結するため、DB を参照する
+        // Better Auth より先に判定する。共有リンクの閲覧を DB 遅延・障害へ
+        // 不要に巻き込まず、cookie が無い場合だけ編集者セッションを確認する。
+        if (await hasViewerSession(requestHeaders)) return true;
+        return (await resolveEditorUserId()) !== null;
       })();
     }
     return isViewerPromise;

--- a/apps/web/src/server/trpc/router/auth.ts
+++ b/apps/web/src/server/trpc/router/auth.ts
@@ -7,7 +7,9 @@ import { appendExpiredSessionCookie, appendSessionCookie } from '@/server/sessio
 import { publicProcedure, router } from '../init';
 import { viewerLoginInputSchema } from '../schema';
 
-function isSameOrigin(request: Request): boolean {
+export const VIEWER_AUTH_NOT_CONFIGURED_MESSAGE = 'viewer authentication is not configured';
+
+export function isSameOriginRequest(request: Request): boolean {
   const origin = request.headers.get('origin');
   const host = request.headers.get('host');
   if (!origin || !host) return true;
@@ -26,7 +28,7 @@ function requireHttpMutationContext(
   if (!request || !responseHeaders) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'HTTP response context is required' });
   }
-  if (!isSameOrigin(request)) {
+  if (!isSameOriginRequest(request)) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'cross-origin request is not allowed' });
   }
   return { request, responseHeaders };
@@ -44,7 +46,7 @@ export const authRouter = router({
     const { responseHeaders } = requireHttpMutationContext(ctx.request, ctx.responseHeaders);
     const viewerCode = process.env.VIEWER_CODE ?? process.env.VITE_VIEWER_CODE;
     if (!viewerCode) {
-      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'viewer authentication is not configured' });
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: VIEWER_AUTH_NOT_CONFIGURED_MESSAGE });
     }
 
     const codeHash = createHash('sha256').update(input.code, 'utf-8').digest();

--- a/apps/web/src/server/trpc/router/github-sheet.ts
+++ b/apps/web/src/server/trpc/router/github-sheet.ts
@@ -6,7 +6,7 @@ import { getCachedSheet, getCachedSheets } from '@/server/sheets-cache';
 import { router, viewerProcedure } from '../init';
 import { githubSheetPathInputSchema } from '../schema';
 
-// DB が正本で、この router は GitHub 由来の legacy 経路（/view/[path]・/compare）専用。
+// DB が正本で、この router は GitHub 由来の legacy 経路（/view/[path]）専用。
 export const githubSheetRouter = router({
   list: viewerProcedure.query(() => getCachedSheets()),
 
@@ -15,7 +15,7 @@ export const githubSheetRouter = router({
   // （sheet.byId と同じ理由。詳細はそちらのコメント参照）。
   //
   // path はここで isValidSheetPath / isSheetFileName を必ず通す。移行前は
-  // app/view/[path]/page.tsx と app/compare/page.tsx が notFound() で弾いていたが、
+  // app/view/[path]/page.tsx が notFound() で弾いていたが、
   // このチェックはページ側にしか無く router には無かった。/api/trpc は URL 直叩きが
   // できるため、ページの導線を経由しない任意の path（.. トラバーサルや
   // CLAUDE.md/AGENTS.md 等の AI 指示系ファイル）でも GitHub API へそのまま渡ってしまう。

--- a/apps/web/src/server/trpc/router/sheet.test.ts
+++ b/apps/web/src/server/trpc/router/sheet.test.ts
@@ -59,6 +59,7 @@ const getCachedDbSheetByIdMock = vi.mocked(getCachedDbSheetById);
 const getCachedDbSheetMock = vi.mocked(getCachedDbSheet);
 const revalidateTagMock = vi.mocked(revalidateTag);
 const MD = { type: 'markdown' as const, data: { markdown: 'x' } };
+const SHEET_ID = '00000000-0000-4000-8000-000000000001';
 
 // editorProcedure/viewerProcedure は middleware が ctx.getEditorUserId() / ctx.getIsViewer() を
 // 解決するだけなので、createTRPCContext()（cookies/headers 読み取り）を経由せず
@@ -231,6 +232,14 @@ describe('sheet.save', () => {
     expect(saveMock).not.toHaveBeenCalled();
   });
 
+  it('UUID でない sheetId は BAD_REQUEST を返し保存しない', async () => {
+    const caller = callerAs('owner');
+    await expect(caller.sheet.save({ title: 'T', blocks: [MD], sheetId: 'not-a-uuid' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
   it('ConflictError は CONFLICT に変換し、キャッシュは無効化しない', async () => {
     saveMock.mockRejectedValue(new ConflictError());
     const caller = callerAs('owner');
@@ -285,15 +294,21 @@ describe('sheet.create', () => {
 describe('sheet.delete', () => {
   it('非編集者は UNAUTHORIZED を返し削除しない', async () => {
     const caller = callerAs(null);
-    await expect(caller.sheet.delete({ sheetId: 's1' })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    await expect(caller.sheet.delete({ sheetId: SHEET_ID })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(deleteSheetMock).not.toHaveBeenCalled();
+  });
+
+  it('UUID でない sheetId は BAD_REQUEST を返し削除しない', async () => {
+    const caller = callerAs('owner');
+    await expect(caller.sheet.delete({ sheetId: 'not-a-uuid' })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     expect(deleteSheetMock).not.toHaveBeenCalled();
   });
 
   it('編集者は指定 sheetId を削除し、キャッシュを即時失効させる', async () => {
     const caller = callerAs('owner');
-    const result = await caller.sheet.delete({ sheetId: 's1' });
+    const result = await caller.sheet.delete({ sheetId: SHEET_ID });
     expect(result).toEqual({ ok: true });
-    expect(deleteSheetMock).toHaveBeenCalledWith('s1');
+    expect(deleteSheetMock).toHaveBeenCalledWith(SHEET_ID);
     expect(revalidateTagMock).toHaveBeenCalledWith('db-sheet', { expire: 0 });
   });
 });

--- a/apps/web/src/server/trpc/schema.ts
+++ b/apps/web/src/server/trpc/schema.ts
@@ -5,18 +5,19 @@ import { z } from 'zod';
 // 既存の isBlockInput（判別ユニオンの型ガード）を唯一の正本として z.custom で再利用する。
 // zod 側でユニオンをミラーすると二重管理になり必ずドリフトするため、ここでは張らない。
 const blockInputSchema = z.custom<BlockInput>(isBlockInput, { message: 'invalid block input' });
+const sheetIdSchema = z.uuid();
 
 // id は DB の uuid 列（packages/db/src/schema.ts）に対応する。形式が UUID でない値を
 // そのまま Drizzle/Postgres へ渡すと SQLSTATE 22P02（invalid input syntax for type uuid）が
 // throw され、is-config-error.ts の判定対象にも入っていないため 500 まで抜けてしまう
 // （Issue #196）。ここで弾いて sheet.byId 側の SkillSheetNotFoundError 経路（404）に
 // 合流させる。
-export const sheetIdInputSchema = z.object({ id: z.uuid() });
+export const sheetIdInputSchema = z.object({ id: sheetIdSchema });
 
 export const saveSheetInputSchema = z.object({
   title: z.string(),
   blocks: z.array(blockInputSchema),
-  sheetId: z.string().optional(),
+  sheetId: sheetIdSchema.optional(),
   // Server Actions のシリアライズ境界と同様、tRPC の HTTP 経路でも Date が
   // シリアライズを跨ぐ可能性があるため superjson 前提でも Date のまま受ける。
   expectedUpdatedAt: z.date().optional(),
@@ -27,7 +28,7 @@ export const createSheetInputSchema = z.object({
   templateId: z.string().optional(),
 });
 
-export const deleteSheetInputSchema = z.object({ sheetId: z.string() });
+export const deleteSheetInputSchema = z.object({ sheetId: sheetIdSchema });
 
 export const githubSheetPathInputSchema = z.object({ path: z.string() });
 

--- a/apps/web/src/server/trpc/schema.ts
+++ b/apps/web/src/server/trpc/schema.ts
@@ -10,8 +10,7 @@ const sheetIdSchema = z.uuid();
 // id は DB の uuid 列（packages/db/src/schema.ts）に対応する。形式が UUID でない値を
 // そのまま Drizzle/Postgres へ渡すと SQLSTATE 22P02（invalid input syntax for type uuid）が
 // throw され、is-config-error.ts の判定対象にも入っていないため 500 まで抜けてしまう
-// （Issue #196）。ここで弾いて sheet.byId 側の SkillSheetNotFoundError 経路（404）に
-// 合流させる。
+// （Issue #196）。ここで BAD_REQUEST として弾き、DB の SQLSTATE 22P02 / 500 を防ぐ。
 export const sheetIdInputSchema = z.object({ id: sheetIdSchema });
 
 export const saveSheetInputSchema = z.object({

--- a/apps/web/src/server/viewer-gate.ts
+++ b/apps/web/src/server/viewer-gate.ts
@@ -41,8 +41,8 @@ function cookieValue(cookieHeader: string, name: string): string | undefined {
 }
 
 /**
- * 閲覧 cookie だけを検証する。tRPC context は編集者判定を先に一度だけ行い、
- * 非編集者の場合にこの関数を呼ぶことで Better Auth の二重参照を避ける。
+ * 閲覧 cookie だけを検証する。tRPC context はこのローカル検証を先に行い、
+ * cookie が無効な場合だけ Better Auth の編集者判定へ進む。
  */
 async function resolveHasViewerSession(requestHeaders?: Headers): Promise<boolean> {
   const token = requestHeaders

--- a/doc/01-setup-and-routing.md
+++ b/doc/01-setup-and-routing.md
@@ -119,8 +119,9 @@ Next.js App Router では `apps/web/app` 配下のディレクトリ構造がそ
 export default async function SheetsListPage() {
   await connection(); // DATABASE_URL はランタイム専用。動的レンダリングを確保
   const caller = await createServerCaller();
-  const sheets = await caller.sheet.list();
-  return <DbSheetsListClient initialSheets={sheets} hasError={hasError} />;
+  const { canEdit } = await caller.auth.status();
+  const { sheets, stale } = await caller.sheet.list();
+  return <DbSheetsListClient initialSheets={sheets} errorKind={null} canEdit={canEdit} stale={stale} />;
 }
 ```
 


### PR DESCRIPTION
## Issue リンク / Link to Issue

<!-- quality-ok -->
関連Issueなし

### 概要

PR #179後のtRPC境界を再監査し、残った退行要因を修正しました。

- 閲覧cookieをDB認証より先に検証します。
- GitHub本文と編集者判定を分離します。
- 保存と削除のsheetIdをUUIDに限定します。
- 互換APIのorigin判定と500応答を整理します。
- 古いコメントとRSC文書例を現行実装へ合わせます。

### 見て欲しいポイント

- [ ] HMAC閲覧時にGitHub本文がDB認証を待たないこと
- [ ] 編集者判定後も編集ボタン領域がずれないこと
- [ ] 空ビルダーが新規シートとして保存できること
- [ ] 不正なsheetIdがDB到達前に拒否されること

### 見なくてもよいポイント

- [x] 環境変数と依存ライブラリに変更なし

### その他(あれば)

- [x] Biome 220ファイル通過
- [x] Web型チェック通過
- [x] 独立した敵対レビュー2件で100点

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **セキュリティ**
  - 不正なオリジンからの認証リクエストを、本文解析前に拒否するよう改善しました。
  - 認証・ログアウト時のエラーメッセージとステータスを明確化しました。

- **改善**
  - 閲覧ページで編集権限を判定後も、編集ボタンの表示領域が安定するよう改善しました。
  - 閲覧用認証を優先して判定し、不要な認証処理を抑制しました。
  - 空のシートIDを保存時に送信しないようにしました。

- **バリデーション**
  - シートの保存・削除に使用するIDをUUID形式に限定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->