### PR TITLE
docs: client.ts のコメントを日本語化（CodeRabbit指摘）

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,12 +1,12 @@
 /**
- * Drizzle client for Neon serverless Postgres.
+ * Neon serverless Postgres 用の Drizzle クライアント。
  *
- * Uses the WebSocket driver (`neon-serverless`) so the auth/edit path (Better
- * Auth) can run interactive transactions, and to avoid the
- * `@neondatabase/serverless` >=1.0 tagged-template incompatibility of the HTTP
- * driver. The pooled `DATABASE_URL` (`-pooler` host) is expected at runtime.
+ * 認証・編集パス（Better Auth）でインタラクティブなトランザクションを実行できるよう、
+ * また HTTP ドライバでの `@neondatabase/serverless` >=1.0 のタグ付きテンプレート非互換を
+ * 避けるため、WebSocket ドライバ（`neon-serverless`）を使用する。実行時にはプール接続用の
+ * `DATABASE_URL`（`-pooler` ホスト）を前提とする。
  *
- * Server-only. Never import this from a Client Component.
+ * サーバー専用。Client Component からは決して import しないこと。
  */
 import { neonConfig, Pool } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
@@ -31,9 +31,9 @@ export function createDb(databaseUrl: string) {
 let cachedDb: Database | null = null;
 
 /**
- * Returns a Drizzle client from `DATABASE_URL`, or throws if it is not configured.
- * The instance is cached at module scope to reuse it across warm serverless
- * invocations (`DATABASE_URL` is fixed for the process lifetime).
+ * `DATABASE_URL` から Drizzle クライアントを返す。未設定の場合は例外を投げる。
+ * warm な serverless 呼び出し間で再利用できるよう、モジュールスコープでインスタンスを
+ * キャッシュする（`DATABASE_URL` はプロセスの生存期間中は固定のため）。
  */
 export function getDb(): Database {
   if (cachedDb) {


### PR DESCRIPTION
## 概要

PR #171（マージ済み）のCodeRabbitレビューで指摘されていた `packages/db/src/client.ts` の英語コメントを日本語化する、未対応のまま残っていた最後の1件です。

PR #171の他のレビュー指摘（fonts.tsのP1ハイフン化対応・#151 opener open→close遷移テスト追加など）は、PR #171内の既存コミットで既に対応済みであることを確認しています。

### 変更内容

- `packages/db/src/client.ts` のモジュール先頭のJSDocコメント、および `getDb()` のJSDocコメントを日本語化（内容・ロジックの変更なし）

## 検証

- `pnpm -r type-check` — exit 0
- `pnpm lint` — exit 0（biome check、エラーなし）
- `pnpm --filter @skillsheet/db test` — 188件全て通過

コメントのみの変更のため、`apps/web` のテストへの影響はありません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrxT9nqCaB69Zs9x14ryMC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * データベース接続に関するコメントを日本語化しました。
  * WebSocket ドライバー、プール接続、サーバー専用利用、接続キャッシュの動作説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->