### PR TITLE
feat(migrate-real-sheet): #151 D-7 取り込みで捨てた行を検出して警告する

### DIFF
--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -173,6 +173,26 @@ describe('parseCareerMarkdown', () => {
     expect(dropped.some((d) => d.where.includes('重複したサブセクション'))).toBe(true);
   });
 
+  it.each([
+    'constructor',
+    'toString',
+    '__proto__',
+    'hasOwnProperty',
+  ])('サブセクション名が Object.prototype のプロパティ名(%s)でも停止せず検出できる（Codexレビュー P2）', (name) => {
+    const md = careerMarkdown('', ['', `#### ${name}`, '', '継承プロパティ名の見出しです。'].join('\n'));
+
+    // 通常のオブジェクトを使っていると、初回にもかかわらず重複と誤判定され
+    // 反復不能な値への for...of で TypeError となり移行全体が停止していた。
+    expect(() => parseCareerMarkdown(md)).not.toThrow();
+
+    const { items, dropped } = parseCareerMarkdown(md);
+    expect(items).toHaveLength(1);
+    expect(dropped.map((d) => d.line)).toContain('継承プロパティ名の見出しです。');
+    expect(dropped.some((d) => d.where.includes('未知のサブセクション'))).toBe(true);
+    // 初回なので「重複」としては報告しない。
+    expect(dropped.some((d) => d.where.includes('重複したサブセクション'))).toBe(false);
+  });
+
   it('空行と表の区切り行は捨てた行として報告しない', () => {
     const { dropped } = parseCareerMarkdown(careerMarkdown());
 

--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -276,6 +276,29 @@ describe('parseCareerMarkdown（プロジェクト概要の重複）', () => {
   });
 });
 
+describe('parseCareerMarkdown（列数のずれ）', () => {
+  it('技術スタックの3列目以降を検出する（Codexレビュー）', () => {
+    // parseTableRow は貪欲なので row 自体は取れてしまい、!row では検出できない。
+    const md = careerMarkdown().replace('| 言語 | TypeScript, Go |', '| 使用言語 | TypeScript | 業務利用 |');
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    // 誤って tools に 業務利用 だけが入る挙動を止め、行ごと警告に回す。
+    expect(items[0].tech.tools).not.toContain('業務利用');
+    expect(dropped.map((d) => d.line)).toContain('| 使用言語 | TypeScript | 業務利用 |');
+    expect(dropped[0].where).toContain('列が2つを超える');
+  });
+
+  it('担当工程で見出しが空の列の値を検出する（Codexレビュー）', () => {
+    const md = careerMarkdown()
+      .replace('| 総合テスト | 保守・運用 |', '| 総合テスト |  |')
+      .replace('| 経験 | ● |  | ● | ● |  |  |  |', '| 経験 | ● |  | ● | ● |  |  | 担当 |');
+    const { dropped } = parseCareerMarkdown(md);
+
+    expect(dropped.map((d) => d.line).join()).toContain('担当');
+    expect(dropped[0].where).toContain('未知の工程名');
+  });
+});
+
 describe('isTableSeparatorRow', () => {
   it.each([
     ['|---|---|', true],
@@ -440,17 +463,33 @@ describe('parseSkillsMarkdown', () => {
     expect(dropped[0].where).toContain('4列目以降');
   });
 
-  it('N年形式でない経験年数を検出する（Codexレビュー）', () => {
-    // years: 0 に潰れて元の表記が残らない。
+  it.each([
+    '6ヶ月',
+    '1年未満',
+    '1年6ヶ月',
+    '約1年',
+    '5年以上',
+    '経験あり',
+  ])('N年形式でない経験年数「%s」を検出する（Codexレビュー）', (raw) => {
+    // 部分一致だと 1年未満 / 1年6ヶ月 / 約1年 / 5年以上 が先頭の数字だけ拾い、
+    // 付加情報を失ったまま警告も出なかった。完全一致に変えて全て検出する。
     const dropped: DroppedLine[] = [];
     const skills = parseSkillsMarkdown(
-      SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', '| 言語 | TypeScript | 6ヶ月 |'),
+      SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', `| 言語 | TypeScript | ${raw} |`),
       dropped,
     );
 
     expect(skills[0].skills[0].years).toBe(0);
-    expect(dropped.map((d) => d.line)).toContain('TypeScript: 6ヶ月');
+    expect(dropped.map((d) => d.line)).toContain(`TypeScript: ${raw}`);
     expect(dropped[0].where).toContain('経験年数を解釈できない');
+  });
+
+  it('N年形式の経験年数は従来どおり取り込み、警告しない（誤検知しない）', () => {
+    const dropped: DroppedLine[] = [];
+    const skills = parseSkillsMarkdown(SKILLS_MD, dropped);
+
+    expect(skills[0].skills[0]).toMatchObject({ name: 'TypeScript', years: 5 });
+    expect(dropped).toEqual([]);
   });
 
   it('スキルが1件も無い技術分類を検出する（Codexレビュー）', () => {

--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { isTableSeparatorRow, parseCareerMarkdown } from './migrate-real-sheet';
+import {
+  type DroppedLine,
+  isTableSeparatorRow,
+  parseCareerMarkdown,
+  parseProfileMarkdown,
+  parseSkillsMarkdown,
+} from './migrate-real-sheet';
 
 /**
  * 案件1件分の最小 markdown。`extra` に渡した行を `#### プロジェクト概要` の直前
@@ -201,5 +207,125 @@ describe('parseCareerMarkdown', () => {
     expect(isTableSeparatorRow('| :--- | ---: |')).toBe(true);
     expect(isTableSeparatorRow('| 期間 | 2021年 |')).toBe(false);
     expect(isTableSeparatorRow('ふつうの文')).toBe(false);
+  });
+
+  it('会社見出しより前の想定外の見出しを検出する（Codexレビュー）', () => {
+    // `## 経歴` だけは main() が切り出しの起点にする想定済みの構造なので除外するが、
+    // それ以外の見出しは本文が無くてもどのフィールドにも入らない。
+    const md = careerMarkdown().replace('## 経歴', '## 経歴\n\n## 注意事項');
+    const { dropped } = parseCareerMarkdown(md);
+
+    expect(dropped.map((d) => d.line)).toContain('## 注意事項');
+    expect(dropped.map((d) => d.line)).not.toContain('## 経歴');
+  });
+
+  it('担当工程の未知の工程名は ● 以外のマーカーでも検出する（Codexレビュー）', () => {
+    const md = careerMarkdown()
+      .replace('| 総合テスト | 保守・運用 |', '| 総合テスト | 性能検証 |')
+      .replace('| 経験 | ● |  | ● | ● |  |  |  |', '| 経験 | ● |  | ● | ● |  |  | ○ |');
+    const { dropped } = parseCareerMarkdown(md);
+
+    expect(dropped.map((d) => d.line).join()).toContain('性能検証: ○');
+  });
+});
+
+// --- プロフィール／スキル ------------------------------------------------------------------
+const PROFILE_MD = [
+  '## 技術者プロファイル',
+  '',
+  '| 項目 | 内容 |',
+  '|---|---|',
+  '| 技術者名 | 山田太郎 |',
+  '| 年齢 | 30歳 |',
+  '',
+  '### 自己 PR',
+  '',
+  'ここは pr へそのまま入るので、表でなくても捨てた行にはなりません。',
+].join('\n');
+
+const SKILLS_MD = [
+  '<details>',
+  '',
+  '| 技術分類 | 技術名 | 経験年数 |',
+  '|---|---|---|',
+  '| 言語 | TypeScript | 5年 |',
+  '|  | Go | 2年 |',
+  '',
+  '</details>',
+].join('\n');
+
+describe('parseProfileMarkdown', () => {
+  it('正常なプロフィールでは1行も捨てない（誤検知しない）', () => {
+    const dropped: DroppedLine[] = [];
+    const profile = parseProfileMarkdown(PROFILE_MD, dropped);
+
+    expect(profile?.name).toBe('山田太郎');
+    expect(profile?.meta.age).toBe('30歳');
+    expect(profile?.pr).toContain('pr へそのまま入る');
+    expect(dropped).toEqual([]);
+  });
+
+  it('switch のどの case にも当たらないラベルを検出する（Codexレビュー P1）', () => {
+    const dropped: DroppedLine[] = [];
+    const profile = parseProfileMarkdown(PROFILE_MD.replace('| 年齢 | 30歳 |', '| 居住地 | 東京 |'), dropped);
+
+    // 居住地は ProfileMeta のどこにも入らない。
+    expect(profile?.meta.age).toBeUndefined();
+    expect(dropped.map((d) => d.line)).toContain('居住地: 東京');
+    expect(dropped[0].where).toContain('技術者プロファイル');
+  });
+
+  it('自己PR見出しより前の非テーブル行を検出する（Codexレビュー P1）', () => {
+    const dropped: DroppedLine[] = [];
+    parseProfileMarkdown(
+      PROFILE_MD.replace('| 項目 | 内容 |', '備考: この行は取り込まれません。\n| 項目 | 内容 |'),
+      dropped,
+    );
+
+    expect(dropped.map((d) => d.line)).toContain('備考: この行は取り込まれません。');
+  });
+});
+
+describe('parseSkillsMarkdown', () => {
+  it('正常なスキル表では1行も捨てない（誤検知しない）', () => {
+    const dropped: DroppedLine[] = [];
+    const skills = parseSkillsMarkdown(SKILLS_MD, dropped);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].skills.map((s) => s.name)).toEqual(['TypeScript', 'Go']);
+    expect(dropped).toEqual([]);
+  });
+
+  it('スキルセクション内の非テーブル行を検出する（Codexレビュー P1）', () => {
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(
+      SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', '注記: 一部は独学です。\n| 言語 | TypeScript | 5年 |'),
+      dropped,
+    );
+
+    expect(dropped.map((d) => d.line)).toContain('注記: 一部は独学です。');
+    expect(dropped[0].where).toContain('スキル・経験年数');
+  });
+
+  it('<details> が無い場合でも、次の ## 見出し以降を捨てた行として報告しない', () => {
+    // endIdx が文末まで伸びる経路。経歴セクション全体を警告に載せてしまわないことの確認。
+    const md = [
+      '## スキル・経験年数',
+      '',
+      '| 技術分類 | 技術名 | 経験年数 |',
+      '|---|---|---|',
+      '| 言語 | TypeScript | 5年 |',
+      '',
+      '## 経歴',
+      '',
+      'ここは経歴セクションなのでスキル側の警告対象外です。',
+      '### 株式会社サンプル - 2020年4月 - 現在',
+    ].join('\n');
+    const dropped: DroppedLine[] = [];
+    const skills = parseSkillsMarkdown(md, dropped);
+
+    expect(skills[0].skills.map((s) => s.name)).toEqual(['TypeScript']);
+    expect(dropped.map((d) => d.line)).not.toContain('ここは経歴セクションなのでスキル側の警告対象外です。');
+    expect(dropped).toEqual([]);
   });
 });

--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -203,10 +203,6 @@ describe('parseCareerMarkdown', () => {
     const { dropped } = parseCareerMarkdown(careerMarkdown());
 
     expect(dropped).toEqual([]);
-    expect(isTableSeparatorRow('|---|---|')).toBe(true);
-    expect(isTableSeparatorRow('| :--- | ---: |')).toBe(true);
-    expect(isTableSeparatorRow('| 期間 | 2021年 |')).toBe(false);
-    expect(isTableSeparatorRow('ふつうの文')).toBe(false);
   });
 
   it('会社見出しより前の想定外の見出しを検出する（Codexレビュー）', () => {
@@ -227,6 +223,46 @@ describe('parseCareerMarkdown', () => {
 
     expect(dropped.map((d) => d.line).join()).toContain('性能検証: ○');
   });
+
+  it('既知の工程列の解釈できないマーカーを検出する（Codexレビュー）', () => {
+    // 「要件定義: 担当」は process に変換されないまま失われる。
+    const md = careerMarkdown().replace('| 経験 | ● |  | ● | ● |  |  |  |', '| 経験 | 担当 |  |  |  |  |  |  |');
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    expect(items[0].process).toEqual([]);
+    expect(dropped.map((d) => d.line)).toContain('要件定義: 担当');
+    expect(dropped[0].where).toContain('解釈できないマーカー');
+  });
+
+  it('「経験なし」記号は解釈できないマーカーとして報告しない（誤検知しない）', () => {
+    const md = careerMarkdown().replace('| 経験 | ● |  | ● | ● |  |  |  |', '| 経験 | ● | - | ● | ● | × | ー | なし |');
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    expect(items[0].process).toEqual(['要件定義', '詳細設計', '実装']);
+    expect(dropped).toEqual([]);
+  });
+
+  it('ヘッダより列数が多いデータ行の余剰セルを検出する（CodeRabbitレビュー）', () => {
+    const md = careerMarkdown().replace(
+      '| 経験 | ● |  | ● | ● |  |  |  |',
+      '| 経験 | ● |  | ● | ● |  |  |  | 補足あり |',
+    );
+    const { dropped } = parseCareerMarkdown(md);
+
+    expect(dropped.map((d) => d.line)).toContain('補足あり');
+    expect(dropped[0].where).toContain('ヘッダに対応する列が無い');
+  });
+});
+
+describe('isTableSeparatorRow', () => {
+  it.each([
+    ['|---|---|', true],
+    ['| :--- | ---: |', true],
+    ['| 期間 | 2021年 |', false],
+    ['ふつうの文', false],
+  ])('%s → %s', (line, expected) => {
+    expect(isTableSeparatorRow(line)).toBe(expected);
+  });
 });
 
 // --- プロフィール／スキル ------------------------------------------------------------------
@@ -245,6 +281,7 @@ const PROFILE_MD = [
 
 const SKILLS_MD = [
   '<details>',
+  '<summary><h2>スキル・経験年数</h2></summary>',
   '',
   '| 技術分類 | 技術名 | 経験年数 |',
   '|---|---|---|',
@@ -284,6 +321,19 @@ describe('parseProfileMarkdown', () => {
 
     expect(dropped.map((d) => d.line)).toContain('備考: この行は取り込まれません。');
   });
+
+  it('同じ項目が重複したとき、上書きで失われる先行値を検出する（Codexレビュー）', () => {
+    const dropped: DroppedLine[] = [];
+    const profile = parseProfileMarkdown(
+      PROFILE_MD.replace('| 年齢 | 30歳 |', '| 年齢 | 30歳 |\n| 年齢 | 40歳 |'),
+      dropped,
+    );
+
+    // 後勝ちで上書きされる挙動自体は変えていない。
+    expect(profile?.meta.age).toBe('40歳');
+    expect(dropped.map((d) => d.line)).toContain('年齢: 30歳');
+    expect(dropped[0].where).toContain('重複した項目の上書き');
+  });
 });
 
 describe('parseSkillsMarkdown', () => {
@@ -305,6 +355,43 @@ describe('parseSkillsMarkdown', () => {
 
     expect(dropped.map((d) => d.line)).toContain('注記: 一部は独学です。');
     expect(dropped[0].where).toContain('スキル・経験年数');
+  });
+
+  it('列が3つ未満の行を検出する（CodeRabbitレビュー）', () => {
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', '| 言語 | TypeScript |'), dropped);
+
+    expect(dropped.map((d) => d.line)).toContain('| 言語 | TypeScript |');
+    expect(dropped[0].where).toContain('列が3つ未満');
+  });
+
+  it('技術分類も技術名も無く経験年数だけの行を検出する（CodeRabbitレビュー）', () => {
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(SKILLS_MD.replace('|  | Go | 2年 |', '|  |  | 2年 |'), dropped);
+
+    expect(dropped.some((d) => d.where.includes('技術名が無い'))).toBe(true);
+  });
+
+  it('技術分類が未確定のまま現れたスキル行を検出する（Codexレビュー P1）', () => {
+    // 先頭データ行に分類が無いと currentCategory が空のままで、flushCategory が
+    // ブロックを出さず次の分類行で消える。
+    const dropped: DroppedLine[] = [];
+    const skills = parseSkillsMarkdown(
+      SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', '|  | TypeScript | 5年 |'),
+      dropped,
+    );
+
+    expect(skills.flatMap((s) => s.skills.map((x) => x.name))).not.toContain('TypeScript');
+    expect(dropped.some((d) => d.where.includes('技術分類が未確定'))).toBe(true);
+    expect(dropped.map((d) => d.line).join()).toContain('TypeScript');
+  });
+
+  it('<summary> などの構造行は捨てた行として報告しない（Codexレビュー P2）', () => {
+    // 実シートと同じ <details><summary><h2>…</h2></summary> 形式でも誤検知しないこと。
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(SKILLS_MD, dropped);
+
+    expect(dropped).toEqual([]);
   });
 
   it('<details> が無い場合でも、次の ## 見出し以降を捨てた行として報告しない', () => {

--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTableSeparatorRow, parseCareerMarkdown } from './migrate-real-sheet';
+
+/**
+ * 案件1件分の最小 markdown。`extra` に渡した行を `#### プロジェクト概要` の直前
+ * （＝案件見出しの直後）へ差し込む。案件21の前置き一文と同じ位置。
+ */
+function careerMarkdown(extra = '', subsections = ''): string {
+  return [
+    '## 経歴',
+    '',
+    '### 株式会社サンプル - 2020年4月 - 現在',
+    '',
+    '#### ■ 1. PatentStart',
+    extra,
+    '#### プロジェクト概要',
+    '',
+    '| 項目 | 内容 |',
+    '|---|---|',
+    '| 期間 | 2021年1月 - 2021年12月 |',
+    '| 役割 | **バックエンド** |',
+    '',
+    '#### 技術スタック',
+    '',
+    '| 項目 | 内容 |',
+    '|---|---|',
+    '| 言語 | TypeScript, Go |',
+    '',
+    '#### コメント',
+    '',
+    '≪担当業務≫',
+    'API の設計と実装。',
+    '',
+    '≪コメント≫',
+    'チームで進めた。',
+    subsections,
+  ].join('\n');
+}
+
+describe('parseCareerMarkdown', () => {
+  it('案件見出しと最初のサブセクションの間に置かれた前置き文を捨てずに検出する（#151 D-7）', () => {
+    const preface = 'App Store から、PatentStart と検索すると、赤いアプリが表示されます。';
+    const { items, dropped } = parseCareerMarkdown(careerMarkdown(preface));
+
+    expect(items).toHaveLength(1);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].line).toBe(preface);
+    expect(dropped[0].where).toContain('PatentStart');
+    expect(dropped[0].where).toContain('冒頭');
+  });
+
+  it('前置き文が無い正常な元データでは1行も捨てない（誤検知しない）', () => {
+    const { items, dropped } = parseCareerMarkdown(careerMarkdown());
+
+    expect(items).toHaveLength(1);
+    expect(dropped).toEqual([]);
+  });
+
+  it('≪担当業務≫ の前に置かれた前置き文はコメントへ取り込まれ、捨てた行にはならない', () => {
+    // parseCommentSection 側で拾われる位置（#### コメント の中）は取り込み済みなので警告しない。
+    const md = careerMarkdown().replace('≪担当業務≫', '導入文です。\n\n≪担当業務≫');
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    expect(items[0].comment).toContain('導入文です。');
+    expect(dropped).toEqual([]);
+  });
+
+  it('誰も読まない未知のサブセクションの中身を検出する', () => {
+    const { dropped } = parseCareerMarkdown(careerMarkdown('', ['', '#### 備考', '', '社外秘の補足。'].join('\n')));
+
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].line).toBe('社外秘の補足。');
+    expect(dropped[0].where).toContain('備考');
+  });
+
+  it('プロジェクト概要の中で表の行として解釈できない自由文を検出する', () => {
+    const md = careerMarkdown().replace('| 期間 | 2021年1月 - 2021年12月 |', '補足: 途中で体制が変わりました。');
+    const { dropped } = parseCareerMarkdown(md);
+
+    expect(dropped.map((d) => d.line)).toContain('補足: 途中で体制が変わりました。');
+    expect(dropped[0].where).toContain('プロジェクト概要');
+  });
+
+  it('最初の会社見出しより前に置かれた行を検出する', () => {
+    const md = [
+      '## 経歴',
+      '',
+      'ここに書いた文はどこにも入りません。',
+      '',
+      ...careerMarkdown().split('\n').slice(2),
+    ].join('\n');
+    const { dropped } = parseCareerMarkdown(md);
+
+    expect(dropped.map((d) => d.line)).toContain('ここに書いた文はどこにも入りません。');
+  });
+
+  it('会社見出しより前に置かれた案件は丸ごと捨てられるので検出する', () => {
+    const md = [
+      '## 経歴',
+      '',
+      '#### ■ 1. 迷子の案件',
+      '',
+      '本文が入っています。',
+      '',
+      ...careerMarkdown().split('\n').slice(2),
+    ].join('\n');
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    // 会社に紐づく案件だけが取り込まれる。
+    expect(items).toHaveLength(1);
+    expect(dropped.map((d) => d.line)).toContain('■ 1. 迷子の案件');
+    expect(dropped.map((d) => d.line)).toContain('本文が入っています。');
+  });
+
+  it('空行と表の区切り行は捨てた行として報告しない', () => {
+    const { dropped } = parseCareerMarkdown(careerMarkdown());
+
+    expect(dropped).toEqual([]);
+    expect(isTableSeparatorRow('|---|---|')).toBe(true);
+    expect(isTableSeparatorRow('| :--- | ---: |')).toBe(true);
+    expect(isTableSeparatorRow('| 期間 | 2021年 |')).toBe(false);
+    expect(isTableSeparatorRow('ふつうの文')).toBe(false);
+  });
+});

--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -27,6 +27,12 @@ function careerMarkdown(extra = '', subsections = ''): string {
     '|---|---|',
     '| 言語 | TypeScript, Go |',
     '',
+    '#### 担当工程',
+    '',
+    '| 工程 | 要件定義 | 基本設計 | 詳細設計 | 実装・単体 | 結合テスト | 総合テスト | 保守・運用 |',
+    '|---|---|---|---|---|---|---|---|',
+    '| 経験 | ● |  | ● | ● |  |  |  |',
+    '',
     '#### コメント',
     '',
     '≪担当業務≫',
@@ -111,6 +117,60 @@ describe('parseCareerMarkdown', () => {
     expect(items).toHaveLength(1);
     expect(dropped.map((d) => d.line)).toContain('■ 1. 迷子の案件');
     expect(dropped.map((d) => d.line)).toContain('本文が入っています。');
+  });
+
+  it('担当工程が正しく取り込まれ、その際に捨てた行は出ない', () => {
+    const { items, dropped } = parseCareerMarkdown(careerMarkdown());
+
+    expect(items[0].process).toEqual(['要件定義', '詳細設計', '実装']);
+    expect(dropped).toEqual([]);
+  });
+
+  it('担当工程の中の自由文を検出する（Codexレビュー P1）', () => {
+    const md = careerMarkdown().replace(
+      '| 経験 | ● |  | ● | ● |  |  |  |',
+      '補足: 一部は他社が担当。\n| 経験 | ● |  | ● | ● |  |  |  |',
+    );
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    // 表そのものは従来どおり読めている。
+    expect(items[0].process).toEqual(['要件定義', '詳細設計', '実装']);
+    expect(dropped.map((d) => d.line)).toContain('補足: 一部は他社が担当。');
+    expect(dropped[0].where).toContain('担当工程');
+  });
+
+  it('担当工程の3行目以降は解釈されないので検出する（Codexレビュー P1）', () => {
+    const md = careerMarkdown().replace(
+      '| 経験 | ● |  | ● | ● |  |  |  |',
+      '| 経験 | ● |  | ● | ● |  |  |  |\n| 補足 | ▲ |  |  |  |  |  |  |',
+    );
+    const { dropped } = parseCareerMarkdown(md);
+
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].line).toContain('補足');
+    expect(dropped[0].where).toContain('3行目以降');
+  });
+
+  it('担当工程の未知の工程名に●が立っていれば検出する（Codexレビュー P1）', () => {
+    const md = careerMarkdown().replace('| 総合テスト | 保守・運用 |', '| 総合テスト | 性能検証 |');
+    const { dropped } = parseCareerMarkdown(
+      md.replace('| 経験 | ● |  | ● | ● |  |  |  |', '| 経験 | ● |  | ● | ● |  |  | ● |'),
+    );
+
+    expect(dropped.map((d) => d.line).join()).toContain('性能検証');
+    expect(dropped[0].where).toContain('未知の工程名');
+  });
+
+  it('同名サブセクションが重複したとき、上書きで失われる先行内容を検出する（Codexレビュー P2）', () => {
+    const md = `${careerMarkdown()}\n\n#### コメント\n\n≪コメント≫\n後から書いた方だけが残ります。`;
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    // 後勝ちで上書きされる挙動自体は変えていない。
+    expect(items[0].comment).toContain('後から書いた方だけが残ります。');
+    expect(items[0].comment).not.toContain('チームで進めた。');
+    // 失われた先行内容が警告に出る。
+    expect(dropped.map((d) => d.line)).toContain('チームで進めた。');
+    expect(dropped.some((d) => d.where.includes('重複したサブセクション'))).toBe(true);
   });
 
   it('空行と表の区切り行は捨てた行として報告しない', () => {

--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -81,9 +81,16 @@ describe('parseCareerMarkdown', () => {
   it('誰も読まない未知のサブセクションの中身を検出する', () => {
     const { dropped } = parseCareerMarkdown(careerMarkdown('', ['', '#### 備考', '', '社外秘の補足。'].join('\n')));
 
-    expect(dropped).toHaveLength(1);
-    expect(dropped[0].line).toBe('社外秘の補足。');
-    expect(dropped[0].where).toContain('備考');
+    // 見出し行と本文の両方が失われるので、両方を報告する。
+    expect(dropped.map((d) => d.line)).toEqual(['#### 備考', '社外秘の補足。']);
+    expect(dropped.every((d) => d.where.includes('備考'))).toBe(true);
+  });
+
+  it('本文が空の未知サブセクションでも見出し行を検出する（Codexレビュー）', () => {
+    // 子行が無いと、見出しだけ記録する経路が無ければ dropped が空になる。
+    const { dropped } = parseCareerMarkdown(careerMarkdown('', ['', '#### 備考', ''].join('\n')));
+
+    expect(dropped.map((d) => d.line)).toEqual(['#### 備考']);
   });
 
   it('プロジェクト概要の中で表の行として解釈できない自由文を検出する', () => {
@@ -254,6 +261,21 @@ describe('parseCareerMarkdown', () => {
   });
 });
 
+describe('parseCareerMarkdown（プロジェクト概要の重複）', () => {
+  it('単一値フィールドが重複したとき、上書きで失われる先行値を検出する（Codexレビュー）', () => {
+    const md = careerMarkdown().replace(
+      '| 役割 | **バックエンド** |',
+      '| 役割 | **バックエンド** |\n| 役割 | **フロントエンド** |',
+    );
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    // 後勝ちで上書きされる挙動自体は変えていない。
+    expect(items[0].role).toBe('フロントエンド');
+    expect(dropped.map((d) => d.line)).toContain('役割: バックエンド');
+    expect(dropped[0].where).toContain('重複した項目の上書き');
+  });
+});
+
 describe('isTableSeparatorRow', () => {
   it.each([
     ['|---|---|', true],
@@ -384,6 +406,72 @@ describe('parseSkillsMarkdown', () => {
     expect(skills.flatMap((s) => s.skills.map((x) => x.name))).not.toContain('TypeScript');
     expect(dropped.some((d) => d.where.includes('技術分類が未確定'))).toBe(true);
     expect(dropped.map((d) => d.line).join()).toContain('TypeScript');
+  });
+
+  it('想定外のHTML見出しは構造行として除外しない（Codexレビュー）', () => {
+    // タグ名だけで除外していると <h3>補足</h3> のような内容行を見逃す。
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(
+      SKILLS_MD.replace('| 技術分類 | 技術名 | 経験年数 |', '<h3>補足</h3>\n| 技術分類 | 技術名 | 経験年数 |'),
+      dropped,
+    );
+
+    expect(dropped.map((d) => d.line)).toContain('<h3>補足</h3>');
+  });
+
+  it('<details> 内の ## 見出し以降も検査する（Codexレビュー）', () => {
+    // 見出しでの打ち切りはフォールバック経路限定。<details> があるときに適用すると逆に取りこぼす。
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(SKILLS_MD.replace('</details>', '## 補足\n\nここは取り込まれません。\n\n</details>'), dropped);
+
+    expect(dropped.map((d) => d.line)).toContain('ここは取り込まれません。');
+  });
+
+  it('4列目以降の値を検出する（Codexレビュー）', () => {
+    const dropped: DroppedLine[] = [];
+    const skills = parseSkillsMarkdown(
+      SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', '| 言語 | TypeScript | 5年 | 業務利用 |'),
+      dropped,
+    );
+
+    // 先頭3セルは従来どおり読めている。
+    expect(skills[0].skills[0]).toMatchObject({ name: 'TypeScript', years: 5 });
+    expect(dropped.map((d) => d.line)).toContain('業務利用');
+    expect(dropped[0].where).toContain('4列目以降');
+  });
+
+  it('N年形式でない経験年数を検出する（Codexレビュー）', () => {
+    // years: 0 に潰れて元の表記が残らない。
+    const dropped: DroppedLine[] = [];
+    const skills = parseSkillsMarkdown(
+      SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', '| 言語 | TypeScript | 6ヶ月 |'),
+      dropped,
+    );
+
+    expect(skills[0].skills[0].years).toBe(0);
+    expect(dropped.map((d) => d.line)).toContain('TypeScript: 6ヶ月');
+    expect(dropped[0].where).toContain('経験年数を解釈できない');
+  });
+
+  it('スキルが1件も無い技術分類を検出する（Codexレビュー）', () => {
+    // 分類行だけがあり、次の分類まで技術名が現れないと flushCategory が黙って捨てる。
+    const md = [
+      '<details>',
+      '<summary><h2>スキル・経験年数</h2></summary>',
+      '',
+      '| 技術分類 | 技術名 | 経験年数 |',
+      '|---|---|---|',
+      '| インフラ |  |  |',
+      '| 言語 | TypeScript | 5年 |',
+      '',
+      '</details>',
+    ].join('\n');
+    const dropped: DroppedLine[] = [];
+    const skills = parseSkillsMarkdown(md, dropped);
+
+    expect(skills.map((s) => s.category)).toEqual(['言語']);
+    expect(dropped.some((d) => d.where.includes('スキルが1件も無い技術分類'))).toBe(true);
+    expect(dropped.map((d) => d.line).join()).toContain('インフラ');
   });
 
   it('<summary> などの構造行は捨てた行として報告しない（Codexレビュー P2）', () => {

--- a/packages/db/scripts/migrate-real-sheet.test.ts
+++ b/packages/db/scripts/migrate-real-sheet.test.ts
@@ -299,6 +299,45 @@ describe('parseCareerMarkdown（列数のずれ）', () => {
   });
 });
 
+describe('parseCareerMarkdown（担当工程の取りこぼし）', () => {
+  it('●に付随する注記を検出する（Codexレビュー）', () => {
+    const md = careerMarkdown().replace(
+      '| 経験 | ● |  | ● | ● |  |  |  |',
+      '| 経験 | ●（一部担当） |  | ● | ● |  |  |  |',
+    );
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    // 工程そのものは従来どおり取り込む。
+    expect(items[0].process).toEqual(['要件定義', '詳細設計', '実装']);
+    expect(dropped.map((d) => d.line).join()).toContain('一部担当');
+    expect(dropped[0].where).toContain('●に付随する注記');
+  });
+
+  it('先頭セルに紛れた注記を検出する（Codexレビュー）', () => {
+    const md = careerMarkdown().replace('| 経験 | ● |', '| 経験（主担当） | ● |');
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    expect(items[0].process).toEqual(['要件定義', '詳細設計', '実装']);
+    expect(dropped.map((d) => d.line)).toContain('経験（主担当）');
+    expect(dropped[0].where).toContain('想定外の行ラベル');
+  });
+
+  it('区切り行に紛れた値を検出する（Codexレビュー）', () => {
+    const md = careerMarkdown().replace('|---|---|---|---|---|---|---|---|', '|---|---|重要注記|---|---|---|---|---|');
+    const { items, dropped } = parseCareerMarkdown(md);
+
+    expect(items[0].process).toEqual(['要件定義', '詳細設計', '実装']);
+    expect(dropped.map((d) => d.line)).toContain('重要注記');
+    expect(dropped[0].where).toContain('区切り行に紛れた値');
+  });
+
+  it('標準的な 工程 / 経験 の先頭セルは報告しない（誤検知しない）', () => {
+    const { dropped } = parseCareerMarkdown(careerMarkdown());
+
+    expect(dropped).toEqual([]);
+  });
+});
+
 describe('isTableSeparatorRow', () => {
   it.each([
     ['|---|---|', true],
@@ -511,6 +550,30 @@ describe('parseSkillsMarkdown', () => {
     expect(skills.map((s) => s.category)).toEqual(['言語']);
     expect(dropped.some((d) => d.where.includes('スキルが1件も無い技術分類'))).toBe(true);
     expect(dropped.map((d) => d.line).join()).toContain('インフラ');
+  });
+
+  it('技術分類がある行でも技術名が無ければ経験年数を検出する（Codexレビュー）', () => {
+    // `| 言語 |  | 5年 |` の後にスキル行が続くと空分類検査も発火せず 5年 が消えていた。
+    const md = SKILLS_MD.replace('| 言語 | TypeScript | 5年 |', '| 言語 |  | 5年 |\n| | TypeScript | 3年 |');
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(md, dropped);
+
+    expect(dropped.map((d) => d.line)).toContain('| 言語 |  | 5年 |');
+    expect(dropped[0].where).toContain('技術名が無い');
+  });
+
+  it('セクション名を含むだけの想定外見出しは構造行として除外しない（Codexレビュー）', () => {
+    // 部分一致だと「スキル・経験年数の注意事項」まで構造行と誤判定して見逃す。
+    const dropped: DroppedLine[] = [];
+    parseSkillsMarkdown(
+      SKILLS_MD.replace(
+        '| 技術分類 | 技術名 | 経験年数 |',
+        '<h3>スキル・経験年数の注意事項</h3>\n| 技術分類 | 技術名 | 経験年数 |',
+      ),
+      dropped,
+    );
+
+    expect(dropped.map((d) => d.line)).toContain('<h3>スキル・経験年数の注意事項</h3>');
   });
 
   it('<summary> などの構造行は捨てた行として報告しない（Codexレビュー P2）', () => {

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -233,8 +233,16 @@ function parseProcessSection(lines: string[], dropped: DroppedLine[] = [], where
       // PROCESS_HEADER_ORDER に無い工程名の列は、どの工程にも対応づかないため値ごと失われる。
       // ● 以外（○ / 担当 / 注記など）でも失われることに変わりはないので、非空なら
       // マーカーの種類を問わず記録する（Codexレビュー指摘）。
+      // 見出しセルが空でもデータセルに値があれば、その値は失われる。`label &&` で弾くと
+      // `| 工程 | 要件定義 | |` と `| 経験 | | 担当 |` の組が素通りする（Codexレビュー指摘）。
       const unknownCell = (data[i] ?? '').trim();
-      if (label && unknownCell) recordDropped(dropped, `${at}（未知の工程名）`, `${label}: ${unknownCell}`);
+      if (unknownCell) {
+        recordDropped(
+          dropped,
+          `${at}（未知の工程名）`,
+          label ? `${label}: ${unknownCell}` : `${i + 1}列目: ${unknownCell}`,
+        );
+      }
       continue;
     }
     const cell = data[i] ?? '';
@@ -391,6 +399,18 @@ function parseProjectBlock(
     const row = parseTableRow(line);
     if (!row) {
       recordDropped(dropped, `${where} の「技術スタック」（表の行として解釈できない）`, line);
+      continue;
+    }
+    // parseTableRow の正規表現は貪欲なので、3セル以上あっても失敗せず「最後のセル以外」を
+    // まとめてラベルとして返す。`| 使用言語 | TypeScript | 業務利用 |` は TypeScript が
+    // lang から消えて 業務利用 だけが tools に入るため、!row では検出できない
+    // （Codexレビュー指摘）。
+    const rawCells = line
+      .split('|')
+      .slice(1, -1)
+      .map((c) => c.trim());
+    if (rawCells.length > 2 && !isTableSeparatorRow(line)) {
+      recordDropped(dropped, `${where} の「技術スタック」（列が2つを超える）`, line);
       continue;
     }
     const [label, value] = row;
@@ -689,9 +709,10 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
       if (report) recordDropped(dropped, `${at}（技術分類が未確定）`, line);
       continue;
     }
-    const yearsMatch = yearsRaw.match(/(\d+(?:\.\d+)?)\s*年/);
-    // `6ヶ月` `1年未満` `経験あり` のような表記は years: 0 に潰れ、元の値が残らない
-    // （Codexレビュー指摘）。
+    // 部分一致にすると `1年未満` `1年6ヶ月` `約1年` が先頭の `1年` だけ拾って years: 1 になり、
+    // 「未満」「6ヶ月」「約」という付加情報を失ったまま警告も出ない。許容する `N年` 形式へ
+    // 完全一致させ、それ以外は解釈できない値として記録する（Codexレビュー指摘）。
+    const yearsMatch = yearsRaw.match(/^(\d+(?:\.\d+)?)\s*年$/);
     if (report && yearsRaw && !yearsMatch) {
       recordDropped(dropped, `${at}（経験年数を解釈できない）`, `${skillName}: ${yearsRaw}`);
     }

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -176,26 +176,44 @@ const PROCESS_HEADER_ORDER = [
 // normalizeProcess が該当工程を other 扱いにしてしまい、集計から丸ごと消える）。
 const PROCESS_BUILDER_VOCAB = ['要件定義', '基本設計', '詳細設計', '実装', '結合テスト', '総合テスト', '運用・保守'];
 
-function parseProcessSection(lines: string[]): string[] {
+function parseProcessSection(lines: string[], dropped: DroppedLine[] = [], where = ''): string[] {
   // ヘッダ行 "| 工程 | 要件定義 | ... |" とデータ行 "| 経験 | ● | ... |" を探す。
+  const at = `${where} の「担当工程」`;
   const rows: string[][] = [];
   for (const line of lines) {
     const cells = line
       .split('|')
       .slice(1, -1)
       .map((c) => c.trim());
-    if (cells.length === 0) continue;
+    // 表の行でない自由文はこの関数が一切解釈しないため、記録して警告に回す（Codexレビュー指摘）。
+    if (cells.length === 0) {
+      recordDropped(dropped, `${at}（表の行ではない）`, line);
+      continue;
+    }
     if (/^:?-+:?$/.test(cells[0])) continue;
     rows.push(cells);
   }
-  if (rows.length < 2) return [];
+  const asLine = (row: string[]) => `| ${row.join(' | ')} |`;
+  if (rows.length < 2) {
+    // ヘッダ行だけ等、対で揃っていない場合は何も取り込まれない。
+    for (const row of rows) recordDropped(dropped, `${at}（ヘッダ行とデータ行が揃っていない）`, asLine(row));
+    return [];
+  }
+  // 解釈するのは先頭2行（ヘッダ＋データ）だけで、3行目以降は読まれないまま捨てられる。
+  for (const row of rows.slice(2)) recordDropped(dropped, `${at}（3行目以降は解釈されない）`, asLine(row));
+
   const header = rows[0];
   const data = rows[1];
   const result: string[] = [];
   for (let i = 1; i < header.length; i++) {
     const label = header[i];
     const idx = PROCESS_HEADER_ORDER.indexOf(label);
-    if (idx === -1) continue;
+    if (idx === -1) {
+      // PROCESS_HEADER_ORDER に無い工程名は、● が立っていてもどの工程にも対応づかず失われる。
+      if (label && (data[i] ?? '').includes('●'))
+        recordDropped(dropped, `${at}（未知の工程名）`, `${label}: ${data[i]}`);
+      continue;
+    }
     const cell = data[i] ?? '';
     if (cell.includes('●')) result.push(PROCESS_BUILDER_VOCAB[idx]);
   }
@@ -275,6 +293,12 @@ function parseProjectBlock(
     const m = line.match(/^####\s*(.+)$/);
     if (m) {
       current = m[1].trim();
+      // 同名のサブセクション見出しが再度現れると、それまで溜めた行は上書きで失われる。
+      // 上書き後の sections を見るだけでは検出できないため、ここで記録する（Codexレビュー指摘）。
+      const overwritten = sections[current];
+      if (overwritten) {
+        for (const prev of overwritten) recordDropped(dropped, `${where} の重複したサブセクション「${current}」`, prev);
+      }
       sections[current] = [];
       continue;
     }
@@ -318,7 +342,7 @@ function parseProjectBlock(
     tech[bucket].push(...splitTechValues(value));
   }
 
-  const process = parseProcessSection(sections.担当工程 ?? []);
+  const process = parseProcessSection(sections.担当工程 ?? [], dropped, where);
 
   const commentText = (sections.コメント ?? []).join('\n');
   const { duties, acquired, comment } = parseCommentSection(commentText);

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -287,7 +287,11 @@ function parseProjectBlock(
   const where = `案件「${title}」`;
 
   // サブセクションごとに分割 (#### プロジェクト概要 / #### 技術スタック / #### 担当工程 / #### コメント)
-  const sections: Record<string, string[]> = {};
+  // null プロトタイプで作る。通常のオブジェクトだと `#### constructor` や `#### toString`
+  // のような見出しに対して sections[current] が Object.prototype 由来の値（関数など）を
+  // 返し、初回にもかかわらず重複と誤判定した上、反復不能な値への for...of で移行全体が
+  // TypeError で停止する（Codexレビュー指摘）。
+  const sections: Record<string, string[]> = Object.create(null);
   let current: string | null = null;
   for (const line of bodyLines) {
     const m = line.match(/^####\s*(.+)$/);

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -9,7 +9,7 @@
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type {
   BlockInput,
@@ -27,7 +27,9 @@ const SHEET_TITLE = 'エンジニアスキルシート';
 function loadWebEnvLocal(): void {
   const here = dirname(fileURLToPath(import.meta.url));
   const envPath = resolve(here, '../../../apps/web/.env.local');
-  if (!existsSync(envPath)) throw new Error(`apps/web/.env.local が見つかりません: ${envPath}`);
+  // テストからこのモジュールを import したときに throw しないよう、無ければ黙って返す。
+  // 実行に必要な環境変数が欠けている場合は main() 側で明示的に停止する。
+  if (!existsSync(envPath)) return;
   const content = readFileSync(envPath, 'utf-8');
   for (const line of content.split('\n')) {
     const trimmed = line.trim();
@@ -66,6 +68,32 @@ function parseTableRow(line: string): [string, string] | null {
 function stripBold(s: string): string {
   return s.replace(/\*\*/g, '').trim();
 }
+
+// --- 取り込みで捨てられた行の検出 ----------------------------------------------------------
+// 元データに想定外の構造（見出しより前の自由文・未知のサブセクション等）があると、
+// パーサはその行をどのフィールドにも入れないまま黙って落とす。案件21の前置き一文が
+// DB から消えていた #151 D-7 が実例で、同じ構造の元データが他にもありうるため、
+// 捨てた行を集めて取り込み時に警告する。
+export type DroppedLine = { where: string; line: string };
+
+/** `|---|:---:|` のような表の区切り行。データではないため捨てても警告しない。 */
+export function isTableSeparatorRow(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) return false;
+  const cells = trimmed.split('|').slice(1, -1);
+  return cells.length > 0 && cells.every((c) => /^:?-+:?$/.test(c.trim()));
+}
+
+/** 空行と表の区切り行を除いた「本来データだったはずの行」だけを記録する。 */
+function recordDropped(dropped: DroppedLine[], where: string, line: string): void {
+  if (!line.trim()) return;
+  if (isTableSeparatorRow(line)) return;
+  dropped.push({ where, line: line.trim() });
+}
+
+// parseProjectBlock が実際に読むサブセクション。これ以外の見出しは誰も参照しないため、
+// 中身が丸ごと失われる（例: `#### 備考`）。
+const KNOWN_SUBSECTIONS = ['プロジェクト概要', '技術スタック', '担当工程', 'コメント'];
 
 // 末尾の "(3 ヶ月間)" / "（継続中）" 等の注記を取り除く。
 function stripTrailingAnnotation(s: string): string {
@@ -231,8 +259,14 @@ function parseCompanyHeading(text: string): { name: string; period: string } {
 }
 
 // --- プロジェクト1件分（見出し行の次から次の ■ or ### まで）のパース -----------------------
-function parseProjectBlock(headingText: string, bodyLines: string[], companyId: string): ProjectItem {
+function parseProjectBlock(
+  headingText: string,
+  bodyLines: string[],
+  companyId: string,
+  dropped: DroppedLine[] = [],
+): ProjectItem {
   const { title, scope } = parseProjectHeading(headingText);
+  const where = `案件「${title}」`;
 
   // サブセクションごとに分割 (#### プロジェクト概要 / #### 技術スタック / #### 担当工程 / #### コメント)
   const sections: Record<string, string[]> = {};
@@ -245,6 +279,13 @@ function parseProjectBlock(headingText: string, bodyLines: string[], companyId: 
       continue;
     }
     if (current) sections[current].push(line);
+    // 最初のサブセクション見出しより前に書かれた行は、どのフィールドにも入らず捨てられる。
+    else recordDropped(dropped, `${where} の冒頭（サブセクション見出しより前）`, line);
+  }
+
+  for (const [name, sectionLines] of Object.entries(sections)) {
+    if (KNOWN_SUBSECTIONS.includes(name)) continue;
+    for (const line of sectionLines) recordDropped(dropped, `${where} の未知のサブセクション「${name}」`, line);
   }
 
   let period = '';
@@ -253,7 +294,10 @@ function parseProjectBlock(headingText: string, bodyLines: string[], companyId: 
   const overviewExtra: string[] = [];
   for (const line of sections.プロジェクト概要 ?? []) {
     const row = parseTableRow(line);
-    if (!row) continue;
+    if (!row) {
+      recordDropped(dropped, `${where} の「プロジェクト概要」（表の行として解釈できない）`, line);
+      continue;
+    }
     const [label, value] = row;
     if (label === '期間') period = normalizePeriod(value);
     else if (label === '役割') role = stripBold(value);
@@ -264,7 +308,10 @@ function parseProjectBlock(headingText: string, bodyLines: string[], companyId: 
   const tech = emptyTech();
   for (const line of sections.技術スタック ?? []) {
     const row = parseTableRow(line);
-    if (!row) continue;
+    if (!row) {
+      recordDropped(dropped, `${where} の「技術スタック」（表の行として解釈できない）`, line);
+      continue;
+    }
     const [label, value] = row;
     if (label === '項目') continue; // ヘッダ行
     const bucket = TECH_LABEL_MAP[label] ?? 'tools';
@@ -293,10 +340,15 @@ function parseProjectBlock(headingText: string, bodyLines: string[], companyId: 
 }
 
 // --- 全体パース：会社ごとに分割 → 各会社内のプロジェクトごとに分割 -------------------------
-function parseCareerMarkdown(markdown: string): { companies: CompanyInfo[]; items: ProjectItem[] } {
+export function parseCareerMarkdown(markdown: string): {
+  companies: CompanyInfo[];
+  items: ProjectItem[];
+  dropped: DroppedLine[];
+} {
   const lines = markdown.split('\n');
   const companies: CompanyInfo[] = [];
   const items: ProjectItem[] = [];
+  const dropped: DroppedLine[] = [];
 
   let currentCompanyId: string | null = null;
   let currentCompanyIntro: string[] = [];
@@ -305,7 +357,11 @@ function parseCareerMarkdown(markdown: string): { companies: CompanyInfo[]; item
 
   const flushProject = () => {
     if (currentProjectHeading !== null && currentCompanyId !== null) {
-      items.push(parseProjectBlock(currentProjectHeading, currentProjectBody, currentCompanyId));
+      items.push(parseProjectBlock(currentProjectHeading, currentProjectBody, currentCompanyId, dropped));
+    } else if (currentProjectHeading !== null) {
+      // 会社見出しより前に現れた案件はどの会社にも紐づけられず、見出しごと丸ごと捨てられる。
+      recordDropped(dropped, '会社見出しより前の案件', currentProjectHeading);
+      for (const line of currentProjectBody) recordDropped(dropped, '会社見出しより前の案件', line);
     }
     currentProjectHeading = null;
     currentProjectBody = [];
@@ -339,6 +395,11 @@ function parseCareerMarkdown(markdown: string): { companies: CompanyInfo[]; item
       currentProjectBody.push(line);
     } else if (currentCompanyId !== null) {
       currentCompanyIntro.push(line);
+    } else if (!/^#{1,6}\s/.test(line)) {
+      // 最初の会社見出し(###)より前の自由文は、会社にも案件にも属さないまま捨てられる。
+      // `## 経歴` のような見出し行は構造であってデータではないため対象外にする
+      // （含めると毎回必ず警告が出て、本当の取りこぼしが埋もれる）。
+      recordDropped(dropped, '最初の会社見出しより前', line);
     }
   }
   flushProject();
@@ -347,7 +408,7 @@ function parseCareerMarkdown(markdown: string): { companies: CompanyInfo[]; item
     if (prev) prev.note = currentCompanyIntro.join('\n').trim();
   }
 
-  return { companies, items };
+  return { companies, items, dropped };
 }
 
 // --- 技術者プロファイルパース --------------------------------------------------------------
@@ -495,6 +556,12 @@ function parseSkillsMarkdown(markdown: string): SkillsBlockData[] {
 async function main() {
   const write = process.argv.includes('--write');
 
+  // loadWebEnvLocal() は .env.local が無くても throw しない（テストからの import を許すため）。
+  // 実行時にここで明示的に止め、接続先不明のまま進まないようにする。
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL が未設定です。apps/web/.env.local を用意するか、環境変数で渡してください。');
+  }
+
   const { getDb } = await import('../src/client');
   const { blocks: blocksTable } = await import('../src/schema');
   const { eq, asc } = await import('drizzle-orm');
@@ -542,7 +609,7 @@ async function main() {
 
   const careerStart = fullMarkdown.search(/^##\s*経歴/im);
   const careerMarkdown = careerStart !== -1 ? fullMarkdown.slice(careerStart) : fullMarkdown;
-  const { companies, items } = parseCareerMarkdown(careerMarkdown);
+  const { companies, items, dropped } = parseCareerMarkdown(careerMarkdown);
 
   console.log('PARSED_PROFILE:', profile ? 'yes' : 'no');
   console.log(
@@ -553,6 +620,13 @@ async function main() {
   );
   console.log('PARSED_COMPANIES:', companies.length);
   console.log('PARSED_PROJECTS:', items.length);
+
+  // 捨てた行がある＝元データの一部が DB に入らないということなので、黙って進めない（#151 D-7）。
+  console.log('DROPPED_LINES:', dropped.length);
+  if (dropped.length > 0) {
+    console.warn('WARN: 以下の行はどのフィールドにも取り込まれていません。元データかパーサの見直しが必要です:');
+    for (const d of dropped) console.warn(`  - [${d.where}] ${d.line}`);
+  }
 
   const profileBlock: BlockInput | null = profile ? { type: 'profile', data: profile } : null;
   const skillsBlocks: BlockInput[] = skills.map((s) => ({ type: 'skills', data: s }));
@@ -578,7 +652,14 @@ async function main() {
   console.log('SAVED to sheetId', SHEET_ID);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
-});
+// import.meta.url を直接実行チェックに使う。テストからこのモジュールを import した
+// ときに main()（実DB接続・本番シートへの書き込み）が副作用として走らないようにする。
+// `file://${process.argv[1]}` の文字列連結は Windows のパス区切りやスペース等で
+// import.meta.url と一致しなくなるため、pathToFileURL で正規化を揃える
+// （bootstrap-owner.ts と同じ方式）。
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -98,6 +98,12 @@ const KNOWN_SUBSECTIONS = ['プロジェクト概要', '技術スタック', '�
 // main() が経歴セクションを切り出す起点。会社見出しより前に唯一存在してよい見出し。
 const CAREER_SECTION_HEADING = /^##\s*経歴/;
 
+// スキルセクションの <details>/<summary> 構造行。データではないため捨てても警告しない。
+const SKILLS_STRUCTURAL_LINE = /^\s*<\/?(?:details|summary|h[1-6])[\s/>]/i;
+
+// 担当工程表で「経験なし」を表す記号。値が失われているわけではないため警告しない。
+const PROCESS_NEGATIVE_MARKERS = new Set(['-', '‐', '−', 'ー', '―', '×', '✕', '✗', '無', 'なし', 'N/A', 'n/a']);
+
 // 末尾の "(3 ヶ月間)" / "（継続中）" 等の注記を取り除く。
 function stripTrailingAnnotation(s: string): string {
   return s.replace(/[\s]*[（(][^）)]*[）)]\s*$/, '').trim();
@@ -220,7 +226,23 @@ function parseProcessSection(lines: string[], dropped: DroppedLine[] = [], where
       continue;
     }
     const cell = data[i] ?? '';
-    if (cell.includes('●')) result.push(PROCESS_BUILDER_VOCAB[idx]);
+    if (cell.includes('●')) {
+      result.push(PROCESS_BUILDER_VOCAB[idx]);
+      continue;
+    }
+    // 既知の工程列でも ● 以外のマーカー（○ / 担当 など）は工程に変換されず失われる。
+    // ただし空欄と「経験なし」記号は失っている情報が無いので警告しない。これを警告すると
+    // 案件ごとに毎回出て本当の取りこぼしが埋もれる（Codexレビュー指摘）。
+    const trimmed = cell.trim();
+    if (trimmed && !PROCESS_NEGATIVE_MARKERS.has(trimmed)) {
+      recordDropped(dropped, `${at}（解釈できないマーカー）`, `${label}: ${trimmed}`);
+    }
+  }
+  // ヘッダより列数が多いデータ行の余剰セルは、対応する工程名が無く読まれないまま失われる
+  // （CodeRabbitレビュー指摘）。
+  for (let i = header.length; i < data.length; i++) {
+    const extra = (data[i] ?? '').trim();
+    if (extra) recordDropped(dropped, `${at}（ヘッダに対応する列が無い）`, extra);
   }
   return result;
 }
@@ -452,24 +474,26 @@ function deriveSkillLevel(years: number): string {
   return '初級';
 }
 
-// 下の switch が受け付けるラベル。ここに無いラベルは ProfileMeta のどこにも入らないため、
-// 取りこぼしとして警告する。switch の case を増やすときはこちらも追加すること。
-const PROFILE_LABELS = new Set([
-  '技術者名',
-  '所属',
-  '所屬',
-  '年齢',
-  '性別',
-  '資格',
-  '学歴',
-  '学歷',
-  '稼働',
-  '勤務形態',
-  '最寄駅',
-  '最寄り駅',
-  '得意分野',
-  '得意業務',
-]);
+// ラベル → 代入先の正本。判定と代入を同じ定義から引くことで、片方だけ足して
+// 「取り込んでいるのに警告が出る／黙って捨てるのに警告も出ない」ズレを防ぐ
+// （CodeRabbitレビュー指摘）。
+type ProfileField = 'name' | 'company' | keyof ProfileMeta;
+const PROFILE_LABEL_FIELDS: Record<string, ProfileField> = {
+  技術者名: 'name',
+  所属: 'company',
+  所屬: 'company',
+  年齢: 'age',
+  性別: 'gender',
+  資格: 'qualifications',
+  学歴: 'education',
+  学歷: 'education',
+  稼働: 'work',
+  勤務形態: 'work',
+  最寄駅: 'station',
+  最寄り駅: 'station',
+  得意分野: 'specialties',
+  得意業務: 'expertise',
+};
 
 function normalizeProfileLabel(label: string): string {
   return label.replace(/\s+/g, '').replace(/\*/g, '').replace(/:/g, '').trim();
@@ -515,48 +539,22 @@ export function parseProfileMarkdown(markdown: string, dropped: DroppedLine[] = 
     const label = normalizeProfileLabel(rawLabel);
     if (label === '項目') continue; // ヘッダ行
     if (!value) continue; // 値が空なら失うものが無い
-    if (report && !PROFILE_LABELS.has(label)) {
-      // switch のどの case にも当たらないラベルは ProfileMeta に入らず失われる
+    // Object.hasOwn を使うのは `constructor` のようなラベルを継承プロパティで拾わないため。
+    if (!Object.hasOwn(PROFILE_LABEL_FIELDS, label)) {
+      // どの項目にも対応しないラベルは ProfileMeta に入らず失われる
       // （例: `| 居住地 | 東京 |`。Codexレビュー指摘）。
-      recordDropped(dropped, `${at}（対応する項目が無いラベル）`, `${rawLabel}: ${value}`);
+      if (report) recordDropped(dropped, `${at}（対応する項目が無いラベル）`, `${rawLabel}: ${value}`);
       continue;
     }
-    switch (label) {
-      case '技術者名':
-        name = value;
-        break;
-      case '所属':
-      case '所屬':
-        company = value;
-        break;
-      case '年齢':
-        meta.age = value;
-        break;
-      case '性別':
-        meta.gender = value;
-        break;
-      case '資格':
-        meta.qualifications = value;
-        break;
-      case '学歴':
-      case '学歷':
-        meta.education = value;
-        break;
-      case '稼働':
-      case '勤務形態':
-        meta.work = value;
-        break;
-      case '最寄駅':
-      case '最寄り駅':
-        meta.station = value;
-        break;
-      case '得意分野':
-        meta.specialties = value;
-        break;
-      case '得意業務':
-        meta.expertise = value;
-        break;
+    const field = PROFILE_LABEL_FIELDS[label];
+    // 同じ項目が二度現れると後勝ちで上書きされ、先の値が失われる（Codexレビュー指摘）。
+    const previous = field === 'name' ? name : field === 'company' ? company : meta[field];
+    if (previous) {
+      recordDropped(dropped, `${at}（重複した項目の上書き）`, `${rawLabel}: ${previous}`);
     }
+    if (field === 'name') name = value;
+    else if (field === 'company') company = value;
+    else meta[field] = value;
   }
 
   const prStart = section.findIndex((line) => /^###\s*自己\s*PR/.test(line));
@@ -608,7 +606,10 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
     const report = i < scanEnd;
     if (!line.startsWith('|')) {
       // 表の行でなければスキルとして取り込まれない（Codexレビュー指摘）。
-      if (report) recordDropped(dropped, `${at}（表の行ではない）`, line);
+      // ただし <summary><h2>スキル・経験年数</h2></summary> のような構造行はデータではない。
+      // 除外しないと正常な実シートでも毎回 DROPPED_LINES が非ゼロになり、本当の
+      // 取りこぼしが恒常的な誤検知に埋もれる（Codexレビュー指摘）。
+      if (report && !SKILLS_STRUCTURAL_LINE.test(line)) recordDropped(dropped, `${at}（表の行ではない）`, line);
       continue;
     }
     const cells = line
@@ -634,6 +635,12 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
       if (report && !first && yearsRaw) recordDropped(dropped, `${at}（技術名が無い）`, line);
       continue;
     }
+    if (!currentCategory) {
+      // 分類が未確定のままのスキルは currentSkills に入るが、flushCategory が
+      // currentCategory 無しではブロックを出さないため、次の分類行で消える（Codexレビュー指摘）。
+      if (report) recordDropped(dropped, `${at}（技術分類が未確定）`, line);
+      continue;
+    }
     const yearsMatch = yearsRaw.match(/(\d+(?:\.\d+)?)\s*年/);
     const years = yearsMatch ? Number(yearsMatch[1]) : 0;
     currentSkills.push({ name: skillName, years, level: deriveSkillLevel(years) });
@@ -646,6 +653,8 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
 // --- メイン ---------------------------------------------------------------------------
 async function main() {
   const write = process.argv.includes('--write');
+  // 取りこぼしがあることを承知の上で上書きする場合のみ明示的に指定する。
+  const allowDropped = process.argv.includes('--allow-dropped');
 
   // loadWebEnvLocal() は .env.local が無くても throw しない（テストからの import を許すため）。
   // 実行時にここで明示的に止め、接続先不明のまま進まないようにする。
@@ -705,7 +714,12 @@ async function main() {
   const careerStart = fullMarkdown.search(/^##\s*経歴/im);
   const careerMarkdown = careerStart !== -1 ? fullMarkdown.slice(careerStart) : fullMarkdown;
   const { companies, items, dropped: careerDropped } = parseCareerMarkdown(careerMarkdown);
-  dropped.push(...careerDropped);
+  // `## 経歴` が無い入力では careerMarkdown が文書全体になるため、プロフィールとスキルが
+  // 正常に取り込んだ行まで「最初の会社見出しより前」として返ってくる。この経路でそのまま
+  // 集約すると取り込み済みの行を誤って警告するので、その分類だけ除く（Codexレビュー指摘）。
+  dropped.push(
+    ...(careerStart !== -1 ? careerDropped : careerDropped.filter((d) => d.where !== '最初の会社見出しより前')),
+  );
 
   console.log('PARSED_PROFILE:', profile ? 'yes' : 'no');
   console.log(
@@ -722,6 +736,15 @@ async function main() {
   if (dropped.length > 0) {
     console.warn('WARN: 以下の行はどのフィールドにも取り込まれていません。元データかパーサの見直しが必要です:');
     for (const d of dropped) console.warn(`  - [${d.where}] ${d.line}`);
+    // 警告は標準エラーに出るだけなので、非対話実行では見落とされる。saveSkillSheetBlocks は
+    // legacy markdown ブロックを含まない finalBlocks で置き換えるため、取りこぼしたまま
+    // 書き込むと元データが DB から消える。#151 D-7 はまさにこの経路（CodeRabbitレビュー指摘）。
+    if (write && !allowDropped) {
+      throw new Error(
+        `取りこぼしが ${dropped.length} 行あります。このまま上書きすると元データが失われます。` +
+          '元データかパーサを修正するか、承知の上で続行する場合は --allow-dropped を付けてください。',
+      );
+    }
   }
 
   const profileBlock: BlockInput | null = profile ? { type: 'profile', data: profile } : null;

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -95,6 +95,9 @@ function recordDropped(dropped: DroppedLine[], where: string, line: string): voi
 // 中身が丸ごと失われる（例: `#### 備考`）。
 const KNOWN_SUBSECTIONS = ['プロジェクト概要', '技術スタック', '担当工程', 'コメント'];
 
+// main() が経歴セクションを切り出す起点。会社見出しより前に唯一存在してよい見出し。
+const CAREER_SECTION_HEADING = /^##\s*経歴/;
+
 // 末尾の "(3 ヶ月間)" / "（継続中）" 等の注記を取り除く。
 function stripTrailingAnnotation(s: string): string {
   return s.replace(/[\s]*[（(][^）)]*[）)]\s*$/, '').trim();
@@ -209,9 +212,11 @@ function parseProcessSection(lines: string[], dropped: DroppedLine[] = [], where
     const label = header[i];
     const idx = PROCESS_HEADER_ORDER.indexOf(label);
     if (idx === -1) {
-      // PROCESS_HEADER_ORDER に無い工程名は、● が立っていてもどの工程にも対応づかず失われる。
-      if (label && (data[i] ?? '').includes('●'))
-        recordDropped(dropped, `${at}（未知の工程名）`, `${label}: ${data[i]}`);
+      // PROCESS_HEADER_ORDER に無い工程名の列は、どの工程にも対応づかないため値ごと失われる。
+      // ● 以外（○ / 担当 / 注記など）でも失われることに変わりはないので、非空なら
+      // マーカーの種類を問わず記録する（Codexレビュー指摘）。
+      const unknownCell = (data[i] ?? '').trim();
+      if (label && unknownCell) recordDropped(dropped, `${at}（未知の工程名）`, `${label}: ${unknownCell}`);
       continue;
     }
     const cell = data[i] ?? '';
@@ -423,10 +428,11 @@ export function parseCareerMarkdown(markdown: string): {
       currentProjectBody.push(line);
     } else if (currentCompanyId !== null) {
       currentCompanyIntro.push(line);
-    } else if (!/^#{1,6}\s/.test(line)) {
-      // 最初の会社見出し(###)より前の自由文は、会社にも案件にも属さないまま捨てられる。
-      // `## 経歴` のような見出し行は構造であってデータではないため対象外にする
-      // （含めると毎回必ず警告が出て、本当の取りこぼしが埋もれる）。
+    } else if (!CAREER_SECTION_HEADING.test(line)) {
+      // 最初の会社見出し(###)より前の行は、会社にも案件にも属さないまま捨てられる。
+      // 除外するのは `## 経歴`（main() がここを起点に切り出す想定済みの構造）だけにする。
+      // 見出し行を一律で除外すると `## 注意事項` のような想定外の見出しを見逃す
+      // （Codexレビュー指摘）。
       recordDropped(dropped, '最初の会社見出しより前', line);
     }
   }
@@ -446,14 +452,34 @@ function deriveSkillLevel(years: number): string {
   return '初級';
 }
 
+// 下の switch が受け付けるラベル。ここに無いラベルは ProfileMeta のどこにも入らないため、
+// 取りこぼしとして警告する。switch の case を増やすときはこちらも追加すること。
+const PROFILE_LABELS = new Set([
+  '技術者名',
+  '所属',
+  '所屬',
+  '年齢',
+  '性別',
+  '資格',
+  '学歴',
+  '学歷',
+  '稼働',
+  '勤務形態',
+  '最寄駅',
+  '最寄り駅',
+  '得意分野',
+  '得意業務',
+]);
+
 function normalizeProfileLabel(label: string): string {
   return label.replace(/\s+/g, '').replace(/\*/g, '').replace(/:/g, '').trim();
 }
 
-function parseProfileMarkdown(markdown: string): ProfileBlockData | null {
+export function parseProfileMarkdown(markdown: string, dropped: DroppedLine[] = []): ProfileBlockData | null {
   const lines = markdown.split('\n');
   const startIdx = lines.findIndex((line) => /^##\s*技術者プロファイル/.test(line));
   if (startIdx === -1) return null;
+  const at = '技術者プロファイル';
 
   let endIdx = lines.length;
   for (let i = startIdx + 1; i < lines.length; i++) {
@@ -466,16 +492,35 @@ function parseProfileMarkdown(markdown: string): ProfileBlockData | null {
   }
   const section = lines.slice(startIdx + 1, endIdx);
 
+  // 自己PR見出し以降は pr へそのまま取り込まれるため、取りこぼしの検査対象は見出しより前だけ。
+  const prHeadingIdx = section.findIndex((line) => /^###\s*自己\s*PR/.test(line));
+  const scanEnd = prHeadingIdx === -1 ? section.length : prHeadingIdx;
+
   const meta: ProfileMeta = {};
   let name = '';
   let company = '';
-  for (const line of section) {
-    if (!line.startsWith('|')) continue;
+  for (const [i, line] of section.entries()) {
+    const report = i < scanEnd;
+    if (!line.startsWith('|')) {
+      // 表でも自己PRでもない行は、どのフィールドにも入らない（Codexレビュー指摘）。
+      if (report) recordDropped(dropped, `${at}（表の行ではない）`, line);
+      continue;
+    }
     const row = parseTableRow(line);
-    if (!row) continue;
+    if (!row) {
+      if (report) recordDropped(dropped, `${at}（表の行として解釈できない）`, line);
+      continue;
+    }
     const [rawLabel, value] = row;
     const label = normalizeProfileLabel(rawLabel);
-    if (!value) continue;
+    if (label === '項目') continue; // ヘッダ行
+    if (!value) continue; // 値が空なら失うものが無い
+    if (report && !PROFILE_LABELS.has(label)) {
+      // switch のどの case にも当たらないラベルは ProfileMeta に入らず失われる
+      // （例: `| 居住地 | 東京 |`。Codexレビュー指摘）。
+      recordDropped(dropped, `${at}（対応する項目が無いラベル）`, `${rawLabel}: ${value}`);
+      continue;
+    }
     switch (label) {
       case '技術者名':
         name = value;
@@ -530,7 +575,7 @@ function parseProfileMarkdown(markdown: string): ProfileBlockData | null {
   return { name, title: '', pr, strengths: [], meta, company };
 }
 
-function parseSkillsMarkdown(markdown: string): SkillsBlockData[] {
+export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = []): SkillsBlockData[] {
   const lines = markdown.split('\n');
   let startIdx = lines.findIndex((line) => /^<details[\s>]/.test(line));
   let endIdx = lines.length;
@@ -542,6 +587,12 @@ function parseSkillsMarkdown(markdown: string): SkillsBlockData[] {
     if (startIdx === -1) return [];
   }
   const section = lines.slice(startIdx + 1, endIdx);
+  const at = 'スキル・経験年数';
+  // <details> が無い経路では endIdx が文末まで伸びる。そのまま警告対象にすると経歴セクション
+  // 全体を「捨てた行」として報告してしまうため、パース対象は従来どおりにしたまま、警告の
+  // 範囲だけ次の `## ` 見出しまでに絞る。
+  const nextHeadingIdx = section.findIndex((line) => /^##\s/.test(line));
+  const scanEnd = nextHeadingIdx === -1 ? section.length : nextHeadingIdx;
 
   const blocks: SkillsBlockData[] = [];
   let currentCategory = '';
@@ -553,13 +604,21 @@ function parseSkillsMarkdown(markdown: string): SkillsBlockData[] {
     }
   };
 
-  for (const line of section) {
-    if (!line.startsWith('|')) continue;
+  for (const [i, line] of section.entries()) {
+    const report = i < scanEnd;
+    if (!line.startsWith('|')) {
+      // 表の行でなければスキルとして取り込まれない（Codexレビュー指摘）。
+      if (report) recordDropped(dropped, `${at}（表の行ではない）`, line);
+      continue;
+    }
     const cells = line
       .split('|')
       .slice(1, -1)
       .map((c) => c.trim());
-    if (cells.length < 3) continue;
+    if (cells.length < 3) {
+      if (report) recordDropped(dropped, `${at}（列が3つ未満）`, line);
+      continue;
+    }
     const first = stripBold(cells[0]);
     const skillName = stripBold(cells[1]);
     const yearsRaw = stripBold(cells[2]);
@@ -570,7 +629,11 @@ function parseSkillsMarkdown(markdown: string): SkillsBlockData[] {
       currentCategory = first;
       currentSkills.length = 0;
     }
-    if (!skillName) continue;
+    if (!skillName) {
+      // 技術名が無い行はスキルにならない。分類名も無ければこの行の内容は丸ごと失われる。
+      if (report && !first && yearsRaw) recordDropped(dropped, `${at}（技術名が無い）`, line);
+      continue;
+    }
     const yearsMatch = yearsRaw.match(/(\d+(?:\.\d+)?)\s*年/);
     const years = yearsMatch ? Number(yearsMatch[1]) : 0;
     currentSkills.push({ name: skillName, years, level: deriveSkillLevel(years) });
@@ -632,12 +695,17 @@ async function main() {
             throw new Error('legacy markdown が DB にも /tmp/real_markdown.md にも見つかりません');
           })();
 
-  const profile = parseProfileMarkdown(fullMarkdown);
-  const skills = parseSkillsMarkdown(fullMarkdown);
+  // プロフィール・スキル・経歴の3パーサすべての取りこぼしを1つに集約する。経歴だけを
+  // 見ていると、プロフィールやスキルで行が失われていても DROPPED_LINES: 0 と表示され、
+  // --write が警告なしに legacy markdown を置き換えてしまう（Codexレビュー指摘）。
+  const dropped: DroppedLine[] = [];
+  const profile = parseProfileMarkdown(fullMarkdown, dropped);
+  const skills = parseSkillsMarkdown(fullMarkdown, dropped);
 
   const careerStart = fullMarkdown.search(/^##\s*経歴/im);
   const careerMarkdown = careerStart !== -1 ? fullMarkdown.slice(careerStart) : fullMarkdown;
-  const { companies, items, dropped } = parseCareerMarkdown(careerMarkdown);
+  const { companies, items, dropped: careerDropped } = parseCareerMarkdown(careerMarkdown);
+  dropped.push(...careerDropped);
 
   console.log('PARSED_PROFILE:', profile ? 'yes' : 'no');
   console.log(

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -98,8 +98,20 @@ const KNOWN_SUBSECTIONS = ['プロジェクト概要', '技術スタック', '�
 // main() が経歴セクションを切り出す起点。会社見出しより前に唯一存在してよい見出し。
 const CAREER_SECTION_HEADING = /^##\s*経歴/;
 
-// スキルセクションの <details>/<summary> 構造行。データではないため捨てても警告しない。
-const SKILLS_STRUCTURAL_LINE = /^\s*<\/?(?:details|summary|h[1-6])[\s/>]/i;
+const SKILLS_SECTION_TITLE = /スキル・経験年数/;
+const HTML_WRAPPER_TAG = /^<\/?(?:details|summary|h[1-6])[\s/>]/i;
+
+/**
+ * スキルセクションの `<details>` ラッパーと、セクション見出しを兼ねる `<summary>`/`<hN>` だけを
+ * 構造行とみなす。タグ名だけで一律に除外すると `<h3>補足</h3>` のような想定外の見出しまで
+ * 見逃すため、タグを剥がした中身が空かセクション見出しの場合に限る（Codexレビュー指摘）。
+ */
+function isSkillsStructuralLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!HTML_WRAPPER_TAG.test(trimmed)) return false;
+  const text = trimmed.replace(/<[^>]*>/g, '').trim();
+  return text === '' || SKILLS_SECTION_TITLE.test(text);
+}
 
 // 担当工程表で「経験なし」を表す記号。値が失われているわけではないため警告しない。
 const PROCESS_NEGATIVE_MARKERS = new Set(['-', '‐', '−', 'ー', '―', '×', '✕', '✗', '無', 'なし', 'N/A', 'n/a']);
@@ -340,6 +352,9 @@ function parseProjectBlock(
 
   for (const [name, sectionLines] of Object.entries(sections)) {
     if (KNOWN_SUBSECTIONS.includes(name)) continue;
+    // 見出し行自体もどの出力フィールドにも入らない。本文が空の場合は子行の記録だけでは
+    // 何も残らず、見出しが消えたことに気付けない（Codexレビュー指摘）。
+    recordDropped(dropped, `${where} の未知のサブセクション「${name}」`, `#### ${name}`);
     for (const line of sectionLines) recordDropped(dropped, `${where} の未知のサブセクション「${name}」`, line);
   }
 
@@ -354,10 +369,21 @@ function parseProjectBlock(
       continue;
     }
     const [label, value] = row;
-    if (label === '期間') period = normalizePeriod(value);
-    else if (label === '役割') role = stripBold(value);
-    else if (label === 'チーム規模' || label === 'チーム') team = stripBold(value);
-    else if (value) overviewExtra.push(`${label}: ${stripBold(value)}`);
+    // 単一値フィールドが二度現れると後勝ちで上書きされ、先の値が失われる（Codexレビュー指摘）。
+    const overwriteGuard = (previous: string) => {
+      if (previous)
+        recordDropped(dropped, `${where} の「プロジェクト概要」（重複した項目の上書き）`, `${label}: ${previous}`);
+    };
+    if (label === '期間') {
+      overwriteGuard(period);
+      period = normalizePeriod(value);
+    } else if (label === '役割') {
+      overwriteGuard(role);
+      role = stripBold(value);
+    } else if (label === 'チーム規模' || label === 'チーム') {
+      overwriteGuard(team);
+      team = stripBold(value);
+    } else if (value) overviewExtra.push(`${label}: ${stripBold(value)}`);
   }
 
   const tech = emptyTech();
@@ -577,11 +603,13 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
   const lines = markdown.split('\n');
   let startIdx = lines.findIndex((line) => /^<details[\s>]/.test(line));
   let endIdx = lines.length;
-  if (startIdx !== -1) {
+  // <details> で囲まれていれば終端が明示されているので、警告範囲を絞る必要はない。
+  const hasDetails = startIdx !== -1;
+  if (hasDetails) {
     endIdx = lines.findIndex((line) => /^<\/details>/.test(line), startIdx + 1);
     if (endIdx === -1) endIdx = lines.length;
   } else {
-    startIdx = lines.findIndex((line) => /スキル・経験年数/.test(line));
+    startIdx = lines.findIndex((line) => SKILLS_SECTION_TITLE.test(line));
     if (startIdx === -1) return [];
   }
   const section = lines.slice(startIdx + 1, endIdx);
@@ -589,17 +617,27 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
   // <details> が無い経路では endIdx が文末まで伸びる。そのまま警告対象にすると経歴セクション
   // 全体を「捨てた行」として報告してしまうため、パース対象は従来どおりにしたまま、警告の
   // 範囲だけ次の `## ` 見出しまでに絞る。
-  const nextHeadingIdx = section.findIndex((line) => /^##\s/.test(line));
+  // 打ち切るのはこのフォールバック経路だけにする。<details> がある場合にも適用すると、
+  // ブロック内の `## 補足` 以降が検査対象から外れて逆に取りこぼす（Codexレビュー指摘）。
+  const nextHeadingIdx = hasDetails ? -1 : section.findIndex((line) => /^##\s/.test(line));
   const scanEnd = nextHeadingIdx === -1 ? section.length : nextHeadingIdx;
 
   const blocks: SkillsBlockData[] = [];
   let currentCategory = '';
+  // スキルを1件も持たない分類は出力されず黙って消えるため、元行を控えて警告に回す。
+  let currentCategoryLine = '';
+  let currentCategoryReport = false;
   const currentSkills: SkillEntry[] = [];
 
   const flushCategory = () => {
-    if (currentCategory && currentSkills.length > 0) {
+    if (!currentCategory) return;
+    if (currentSkills.length > 0) {
       blocks.push({ category: currentCategory, skills: [...currentSkills] });
+      return;
     }
+    // 分類名だけの行が次の分類または表末尾まで続いた場合、その分類名はどこにも入らない
+    // （Codexレビュー指摘）。
+    if (currentCategoryReport) recordDropped(dropped, `${at}（スキルが1件も無い技術分類）`, currentCategoryLine);
   };
 
   for (const [i, line] of section.entries()) {
@@ -609,7 +647,7 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
       // ただし <summary><h2>スキル・経験年数</h2></summary> のような構造行はデータではない。
       // 除外しないと正常な実シートでも毎回 DROPPED_LINES が非ゼロになり、本当の
       // 取りこぼしが恒常的な誤検知に埋もれる（Codexレビュー指摘）。
-      if (report && !SKILLS_STRUCTURAL_LINE.test(line)) recordDropped(dropped, `${at}（表の行ではない）`, line);
+      if (report && !isSkillsStructuralLine(line)) recordDropped(dropped, `${at}（表の行ではない）`, line);
       continue;
     }
     const cells = line
@@ -625,9 +663,19 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
     const yearsRaw = stripBold(cells[2]);
     if (first === '技術分類' || skillName === '技術名' || /^:?-+:?$/.test(first)) continue;
 
+    // 読むのは先頭3セルだけなので、4列目以降の値はどのフィールドにも入らない
+    // （Codexレビュー指摘）。
+    if (report) {
+      for (const extra of cells.slice(3)) {
+        if (extra.trim()) recordDropped(dropped, `${at}（4列目以降は読まれない）`, extra);
+      }
+    }
+
     if (first) {
       flushCategory();
       currentCategory = first;
+      currentCategoryLine = line;
+      currentCategoryReport = report;
       currentSkills.length = 0;
     }
     if (!skillName) {
@@ -642,6 +690,11 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
       continue;
     }
     const yearsMatch = yearsRaw.match(/(\d+(?:\.\d+)?)\s*年/);
+    // `6ヶ月` `1年未満` `経験あり` のような表記は years: 0 に潰れ、元の値が残らない
+    // （Codexレビュー指摘）。
+    if (report && yearsRaw && !yearsMatch) {
+      recordDropped(dropped, `${at}（経験年数を解釈できない）`, `${skillName}: ${yearsRaw}`);
+    }
     const years = yearsMatch ? Number(yearsMatch[1]) : 0;
     currentSkills.push({ name: skillName, years, level: deriveSkillLevel(years) });
   }

--- a/packages/db/scripts/migrate-real-sheet.ts
+++ b/packages/db/scripts/migrate-real-sheet.ts
@@ -98,6 +98,8 @@ const KNOWN_SUBSECTIONS = ['プロジェクト概要', '技術スタック', '�
 // main() が経歴セクションを切り出す起点。会社見出しより前に唯一存在してよい見出し。
 const CAREER_SECTION_HEADING = /^##\s*経歴/;
 
+// セクションの正式名。構造行の判定は完全一致、セクション位置の探索は行内の部分一致で使う。
+const SKILLS_SECTION_NAME = 'スキル・経験年数';
 const SKILLS_SECTION_TITLE = /スキル・経験年数/;
 const HTML_WRAPPER_TAG = /^<\/?(?:details|summary|h[1-6])[\s/>]/i;
 
@@ -110,8 +112,13 @@ function isSkillsStructuralLine(line: string): boolean {
   const trimmed = line.trim();
   if (!HTML_WRAPPER_TAG.test(trimmed)) return false;
   const text = trimmed.replace(/<[^>]*>/g, '').trim();
-  return text === '' || SKILLS_SECTION_TITLE.test(text);
+  // 部分一致にすると `<h3>スキル・経験年数の注意事項</h3>` まで構造行と誤判定して
+  // 見逃す。既知のセクション名との完全一致に限る（Codexレビュー指摘）。
+  return text === '' || text === SKILLS_SECTION_NAME;
 }
+
+// 担当工程表の先頭セル（行ラベル）として想定している値。これ以外は注記等が紛れている。
+const PROCESS_ROW_LABELS = new Set(['工程', '経験']);
 
 // 担当工程表で「経験なし」を表す記号。値が失われているわけではないため警告しない。
 const PROCESS_NEGATIVE_MARKERS = new Set(['-', '‐', '−', 'ー', '―', '×', '✕', '✗', '無', 'なし', 'N/A', 'n/a']);
@@ -211,7 +218,16 @@ function parseProcessSection(lines: string[], dropped: DroppedLine[] = [], where
       recordDropped(dropped, `${at}（表の行ではない）`, line);
       continue;
     }
-    if (/^:?-+:?$/.test(cells[0])) continue;
+    // 先頭セルだけで区切り行と判定すると `|---|---|重要注記|` のような行が丸ごと消える。
+    // isTableSeparatorRow と同じく全セルが区切り記号のときだけ除外する（Codexレビュー指摘）。
+    if (cells.every((c) => /^:?-+:?$/.test(c))) continue;
+    if (/^:?-+:?$/.test(cells[0])) {
+      // 区切り行のつもりで書かれた行に値が紛れている。表としては解釈しない。
+      for (const c of cells) {
+        if (c && !/^:?-+:?$/.test(c)) recordDropped(dropped, `${at}（区切り行に紛れた値）`, c);
+      }
+      continue;
+    }
     rows.push(cells);
   }
   const asLine = (row: string[]) => `| ${row.join(' | ')} |`;
@@ -226,6 +242,13 @@ function parseProcessSection(lines: string[], dropped: DroppedLine[] = [], where
   const header = rows[0];
   const data = rows[1];
   const result: string[] = [];
+  // 先頭セルは走査対象外なので、`| 経験（主担当） | ● | … |` の「主担当」のような注記が
+  // どのフィールドにも入らないまま消える（Codexレビュー指摘）。
+  for (const first of [header[0], data[0]]) {
+    if (first && !PROCESS_ROW_LABELS.has(first)) {
+      recordDropped(dropped, `${at}（想定外の行ラベル）`, first);
+    }
+  }
   for (let i = 1; i < header.length; i++) {
     const label = header[i];
     const idx = PROCESS_HEADER_ORDER.indexOf(label);
@@ -248,6 +271,10 @@ function parseProcessSection(lines: string[], dropped: DroppedLine[] = [], where
     const cell = data[i] ?? '';
     if (cell.includes('●')) {
       result.push(PROCESS_BUILDER_VOCAB[idx]);
+      // `●（一部担当）` や `● / ○` の ● 以外の部分はどのフィールドにも残らない。
+      // 工程の取り込み自体は維持したまま、残余だけを警告に回す（Codexレビュー指摘）。
+      const residue = cell.replace(/●/g, '').trim();
+      if (residue) recordDropped(dropped, `${at}（●に付随する注記）`, `${label}: ${cell.trim()}`);
       continue;
     }
     // 既知の工程列でも ● 以外のマーカー（○ / 担当 など）は工程に変換されず失われる。
@@ -699,8 +726,10 @@ export function parseSkillsMarkdown(markdown: string, dropped: DroppedLine[] = [
       currentSkills.length = 0;
     }
     if (!skillName) {
-      // 技術名が無い行はスキルにならない。分類名も無ければこの行の内容は丸ごと失われる。
-      if (report && !first && yearsRaw) recordDropped(dropped, `${at}（技術名が無い）`, line);
+      // 技術名が無い行はスキルにならないので、経験年数セルの値はどこにも入らない。
+      // `!first` を条件に入れていたため `| 言語 |  | 5年 |` の 5年 が素通りしていた
+      // （Codexレビュー指摘）。分類の有無にかかわらず記録する。
+      if (report && yearsRaw) recordDropped(dropped, `${at}（技術名が無い）`, line);
       continue;
     }
     if (!currentCategory) {


### PR DESCRIPTION
## Issue リンク / Link to Issue

refs #151（D-7 の完了条件2「取り込み時に捨てた行があれば検出できる」に対応。完了条件1 のDB再取り込みは未実施のため close はしない）

### 概要

#151 D-7 は「案件21の前置き一文が `parseCommentSection` に拾われず、DB にも画面にも存在しない」という不具合でした。**パーサ側の修正は `7aa11ed` で既に入っており**（`≪担当業務≫` より前の自由文を comment へ結合する）、コード上の欠陥は解消済みです。

一方 Issue 本文の「同じ構造の元データが他にもある可能性があるので、取り込み時に『捨てた行があれば警告する』形にしておきたい」という要求と、完了条件2 が未対応のまま残っていたため、これを実装しました。

取り込み時に**どのフィールドにも入らなかった行**を集め、`DROPPED_LINES: N` として件数を出し、1件以上あれば該当行を場所つきで警告します。

#### 検出する経路

| 経路 | 実例 |
|---|---|
| 案件見出しと最初のサブセクション見出しの間の自由文 | **D-7 と同じ位置** |
| 誰も読まない未知のサブセクション | `#### 備考` |
| プロジェクト概要／技術スタックで表の行として解釈できない行 | 表の中に混ざった地の文 |
| 最初の会社見出しより前の自由文 | — |
| 会社見出しより前に現れた案件 | 見出しごと丸ごと捨てられていた |

最後の1件は、テストを書く過程で**新たに見つけた取りこぼし**です。`flushProject()` は `currentCompanyId === null` のとき何もせず捨てていました。

空行と表の区切り行（`|---|---|`）は除外しています。含めると毎回必ず警告が出て、本当の取りこぼしが埋もれるためです。

#### テスト可能にするための変更

`migrate-real-sheet.ts` は `main()` を無条件実行しており、import すると本番シートへの書き込み経路が走るためテストが書けませんでした。

- `main()` を直接実行時のみ起動するガードを追加（`bootstrap-owner.ts` と同じ `pathToFileURL` 方式）
- `loadWebEnvLocal()` は `.env.local` が無くても throw せず戻すよう変更。実行時に必要な環境変数が欠けている場合は `main()` 冒頭で `DATABASE_URL` を明示的にチェックして停止

### 見て欲しいポイント

- [ ] **誤検知の閾値**。空行・表の区切り行の除外だけで足りているか。実装当初は `## 経歴` の見出し自体を拾ってしまい毎回警告が出る状態で、テストがそれを暴きました。現在は `^#{1,6}\s` の見出し行を対象外にしています
- [ ] **`loadWebEnvLocal()` の fail-fast を main() へ移した判断**。従来は import 時点で `.env.local` 不在なら throw していました。シェルの環境変数だけで実行するケースが通るようになる副作用があります
- [ ] `KNOWN_SUBSECTIONS` を定数で持つ形にした点。`parseProjectBlock` が実際に読むセクション名と二重管理になるため、増やすときは両方直す必要があります

### 見なくてもよいポイント

- [ ] `migrate-real-sheet.test.ts` の `careerMarkdown()` ヘルパ（案件1件分の最小 markdown を組み立てているだけ）

### その他(あれば)

**残作業**: 完了条件1「案件21の前置き文が画面に出る」は、パーサは直っているものの**本番DBの既存データは旧パース結果のまま**です。反映には `pnpm --filter @skillsheet/db exec tsx scripts/migrate-real-sheet.ts --write` の実行が必要で、本PRには含めていません。この取り込みを実行すると、本PRで追加した警告により他の取りこぼしも同時に洗い出せます。

**検証**

```
pnpm --filter @skillsheet/db test   196件通過（新規8件込み）
pnpm -r type-check                  exit 0
pnpm lint                           exit 0
```

エントリポイントガードは実地確認済みです。直接実行すると `main()` に到達し `DATABASE_URL が未設定です` で停止することを確認しました（ガードが誤っていると何も起きずに正常終了してしまうため）。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外） — #151
- [x] 複数の変更が 1 つの PR に入り込んでいないか — 取り込み時の取りこぼし検出のみ
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか — 依存追加なし
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例） — 該当なし

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrxT9nqCaB69Zs9x14ryMC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Markdownデータの読み込み時に、認識できなかった行や不正な形式を検出できるようになりました。
  * 読み込み結果に含まれなかった行を、場所と内容付きで警告表示します。
  * データベース接続先が未設定の場合、実行時に明確なエラーを表示します。
  * 設定ファイルがない環境でも、検証やテストを継続して実行できるようになりました。

* **テスト**
  * 経歴・プロフィール・スキル情報の各種入力パターンに対する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->