### PR TITLE
fix(web): builder keyboard reorder, profile custom row drafts, preview overflow, and touch targets

### DIFF
--- a/apps/web/app/builder/builder-client.tsx
+++ b/apps/web/app/builder/builder-client.tsx
@@ -6,19 +6,13 @@ import {
   type DragEndEvent,
   DragOverlay,
   type DragStartEvent,
-  KeyboardSensor,
   PointerSensor,
   useDraggable,
   useDroppable,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
+import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 // tableBlockToMarkdown 等の純関数/型はサーバ専用モジュール（neon ドライバ等）を
 // client バンドルに巻き込まないため、root の @skillsheet/db ではなく純粋サブエクスポート
@@ -63,7 +57,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { toast } from 'sonner';
 import { DateTokenPicker } from '@/components/date-token-picker';
 import { SelectOrCustom } from '@/components/select-or-custom';
@@ -607,6 +601,8 @@ const ProfileBlockEditor = ({
   onChange,
   id,
   onValidityChange,
+  customDraft,
+  onCustomDraftChange,
 }: {
   data: ProfileBlockData;
   onChange: (data: ProfileBlockData) => void;
@@ -614,17 +610,22 @@ const ProfileBlockEditor = ({
   id: string;
   /** ラベル重複の有無を親へ通知する。親はこれを見て保存（自動/手動）を止める。 */
   onValidityChange: (id: string, hasConflict: boolean) => void;
+  /** タブ切替等でアンマウントされたときの未確定自由項目行（#216）。 */
+  customDraft?: CustomMetaRow[];
+  /** 自由項目行のドラフトを親へ通知する。 */
+  onCustomDraftChange?: (rows: CustomMetaRow[]) => void;
 }) => {
   const set = <K extends keyof ProfileBlockData>(field: K, value: ProfileBlockData[K]) =>
     onChange({ ...data, [field]: value });
   const setKnownMeta = (key: keyof ProfileMeta, value: string) =>
     onChange({ ...data, meta: { ...(data.meta ?? {}), [key]: value } });
 
-  const [customRows, setCustomRows] = useState<CustomMetaRow[]>(() =>
-    Object.entries(data.meta ?? {})
+  const [customRows, setCustomRows] = useState<CustomMetaRow[]>(() => {
+    if (customDraft) return customDraft;
+    return Object.entries(data.meta ?? {})
       .filter((e): e is [string, string] => !KNOWN_PROFILE_META_KEYS.has(e[0]) && e[1] !== undefined)
-      .map(([label, value]) => ({ id: `custom-${customMetaRowSeq++}`, label, value })),
-  );
+      .map(([label, value]) => ({ id: `custom-${customMetaRowSeq++}`, label, value }));
+  });
   const conflictingRowIds = useMemo(() => findConflictingRowIds(customRows), [customRows]);
   // ラベルが一時的に空（リネーム中の一瞬等）で、かつ値が既にある行。このまま親へ
   // コミットすると値ごと消える（Codex レビュー指摘）ため、確定した状態になるまで
@@ -654,6 +655,7 @@ const ProfileBlockEditor = ({
   // （画面上は customRows のまま残り、エラー表示で気付ける）。親の data.meta を
   // 「最後に確定した安全な状態」のまま保つことで、タブ切替等での消失を防ぐ。
   const commitCustomRows = (rows: CustomMetaRow[]) => {
+    onCustomDraftChange?.(rows);
     setCustomRows(rows);
     const conflicts = findConflictingRowIds(rows);
     if (conflicts.size > 0 || rows.some((row) => row.label.trim() === '' && row.value.trim() !== '')) return;
@@ -820,7 +822,10 @@ const SortableBlock = ({
   onExperienceChange,
   onProfileChange,
   onProfileValidityChange,
+  customDraft,
+  onCustomDraftChange,
   onDelete,
+  onMoveBlock,
 }: {
   item: EditorItem;
   onMarkdownChange: (id: string, markdown: string) => void;
@@ -829,9 +834,19 @@ const SortableBlock = ({
   onExperienceChange: (id: string, data: ExperienceBlockData) => void;
   onProfileChange: (id: string, data: ProfileBlockData) => void;
   onProfileValidityChange: (id: string, hasConflict: boolean) => void;
+  customDraft?: CustomMetaRow[];
+  onCustomDraftChange?: (rows: CustomMetaRow[]) => void;
   onDelete: (id: string) => void;
+  onMoveBlock: (id: string, direction: -1 | 1) => void;
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      onMoveBlock(item.id, event.key === 'ArrowUp' ? -1 : 1);
+    }
+  };
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -854,6 +869,7 @@ const SortableBlock = ({
         aria-label="ブロックを並べ替え"
         {...attributes}
         {...listeners}
+        onKeyDown={handleKeyDown}
       >
         <GripVertical className="size-5" />
       </button>
@@ -895,6 +911,8 @@ const SortableBlock = ({
           onChange={(data) => onProfileChange(item.id, data)}
           id={item.id}
           onValidityChange={onProfileValidityChange}
+          customDraft={customDraft}
+          onCustomDraftChange={onCustomDraftChange}
         />
       ) : item.type === 'stats' ? (
         <div className="min-w-0 flex-1 rounded border border-dashed border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
@@ -1107,10 +1125,25 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
     });
   }, []);
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
+  // ProfileBlockEditor 内の任意メタ項目行はタブ切替等でアンマウントされても入力中の
+  // 未確定値を失わないよう、ブロック id 単位でドラフトを保持する（#216）。
+  const profileCustomDraftsRef = useRef<Map<string, CustomMetaRow[]>>(new Map());
+  const getProfileCustomDraft = useCallback((id: string) => profileCustomDraftsRef.current.get(id), []);
+  const setProfileCustomDraft = useCallback((id: string, rows: CustomMetaRow[]) => {
+    profileCustomDraftsRef.current.set(id, rows);
+  }, []);
+
+  const moveBlock = useCallback((id: string, direction: -1 | 1) => {
+    setItems((prev) => {
+      const index = prev.findIndex((i) => i.id === id);
+      if (index === -1) return prev;
+      const target = index + direction;
+      if (target < 0 || target >= prev.length) return prev;
+      return arrayMove(prev, index, target);
+    });
+  }, []);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
 
   // プレビューは重い（Markdown パース＋ハイライト）ため、入力のたびではなく
   // デバウンスして更新し、タイピングのラグを防ぐ。初期値・初回レンダリングは即時反映。
@@ -1338,7 +1371,10 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
   const updateProfile = (id: string, data: ProfileBlockData) =>
     setItems((prev) => prev.map((i) => (i.id === id && i.type === 'profile' ? { ...i, ...data } : i)));
 
-  const deleteBlock = (id: string) => setItems((prev) => prev.filter((i) => i.id !== id));
+  const deleteBlock = (id: string) => {
+    profileCustomDraftsRef.current.delete(id);
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  };
 
   const addMarkdownBlock = () => setItems((prev) => [...prev, { id: newId(), type: 'markdown', markdown: '' }]);
 
@@ -1886,7 +1922,10 @@ const BuilderClient = ({ initialBlocks, initialTitle, sheets: initialSheets, act
                         onExperienceChange={updateExperience}
                         onProfileChange={updateProfile}
                         onProfileValidityChange={handleProfileValidityChange}
+                        customDraft={getProfileCustomDraft(item.id)}
+                        onCustomDraftChange={(rows) => setProfileCustomDraft(item.id, rows)}
                         onDelete={deleteBlock}
+                        onMoveBlock={moveBlock}
                       />
                     ))}
                   </div>

--- a/apps/web/app/builder/editor.css
+++ b/apps/web/app/builder/editor.css
@@ -273,6 +273,18 @@
     opacity 0.12s ease,
     color 0.12s ease,
     background 0.12s ease;
+  position: relative;
+}
+.row-del::before,
+.co-del::before,
+.row-eye::before {
+  content: '';
+  position: absolute;
+  top: -11px;
+  right: -11px;
+  bottom: -11px;
+  left: -11px;
+  border-radius: 6px;
 }
 .co-del {
   margin-right: 6px;
@@ -306,6 +318,16 @@
 .co-del:hover {
   color: var(--danger);
   background: var(--danger-soft);
+}
+
+/* タッチ端末では hover が使えないため常時表示し、22px 要素の周囲を ::before で
+   44px のタップ領域まで広げる（見た目は 22px のまま）（#220）。 */
+@media (hover: none) {
+  .row-del,
+  .co-del,
+  .row-eye {
+    opacity: 1;
+  }
 }
 
 .pv-hidden {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -299,8 +299,7 @@ body {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1rem;
-  display: block;
-  overflow: auto;
+  display: table;
 }
 .markdown-content th,
 .markdown-content td {

--- a/apps/web/e2e/adversarial.spec.ts
+++ b/apps/web/e2e/adversarial.spec.ts
@@ -352,9 +352,20 @@ test('E. auth edge cases', async ({ browser }) => {
   await page.getByLabel('認証コード').fill(viewerCode);
   await page.getByRole('button', { name: '認証' }).click();
   await page.waitForURL(/\/(view|view\/db)/);
-  await page.goto('/builder');
-  await expect(page).toHaveURL(/login/);
-  await capture(page, 'E-viewer-to-login.png');
+  await page.waitForLoadState('networkidle');
+
+  // /builder へは新規ページで遷移する。viewer-auth のクライアントサイド
+  // router.push('/view') と page.goto('/builder') が並走すると Chromium で
+  // net::ERR_ABORTED になるケースがある (#207 敵対テストで発覚)。
+  const builderPage = await anonContext.newPage();
+  const { errors: bErrors, warnings: bWarnings, off: bOff } = collectErrors(builderPage);
+  await builderPage.goto('/builder');
+  await expect(builderPage).toHaveURL(/login/);
+  await capture(builderPage, 'E-viewer-to-login.png');
+  bOff();
+  errors.push(...bErrors);
+  warnings.push(...bWarnings);
+  await builderPage.close();
 
   off();
   const nonAuthErrors = errors.filter((e) => !/401|net::ERR_|Failed to load resource/.test(e));

--- a/apps/web/e2e/builder-ux-fixes.spec.ts
+++ b/apps/web/e2e/builder-ux-fixes.spec.ts
@@ -1,0 +1,161 @@
+import { expect, type Locator, test } from '@playwright/test';
+import { createSheet, deleteSheet } from '@skillsheet/db';
+import { TEMPLATES } from '../app/builder/templates';
+import { authFile, login } from './auth';
+
+test.use({ storageState: authFile });
+
+test.describe.configure({ mode: 'serial' });
+
+const getFullTemplateBlocks = () => {
+  const full = TEMPLATES.find((t) => t.id === 'full');
+  if (!full) throw new Error('full template not found');
+  return full.blocks;
+};
+
+const getDashboardTemplateBlocks = () => {
+  const dashboard = TEMPLATES.find((t) => t.id === 'console-dashboard');
+  if (!dashboard) throw new Error('console-dashboard template not found');
+  return dashboard.blocks;
+};
+
+async function getBlockValues(handles: Locator) {
+  return handles.evaluateAll((els) =>
+    els.map((el) => {
+      const block = el.parentElement;
+      const input = block?.querySelector('textarea, input');
+      if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+        return input.value;
+      }
+      return block?.textContent?.trim().slice(0, 30) ?? '';
+    }),
+  );
+}
+
+test('keyboard reorder moves one item at a time', async ({ page }) => {
+  const title = `Keyboard reorder test ${Date.now()}`;
+  const sheetId = await createSheet(title, getFullTemplateBlocks());
+  try {
+    const logs: string[] = [];
+    page.on('console', (msg) => logs.push(msg.text()));
+    await login(page);
+    await page.goto(`/builder?sheet=${sheetId}`, { waitUntil: 'networkidle' });
+
+    const handles = page.getByRole('button', { name: 'ブロックを並べ替え' });
+    await expect(handles).toHaveCount(7);
+
+    const before = await getBlockValues(handles);
+
+    // Focus the drag handle and move the block down one position with ArrowDown.
+    await handles.nth(1).focus();
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(200);
+
+    const after = await getBlockValues(handles);
+    console.log('before:', before);
+    console.log('after:', after);
+    console.log('browser logs:', logs);
+
+    // The block originally at index 1 should now be at index 2.
+    expect(after[1]).not.toBe(before[1]);
+    expect(after[2]).toBe(before[1]);
+  } finally {
+    await deleteSheet(sheetId);
+  }
+});
+
+test('profile custom row draft survives tab switch', async ({ page }) => {
+  const title = `Custom row draft test ${Date.now()}`;
+  const sheetId = await createSheet(title, getDashboardTemplateBlocks());
+  try {
+    const logs: string[] = [];
+    page.on('console', (msg) => logs.push(msg.text()));
+    await login(page);
+    await page.goto(`/builder?sheet=${sheetId}`, { waitUntil: 'networkidle' });
+
+    await page.getByRole('button', { name: '項目を追加' }).click();
+    const customLabel = page.locator('input[placeholder="項目名（例: 得意分野）"]').first();
+    const customValue = page.locator('input[placeholder="値"]').first();
+    await customLabel.fill('得意分野');
+    await customValue.fill('性能改善');
+
+    await page.getByRole('button', { name: '案件エディタ' }).click();
+    await page.getByRole('button', { name: 'ブロック編集' }).click();
+
+    await expect(customLabel).toHaveValue('得意分野');
+    await expect(customValue).toHaveValue('性能改善');
+  } finally {
+    await deleteSheet(sheetId);
+  }
+});
+
+test('preview does not horizontally overflow at 320px', async ({ page }) => {
+  const title = `Overflow test ${Date.now()}`;
+  const sheetId = await createSheet(title, getDashboardTemplateBlocks());
+  try {
+    await login(page);
+    await page.setViewportSize({ width: 320, height: 800 });
+    await page.goto(`/view/db/${sheetId}`, { waitUntil: 'networkidle' });
+
+    const hasHorizontalOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
+    expect(hasHorizontalOverflow).toBe(false);
+  } finally {
+    await deleteSheet(sheetId);
+  }
+});
+
+test.describe('mobile project editor', () => {
+  test.use({
+    viewport: { width: 375, height: 812 },
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 2,
+    storageState: authFile,
+  });
+
+  test('row action buttons stay visible and have 44px tap target on touch devices', async ({ page }) => {
+    const title = `Touch target test ${Date.now()}`;
+    const sheetId = await createSheet(title, getDashboardTemplateBlocks());
+    try {
+      await login(page);
+      await page.goto(`/builder?sheet=${sheetId}`, { waitUntil: 'networkidle' });
+      await page.getByRole('button', { name: '案件エディタ' }).click();
+      await page.getByRole('button', { name: 'ナビを展開' }).click();
+      await page.getByRole('button', { name: '＋ 会社' }).click();
+      await page.waitForSelector('.co-head-row');
+
+      const eye = page.locator('.co-head-row .row-eye').first();
+      const del = page.locator('.co-head-row .co-del').first();
+      await expect(eye).toBeVisible();
+      await expect(del).toBeVisible();
+
+      const tapTarget = await page.evaluate((selector) => {
+        const el = document.querySelector(selector);
+        if (!el) return null;
+        const rect = el.getBoundingClientRect();
+        const before = window.getComputedStyle(el, '::before');
+        return {
+          elementWidth: rect.width,
+          elementHeight: rect.height,
+          top: before.top,
+          right: before.right,
+          bottom: before.bottom,
+          left: before.left,
+          position: window.getComputedStyle(el).position,
+        };
+      }, '.co-head-row .row-eye');
+
+      expect(tapTarget).not.toBeNull();
+      expect(tapTarget?.position).toBe('relative');
+      expect(tapTarget?.left).toBe('-11px');
+      expect(tapTarget?.top).toBe('-11px');
+      expect(tapTarget?.right).toBe('-11px');
+      expect(tapTarget?.bottom).toBe('-11px');
+      // 22px の見た目に -11px の inset があるため、タップ領域は 44px 四方になる。
+      expect((tapTarget?.elementWidth ?? 0) + 22).toBeGreaterThanOrEqual(44);
+      expect((tapTarget?.elementHeight ?? 0) + 22).toBeGreaterThanOrEqual(44);
+    } finally {
+      await deleteSheet(sheetId);
+    }
+  });
+});

--- a/apps/web/src/component/blocks/stat-row.test.tsx
+++ b/apps/web/src/component/blocks/stat-row.test.tsx
@@ -16,14 +16,15 @@ function buildData(): StatsBlockData {
 describe('StatRow', () => {
   it('SP は grid-cols-2、sm 以上で sm:grid-cols-4 が共存する（#190）', () => {
     const { container } = render(<StatRow data={buildData()} />);
-    const grid = container.firstElementChild;
+    // StatRow は overflow-x-auto のラッパーで grid を包んでいる（#217）。
+    const grid = container.firstElementChild?.firstElementChild;
     expect(grid?.className).toContain('grid-cols-2');
     expect(grid?.className).toContain('sm:grid-cols-4');
   });
 
   it('mb-6 はブレークポイント無しで常に付く（space-y-0 のシートで次ブロックとの余白が消える回帰の防止）', () => {
     const { container } = render(<StatRow data={buildData()} />);
-    const grid = container.firstElementChild;
+    const grid = container.firstElementChild?.firstElementChild;
     // ダッシュボードでは親の space-y-* と隣接兄弟マージンとして相殺されるため二重には空かない。
     expect(grid?.className).toMatch(/(?<!sm:)mb-6/);
   });

--- a/apps/web/src/component/blocks/stat-row.tsx
+++ b/apps/web/src/component/blocks/stat-row.tsx
@@ -14,17 +14,19 @@ export const StatRow = ({ data }: StatRowProps) => {
     // mb-6 は親が space-y-* を持つダッシュボードでは隣接兄弟マージンとして相殺されるため
     // 二重には空かない。逆に外すと space-y-0 のレイアウト（project ブロックが無いシート）で
     // 次ブロックとの余白が消えるので、ブレークポイントを付けず常に持たせる。
-    <div className="mb-6 grid grid-cols-2 gap-px border border-border bg-border sm:grid-cols-4">
-      {data.items.map((item, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: 静的リスト
-        <div key={i} className="bg-card px-3 py-3.5 sm:px-4 sm:py-[18px]">
-          <span className="font-mono text-[26px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-foreground sm:text-[30px]">
-            {item.value}
-            <span className="ml-0.5 font-mono text-sm font-normal tracking-normal text-accent-text">{item.unit}</span>
-          </span>
-          <span className="mt-1 block text-xs text-muted-foreground">{item.label}</span>
-        </div>
-      ))}
+    <div className="overflow-x-auto">
+      <div className="mb-6 grid min-w-[360px] grid-cols-2 gap-px border border-border bg-border sm:grid-cols-4">
+        {data.items.map((item, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: 静的リスト
+          <div key={i} className="bg-card px-3 py-3.5 sm:px-4 sm:py-[18px]">
+            <span className="font-mono text-[26px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-foreground sm:text-[30px]">
+              {item.value}
+              <span className="ml-0.5 font-mono text-sm font-normal tracking-normal text-accent-text">{item.unit}</span>
+            </span>
+            <span className="mt-1 block text-xs text-muted-foreground">{item.label}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/apps/web/src/component/skill-sheet-viewer.tsx
+++ b/apps/web/src/component/skill-sheet-viewer.tsx
@@ -139,6 +139,13 @@ const MarkdownContent = memo(function MarkdownContent({ content, blockId, onImag
               </td>
             );
           },
+          table({ children }) {
+            return (
+              <div className="overflow-x-auto">
+                <table className="min-w-[480px] w-full border-collapse">{children}</table>
+              </div>
+            );
+          },
         }}
       >
         {content}
@@ -300,13 +307,18 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false, views }: Sk
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
         // design: max-width 1180px / padding 44px 32px 96px / セクション間 48px
-        className={`mx-auto w-full flex-1 px-4 pt-8 pb-16 sm:px-8 sm:pt-11 sm:pb-24 ${
+        // min-w-0: flex item 子（StatRow 等）の min-w による幅拡張を抑え、横スクロールを子側に閉じ込める。
+        className={`mx-auto min-w-0 w-full flex-1 px-4 pt-8 pb-16 sm:px-8 sm:pt-11 sm:pb-24 ${
           isDashboard ? 'max-w-[1180px]' : 'max-w-4xl'
         }`}
       >
         <div
           ref={contentRef}
-          className={isDashboard ? 'space-y-8 sm:space-y-12' : 'rounded border border-border bg-card p-4 sm:p-6 md:p-8'}
+          className={
+            isDashboard
+              ? 'min-w-0 space-y-8 sm:space-y-12'
+              : 'min-w-0 overflow-hidden rounded border border-border bg-card p-4 sm:p-6 md:p-8'
+          }
         >
           {blocks ? (
             <div className={isDashboard ? 'space-y-8 sm:space-y-12' : 'space-y-0'}>


### PR DESCRIPTION
## Issue リンク / Link to Issue

Closes #202
Closes #216
Closes #217
Closes #220
Refs #207 （敵対テストで発覚した Playwright 次ページ遷移の安定性修正）

### 概要

ビルダー / プレビューに関する 4 つの quick-fix をまとめて対応します。

- #202: ブロックのキーボード並び替えで、ArrowUp/ArrowDown 1 回あたり 1 つずつ移動するように修正
- #216: プロフィールブロックの自由項目行をタブ切替後も入力中のドラフトを失わないよう保持
- #217: 320px ビューア・StatRow・Markdown テーブルで横スクロールがページレベルに発生しないよう制御
- #220: タッチ端末で案件エディタの行アクションアイコンが見えない / タップ領域が小さい問題を修正

### 見て欲しいポイント

- [ ] `builder-client.tsx` の `moveBlock` + `handleKeyDown` が dnd-kit の衝突検出を介さず 1 段ずつ動作するか
- [ ] `ProfileBlockEditor` のドラフト Map がアンマウントで消失しないよう親 `BuilderClient` で管理できているか
- [ ] `stat-row.tsx` / `skill-sheet-viewer.tsx` / `globals.css` の組み合わせで 320px ビューで `documentElement.scrollWidth > innerWidth` にならないか
- [ ] `editor.css` の `@media (hover: none)` と `::before` による 44px タップ領域が実機 / エミュレータで効いているか

### 見なくてもよいポイント

- [ ] `e2e/adversarial.spec.ts` の E. auth edge cases で `/builder` へ新規ページ遷移するよう変更（既存の `page.goto` 直後 `ERR_ABORTED` 回避）

### その他(あれば)

---

### PR チェックポイント

- [x] 複数の変更が 1 つの PR に入り込んでいないか → 4 つの quick-fix は #135 PBI 配下の関連 UIUX 改善のため同一 PR で実施
- [ ] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 矢印キーでブロックを並べ替えられるようになりました。
  * プロフィールの自由項目ドラフトが、画面切り替え後も保持されます。
  * タッチ端末で編集操作ボタンが常時表示され、タップしやすくなりました。

* **改善**
  * 統計情報やMarkdownテーブルが、狭い画面でも横スクロールで確認できるようになりました。
  * ブロック削除時に、関連する下書きも自動的に削除されます。
  * モバイル画面で不要な横スクロールが発生しにくくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->