### PR TITLE
fix: 導出した技術領域に由来ラベルを付ける（担当領域との誤読を防ぐ）

### DIFF
--- a/apps/web/app/builder/project-preview.tsx
+++ b/apps/web/app/builder/project-preview.tsx
@@ -2,7 +2,7 @@
 
 import type { CompanyInfo, ProjectItem } from '@skillsheet/db/blocks';
 import { flattenTech, normalizeProcess, PROCESS_LABELS } from '@skillsheet/db/process';
-import { projectAreaLabel } from '@skillsheet/db/tech-area';
+import { projectAreaText } from '@skillsheet/db/tech-area';
 import { useRef, useState } from 'react';
 
 import { InlineMarkdown } from '@/component/inline-markdown';
@@ -54,7 +54,7 @@ export const ProjectPreview = ({ project, company, no, syncKey, onJump }: Projec
   const summary = project.summary?.trim() || project.duties.trim();
   /** スコープ欄の値そのままか、空なら技術スタックからの導出値（由来を添える）。 */
   const ownScope = project.scope.trim();
-  const derivedArea = ownScope ? '' : projectAreaLabel('', project.tech);
+  const derivedArea = ownScope ? '' : projectAreaText('', project.tech);
   const scopePreview = ownScope || (derivedArea ? `${derivedArea}（技術スタックから導出）` : 'スコープ未入力');
 
   const toolbarRef = useRef<HTMLDivElement>(null);

--- a/apps/web/src/component/blocks/project-card.tsx
+++ b/apps/web/src/component/blocks/project-card.tsx
@@ -2,7 +2,7 @@
 
 import type { CompanyInfo, ProjectItem } from '@skillsheet/db/blocks';
 import { deriveDuration, formatPeriodDisplay, normalizeProcess } from '@skillsheet/db/process';
-import { projectAreaLabel } from '@skillsheet/db/tech-area';
+import { resolveProjectArea } from '@skillsheet/db/tech-area';
 import { formatTeamSize } from '@/util/format-team-size';
 import { sanitizeHtml } from '@/util/sanitize-html';
 import { InlineMarkdown } from '../inline-markdown';
@@ -23,7 +23,7 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
   const normalized = normalizeProcess(item.process);
   const duration = sanitizeHtml(item.duration?.trim() || deriveDuration(item.period));
   const summary = item.summary?.trim() || item.duties;
-  const areaLabel = projectAreaLabel(item.scope, item.tech);
+  const area = resolveProjectArea(item.scope, item.tech);
 
   return (
     <article className="flex min-w-0 flex-col gap-3.5 rounded-[var(--radius-lg)] border border-border bg-card px-[22px] py-5 transition-colors duration-150 hover:border-primary">
@@ -39,9 +39,15 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
             </span>
           </div>
           <h3 className="text-[17px] leading-snug text-foreground">{sanitizeHtml(item.title) || '(タイトル未入力)'}</h3>
-          {/* 「担当領域」ではなく「技術領域」。元シートに担当領域の記載が無い場合は技術スタックから
-              導出しており、「この技術を使った」までしか言えないため（tech-area.ts 参照）。 */}
-          {areaLabel && <p className="mt-0.5 text-[12.5px] text-muted-foreground">{sanitizeHtml(areaLabel)}</p>}
+          {/* 導出値には必ず「技術領域」を添える。タイトル直下という位置だけで読み手は
+              「担当した領域」と受け取るが、技術スタックから言えるのは「その技術がどの領域か」まで。
+              取り込んだ scope は本人の言葉なのでラベルを付けない（tech-area.ts 参照）。 */}
+          {area.text && (
+            <p className="mt-0.5 text-[12.5px] text-muted-foreground">
+              {area.derived && <span className="kicker mr-1.5">技術領域</span>}
+              {sanitizeHtml(area.text)}
+            </p>
+          )}
           {/* 会社概要文（CompanyInfo.note）。従来どこにも描画先が無く、ビューア・PDF・バックアップの
               全経路で欠落していた（#139）。projectBlockToMarkdown 側も同じ位置づけで出力する。
               空白のみの値は projectBlockToMarkdown と同じく trim() 後に判定する。 */}

--- a/apps/web/src/component/blocks/project-section.tsx
+++ b/apps/web/src/component/blocks/project-section.tsx
@@ -2,7 +2,7 @@
 
 import { filterVisibleProjectData, type ProjectBlockData } from '@skillsheet/db/blocks';
 import { flattenTech } from '@skillsheet/db/process';
-import { projectAreaLabel } from '@skillsheet/db/tech-area';
+import { projectAreaText } from '@skillsheet/db/tech-area';
 import { motion, useReducedMotion } from 'framer-motion';
 import { type ReactNode, useMemo, useState } from 'react';
 import { ProcessOverview } from './process-overview';
@@ -81,7 +81,7 @@ export function ProjectSection({
       const company = companyMap.get(item.companyId);
       const haystack = [
         item.title,
-        projectAreaLabel(item.scope, item.tech),
+        projectAreaText(item.scope, item.tech),
         item.role,
         company?.name ?? '',
         item.summary ?? item.duties,

--- a/apps/web/src/component/blocks/timeline.tsx
+++ b/apps/web/src/component/blocks/timeline.tsx
@@ -2,13 +2,19 @@
 
 import type { CompanyInfo, ProjectItem } from '@skillsheet/db/blocks';
 import { flattenTech, formatPeriodDisplay, sortByStartDesc } from '@skillsheet/db/process';
-import { projectAreaLabel } from '@skillsheet/db/tech-area';
+import { resolveProjectArea } from '@skillsheet/db/tech-area';
 import { sanitizeHtml } from '@/util/sanitize-html';
 
 interface TimelineProps {
   items: ProjectItem[];
   companyMap: Map<string, CompanyInfo>;
   activeTech: string[];
+}
+
+function timelineArea(item: ProjectItem): string {
+  const area = resolveProjectArea(item.scope, item.tech);
+  if (!area.text) return '';
+  return area.derived ? `技術領域 ${sanitizeHtml(area.text)}` : sanitizeHtml(area.text);
 }
 
 // 案件タイムライン。start（period から導出）降順の縦レール表示。
@@ -44,11 +50,9 @@ export function Timeline({ items, companyMap, activeTech }: TimelineProps) {
                     {sanitizeHtml(item.title) || '(タイトル未入力)'}
                   </div>
                   <div className="mt-0.5 text-xs text-muted-foreground">
-                    {[
-                      sanitizeHtml(company?.name),
-                      sanitizeHtml(item.role),
-                      sanitizeHtml(projectAreaLabel(item.scope, item.tech)),
-                    ]
+                    {/* 役割の隣に無ラベルで並べると担当領域として読まれるため、
+                        導出値のときだけ「技術領域」を前置する（tech-area.ts 参照）。 */}
+                    {[sanitizeHtml(company?.name), sanitizeHtml(item.role), timelineArea(item)]
                       .filter(Boolean)
                       .join(' · ')}
                   </div>

--- a/packages/db/src/blocks.test.ts
+++ b/packages/db/src/blocks.test.ts
@@ -646,8 +646,8 @@ describe('projectBlockToMarkdown', () => {
     expect(md).toContain('業務内容テスト');
   });
 
-  it('技術領域は元シートから取り込んだ値を優先する', () => {
-    expect(projectBlockToMarkdown(PROJECT)).toContain('| 技術領域 | 5名 |');
+  it('元シートから取り込んだ値は「担当領域」として出す（本人の言葉なので導出扱いにしない）', () => {
+    expect(projectBlockToMarkdown(PROJECT)).toContain('| 担当領域 | 5名 |');
   });
 
   it('取り込んだ担当領域が無い場合は技術スタックから導出する（#240 / #241 — 正本に無い文言を保存しないため）', () => {

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -11,7 +11,7 @@
 import { flattenTech, formatMonthToken, formatPeriodDisplay, normalizeProcess, PROCESS_LABELS } from './process';
 import { sanitizeMarkdown, sanitizeScriptAndStyle } from './sanitize-html';
 // tech-area.ts はこのファイルから型のみを取り込むため、実行時の循環は発生しない。
-import { projectAreaLabel } from './tech-area';
+import { resolveProjectArea } from './tech-area';
 
 export type BlockType = 'markdown' | 'table' | 'skills' | 'experience' | 'profile' | 'stats' | 'project';
 
@@ -725,10 +725,10 @@ export function projectBlockToMarkdown(data: ProjectBlockData, opts?: { includeH
     if (company?.kind) lines.push(`| 会社区分 | ${escapeCell(company.kind)} |`);
     if (item.period) lines.push(`| 期間 | ${escapeCell(formatPeriodDisplay(item.period))} |`);
     if (item.role) lines.push(`| 役割 | ${escapeCell(item.role)} |`);
-    // 元シートに担当領域の記載が無ければ技術スタックから導出する。行名を「技術領域」にしているのは
-    // 「この技術を使った」までしか根拠が無いため（tech-area.ts 参照）。
-    const areaLabel = projectAreaLabel(item.scope, item.tech);
-    if (areaLabel) lines.push(`| 技術領域 | ${escapeCell(areaLabel)} |`);
+    // 導出値は行名を「技術領域」にする。「この技術を使った」までしか根拠が無いため。
+    // 取り込んだ scope は本人の言葉なので「担当領域」で出す（tech-area.ts 参照）。
+    const area = resolveProjectArea(item.scope, item.tech);
+    if (area.text) lines.push(`| ${area.derived ? '技術領域' : '担当領域'} | ${escapeCell(area.text)} |`);
     if (item.team) lines.push(`| チーム | ${escapeCell(item.team)} |`);
     const techParts = flattenTech(item.tech);
     if (techParts.length > 0) lines.push(`| 技術スタック | ${escapeCell(techParts.join(', '))} |`);

--- a/packages/db/src/tech-area.test.ts
+++ b/packages/db/src/tech-area.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ProjectTech } from './blocks';
-import { deriveTechAreas, projectAreaLabel } from './tech-area';
+import { deriveTechAreas, projectAreaText, resolveProjectArea } from './tech-area';
 
 const tech = (partial: Partial<ProjectTech>): ProjectTech => ({
   lang: [],
@@ -77,16 +77,26 @@ describe('deriveTechAreas', () => {
   });
 });
 
-describe('projectAreaLabel', () => {
-  it('元シートから取り込んだ担当領域があればそれを優先する', () => {
-    expect(projectAreaLabel('要件定義 / PM', tech({ fw: ['React'] }))).toBe('要件定義 / PM');
+describe('resolveProjectArea', () => {
+  it('元シートから取り込んだ担当領域を優先し、導出ではないと示す', () => {
+    expect(resolveProjectArea('要件定義 / PM', tech({ fw: ['React'] }))).toEqual({
+      text: '要件定義 / PM',
+      derived: false,
+    });
   });
 
-  it('空白のみの取り込み値は未入力として扱い、技術スタックから導出する', () => {
-    expect(projectAreaLabel('   ', tech({ fw: ['React'] }))).toBe('Web');
+  it('空白のみの取り込み値は未入力として扱い、導出値として返す', () => {
+    expect(resolveProjectArea('   ', tech({ fw: ['React'] }))).toEqual({ text: 'Web', derived: true });
   });
 
   it('導出結果が無ければ空文字（描画側で行ごと落とす）', () => {
-    expect(projectAreaLabel('', tech({ tools: ['Jest'] }))).toBe('');
+    expect(resolveProjectArea('', tech({ tools: ['Jest'] }))).toEqual({ text: '', derived: true });
+  });
+
+  // 由来を落とした文字列だけを返す API を残すと、描画側がラベル無しで出せてしまう。
+  // 検索インデックス用の projectAreaText は由来を必要としない用途に限る。
+  it('projectAreaText は文字列のみを返す', () => {
+    expect(projectAreaText('', tech({ fw: ['React'] }))).toBe('Web');
+    expect(projectAreaText('要件定義', tech({ fw: ['React'] }))).toBe('要件定義');
   });
 });

--- a/packages/db/src/tech-area.ts
+++ b/packages/db/src/tech-area.ts
@@ -124,14 +124,32 @@ export function deriveTechAreas(tech: ProjectTech | undefined): string[] {
   ).map(({ area }) => area);
 }
 
+export interface ProjectArea {
+  /** 表示する文字列。該当が無ければ空。 */
+  text: string;
+  /**
+   * true のとき技術スタックからの導出値。描画側は必ず由来を示すラベルを添える。
+   *
+   * 由来を隠すと、案件タイトル直下の位置だけで読み手は「この人が担当した領域」と受け取る。
+   * 導出できるのは「書かれた技術がどの領域のものか」までで、担当範囲は元シートに無い。
+   * ラベルを外した瞬間にこの導出は嘘になるので、text だけを返す API は用意しない。
+   */
+  derived: boolean;
+}
+
 /**
- * 表示用の技術領域の文字列。
+ * 表示用の技術領域を、由来つきで返す。
  *
  * 元シートに担当領域の列があって取り込まれている場合（`item.scope`）はそちらを優先する。
- * インポートした値が常に導出より正しいため。空のときだけ技術スタックから導出する。
+ * インポートした値が常に導出より正しく、かつ本人の言葉なのでラベルも付けない。
  */
-export function projectAreaLabel(scope: string | undefined, tech: ProjectTech | undefined): string {
+export function resolveProjectArea(scope: string | undefined, tech: ProjectTech | undefined): ProjectArea {
   const imported = scope?.trim();
-  if (imported) return imported;
-  return deriveTechAreas(tech).join(' / ');
+  if (imported) return { text: imported, derived: false };
+  return { text: deriveTechAreas(tech).join(' / '), derived: true };
+}
+
+/** 検索インデックス等、由来の区別が要らない用途向けの文字列。 */
+export function projectAreaText(scope: string | undefined, tech: ProjectTech | undefined): string {
+  return resolveProjectArea(scope, tech).text;
 }


### PR DESCRIPTION
## 概要

#243 マージ後の自己レビュー（pre-mortem + 敵対レビュー）で見つけた欠陥の修正です。

#243 で `item.scope` の手書き値を削除し、代わりに技術スタックからの導出値を描画するようにしました。この設計の安全性は**「技術領域」という語**に全部乗っています——導出できるのは「書かれた技術がどの領域のものか」までで、「その人が担当した領域」は元シートに書かれていないためです。

**その語が PDF にしか無い状態で出荷していました。**

| 描画箇所 | #243 の状態 | 位置が意味してしまうこと |
| :--- | :--- | :--- |
| 案件カード | ラベル無しの素の行 | **案件タイトルの直下**。手書きの担当領域が置かれていた場所そのもの |
| タイムライン | ラベル無しで `·` 区切り | **役割の隣**。役割と並ぶと担当範囲として読まれる |
| PDF | `| 技術領域 |` 行 | 問題なし |

読み手はラベルが無ければ位置から意味を取ります。カードとタイムラインは、導出値を担当領域として提示していました。

## 修正

`resolveProjectArea()` が文字列と**由来（derived）**を一緒に返すようにし、描画側は導出のときだけラベルを添えます。

| 描画箇所 | 導出値 | 取り込んだ `scope` |
| :--- | :--- | :--- |
| 案件カード | `技術領域` の kicker + 値 | ラベル無し（本人の言葉なので） |
| タイムライン | `技術領域 <値>` | 値のみ |
| PDF | `| 技術領域 | <値> |` | `| 担当領域 | <値> |` |

由来を落とした文字列だけを返す API は描画向けに残していません。`projectAreaText()` は検索インデックス専用で、そこでは由来が要りません。テストでこの区別を固定しています。

## 確認

- `pnpm lint` / `pnpm -r type-check` / `pnpm build` / `./scripts/check-naming.sh` すべて exit 0
- テスト **739 件** pass（`resolveProjectArea` の由来判定 4 件を追加）
- **本番シートで実描画**: 案件 32 件すべてにラベルが出ることを DOM から確認。1280px / 390px の両方で横スクロールなし（1280px: doc 765 ≤ win 780 / 390px: doc 390 = win 390）。スクリーンショットを目視
- **本番データで PDF 実描画**: 36 ページ / テキスト層 27,738 字。導出値 32 件すべて掲載、`規模・スコープ` の消滅、案件コメント本文と箇条書きの存在を確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5n6hrNqRnsJyDjCn1h15W)_