### PR TITLE
fix(viewer,pdf): 技術フィルタを検索選択にしPDFの行重なりを直す

### DIFF
--- a/apps/web/src/component/blocks/project-card.tsx
+++ b/apps/web/src/component/blocks/project-card.tsx
@@ -3,6 +3,7 @@
 import type { CompanyInfo, ProjectItem } from '@skillsheet/db/blocks';
 import { deriveDuration, formatPeriodDisplay, normalizeProcess } from '@skillsheet/db/process';
 import { resolveProjectArea } from '@skillsheet/db/tech-area';
+import { collapseSoftBreaks } from '@skillsheet/db/text';
 import { formatTeamSize } from '@/util/format-team-size';
 import { sanitizeHtml } from '@/util/sanitize-html';
 import { InlineMarkdown } from '../inline-markdown';
@@ -26,7 +27,7 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
   const area = resolveProjectArea(item.scope, item.tech);
 
   return (
-    <article className="flex min-w-0 flex-col gap-3.5 rounded-[var(--radius-lg)] border border-border bg-card px-[22px] py-5 transition-colors duration-150 hover:border-primary">
+    <article className="flex min-w-0 flex-col gap-6 rounded-[var(--radius-lg)] border border-border bg-card px-7 py-7 transition-colors duration-150 hover:border-primary">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0">
           <div className="mb-1 flex items-center gap-2">
@@ -71,7 +72,10 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
       </div>
 
       {summary && (
-        <InlineMarkdown content={summary} className="break-words text-[13.5px] leading-[1.85] text-muted-foreground" />
+        <InlineMarkdown
+          content={collapseSoftBreaks(summary)}
+          className="break-words text-[15px] leading-[1.9] text-muted-foreground"
+        />
       )}
 
       {tech.length > 0 && (
@@ -103,7 +107,10 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
       {item.acquired && (
         <div className="text-sm">
           <p className="mb-1 font-mono text-[10px] tracking-[0.1em] text-accent-text">≪習得スキル・実績≫</p>
-          <InlineMarkdown content={item.acquired} className="break-words leading-relaxed text-foreground/80" />
+          <InlineMarkdown
+            content={collapseSoftBreaks(item.acquired)}
+            className="break-words leading-relaxed text-foreground/80"
+          />
         </div>
       )}
 
@@ -111,7 +118,7 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
           引用の意味合いは左罫線だけで十分表現できているので italic は外す。 */}
       {item.comment && (
         <InlineMarkdown
-          content={item.comment}
+          content={collapseSoftBreaks(item.comment)}
           className="whitespace-pre-line break-words border-l-2 border-primary pl-3 text-sm text-muted-foreground"
         />
       )}

--- a/apps/web/src/component/blocks/project-section.tsx
+++ b/apps/web/src/component/blocks/project-section.tsx
@@ -134,7 +134,7 @@ export function ProjectSection({
               total={itemsWithNo.length}
             />
           </div>
-          <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(min(380px,100%),1fr))]">
+          <div className="grid grid-cols-1 gap-5">
             {filtered.map(({ item, no, tech }) => (
               <ProjectCard
                 key={item.id}

--- a/apps/web/src/component/blocks/tech-filter.test.tsx
+++ b/apps/web/src/component/blocks/tech-filter.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { TechFilter } from './tech-filter';
@@ -10,73 +11,57 @@ const noop = {
   onClear: vi.fn(),
 };
 
+const ALL = [
+  { name: 'TypeScript', count: 3 },
+  { name: 'React', count: 2 },
+  { name: 'OnlyOnce', count: 1 },
+];
+
 describe('TechFilter', () => {
-  it('トグル状態を aria-pressed で通知する（スクリーンリーダー a11y 回帰防止）', () => {
+  it('未選択の技術チップは出さない（チップ雲を置かない）', () => {
+    render(<TechFilter all={ALL} active={[]} count={3} total={3} {...noop} />);
+
+    expect(screen.queryByRole('button', { name: /TypeScript/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /すべての技術を表示/ })).toBeNull();
+  });
+
+  it('案件検索欄は技術選択と別に残る', () => {
+    render(<TechFilter all={ALL} active={[]} count={3} total={3} {...noop} />);
+
+    expect(screen.getByPlaceholderText('案件・技術・役割を検索…')).toBeTruthy();
+    expect(screen.getByLabelText('技術を選ぶ')).toBeTruthy();
+  });
+
+  it('技術選択に入力すると一致する技術が出る（1件だけの技術も含む）', async () => {
+    const user = userEvent.setup();
+    render(<TechFilter all={ALL} active={[]} count={3} total={3} {...noop} />);
+
+    await user.click(screen.getByLabelText('技術を選ぶ'));
+    await user.type(screen.getByLabelText('技術を選ぶ'), 'Only');
+
+    expect(screen.getByRole('option', { name: /OnlyOnce/ })).toBeTruthy();
+  });
+
+  it('選んだ技術はチップになり aria-pressed=true になる', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
     render(
       <TechFilter
-        all={[
-          { name: 'TypeScript', count: 3 },
-          { name: 'React', count: 2 },
-        ]}
+        all={ALL}
         active={['TypeScript']}
         count={1}
-        total={2}
-        {...noop}
-      />,
-    );
-
-    expect(screen.getByRole('button', { name: /TypeScript/ })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: /React/ })).toHaveAttribute('aria-pressed', 'false');
-  });
-
-  it('1案件のみの技術は既定で隠し、展開ボタンで出す', async () => {
-    const { rerender } = render(
-      <TechFilter
-        all={[
-          { name: 'TypeScript', count: 3 },
-          { name: 'OnlyOnce', count: 1 },
-        ]}
-        active={[]}
-        count={3}
         total={3}
-        {...noop}
+        query=""
+        onQueryChange={vi.fn()}
+        onToggle={onToggle}
+        onClear={vi.fn()}
       />,
     );
 
-    expect(screen.queryByRole('button', { name: /OnlyOnce/ })).toBeNull();
+    const chip = screen.getByRole('button', { name: /TypeScript/ });
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
 
-    const expand = screen.getByRole('button', { name: /すべての技術を表示/ });
-    expand.click();
-    rerender(
-      <TechFilter
-        all={[
-          { name: 'TypeScript', count: 3 },
-          { name: 'OnlyOnce', count: 1 },
-        ]}
-        active={[]}
-        count={3}
-        total={3}
-        {...noop}
-      />,
-    );
-
-    expect(screen.getByRole('button', { name: /OnlyOnce/ })).toBeTruthy();
-  });
-
-  it('選択中の技術は1案件のみでも隠さない（隠れると解除できなくなるため）', () => {
-    render(
-      <TechFilter
-        all={[
-          { name: 'TypeScript', count: 3 },
-          { name: 'OnlyOnce', count: 1 },
-        ]}
-        active={['OnlyOnce']}
-        count={1}
-        total={3}
-        {...noop}
-      />,
-    );
-
-    expect(screen.getByRole('button', { name: /OnlyOnce/ })).toHaveAttribute('aria-pressed', 'true');
+    await user.click(chip);
+    expect(onToggle).toHaveBeenCalledWith('TypeScript');
   });
 });

--- a/apps/web/src/component/blocks/tech-filter.tsx
+++ b/apps/web/src/component/blocks/tech-filter.tsx
@@ -20,24 +20,30 @@ interface TechFilterProps {
   total: number;
 }
 
-// 1案件でしか使っていない技術は既定で畳む閾値。実データでは 258 種中 149 種がこれに該当し、
-// 全部並べると案件カードが画面外へ押し出される（design 本体は 91 種でしか検証されていない）。
-const COMMON_MIN_COUNT = 2;
+const SUGGESTION_LIMIT = 40;
 
-// 技術チップの検索フィルタ。チップはトグルでOR条件、検索欄は案件・技術・役割を横断検索する。
+// 案件テキスト検索と、技術の検索選択は別コントロール。チップ雲は出さない。
 export function TechFilter({ all, active, query, onQueryChange, onToggle, onClear, count, total }: TechFilterProps) {
-  const [showAll, setShowAll] = useState(false);
+  const [techQuery, setTechQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [hi, setHi] = useState(-1);
 
-  // 選択中のチップは、たとえ1案件のみの技術でも隠さない（選択が視界から消えると解除できない）。
-  const shown = useMemo(() => {
-    if (showAll) return all;
-    const activeSet = new Set(active);
-    return all.filter((t) => t.count >= COMMON_MIN_COUNT || activeSet.has(t.name));
-  }, [all, active, showAll]);
+  const activeSet = useMemo(() => new Set(active), [active]);
+  const selected = useMemo(() => all.filter((t) => activeSet.has(t.name)), [all, activeSet]);
 
-  // 選択中のチップは 1 案件だけの技術でも隠さないので、共通タグの数から引くとズレる。
-  // 実際に描画している数との差で数える。
-  const hiddenCount = all.length - shown.length;
+  const q = techQuery.trim().toLowerCase();
+  const matches = useMemo(
+    () =>
+      all.filter((t) => !activeSet.has(t.name) && (!q || t.name.toLowerCase().includes(q))).slice(0, SUGGESTION_LIMIT),
+    [all, activeSet, q],
+  );
+
+  const pick = (name: string) => {
+    onToggle(name);
+    setTechQuery('');
+    setHi(-1);
+    setOpen(true);
+  };
 
   return (
     <div className="flex flex-col gap-3.5">
@@ -65,7 +71,6 @@ export function TechFilter({ all, active, query, onQueryChange, onToggle, onClea
         <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
           <b className="text-accent-text">{count}</b> / {total} 件
         </span>
-        {/* クリアは値の選択ではなく操作なので .chip ではなく .softbtn。 */}
         {(active.length > 0 || query.length > 0) && (
           <button type="button" onClick={onClear} className="softbtn compact">
             クリア
@@ -73,46 +78,89 @@ export function TechFilter({ all, active, query, onQueryChange, onToggle, onClea
         )}
       </div>
 
-      {/* 既定は約3行で頭打ちにし、下端のグラデーションで「まだ続く」ことを示す。 */}
-      <div className={showAll ? 'relative' : 'relative max-h-[146px] overflow-hidden'}>
-        {!showAll && (
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-[34px] bg-gradient-to-b from-transparent to-background"
-          />
+      <div className="relative min-w-[220px] max-w-[420px]">
+        <input
+          value={techQuery}
+          role="combobox"
+          aria-label="技術を選ぶ"
+          aria-expanded={open}
+          aria-autocomplete="list"
+          placeholder="技術を選ぶ…"
+          onChange={(e) => {
+            setTechQuery(e.target.value);
+            setOpen(true);
+            setHi(-1);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+            if (e.key === 'ArrowDown' && matches.length > 0) {
+              e.preventDefault();
+              setOpen(true);
+              setHi((hi + 1 + matches.length) % matches.length);
+            } else if (e.key === 'ArrowUp' && matches.length > 0) {
+              e.preventDefault();
+              setOpen(true);
+              setHi((hi - 1 + matches.length) % matches.length);
+            } else if (e.key === 'Escape') {
+              setOpen(false);
+              setHi(-1);
+            } else if (e.key === 'Enter' && open && hi >= 0 && matches[hi]) {
+              e.preventDefault();
+              pick(matches[hi].name);
+            }
+          }}
+          onBlur={() => {
+            setOpen(false);
+            setHi(-1);
+          }}
+          className="min-h-11 w-full rounded-[var(--radius)] border border-border bg-surface2 py-[9px] px-3 text-[13px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary focus:bg-card focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        />
+        {open && matches.length > 0 && (
+          <div
+            role="listbox"
+            className="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-[var(--radius)] border border-border bg-card py-1 shadow-md"
+          >
+            {matches.map((tech, i) => (
+              <button
+                key={tech.name}
+                type="button"
+                role="option"
+                aria-selected={i === hi}
+                className={`flex w-full items-center justify-between px-3 py-1.5 text-left text-[13px] ${
+                  i === hi ? 'bg-accent-soft text-accent-text' : 'text-foreground'
+                }`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  pick(tech.name);
+                }}
+                onMouseEnter={() => setHi(i)}
+              >
+                <span>{tech.name}</span>
+                <span className="font-mono text-[11px] text-faint">{tech.count}</span>
+              </button>
+            ))}
+          </div>
         )}
+      </div>
+
+      {selected.length > 0 && (
         <div className="flex flex-wrap gap-[7px]">
-          {shown.map((tech) => (
+          {selected.map((tech) => (
             <button
               key={tech.name}
               type="button"
               onClick={() => onToggle(tech.name)}
-              aria-pressed={active.includes(tech.name)}
+              aria-pressed="true"
               title={`${tech.name}（${tech.count}件）`}
-              className={`chip max-w-[220px] gap-1.5 ${active.includes(tech.name) ? 'on' : ''}`}
+              className="chip max-w-[220px] gap-1.5 on"
             >
               <span className="overflow-hidden text-ellipsis">{tech.name}</span>
-              {/* active時は opacity-70 で .chip.on の色(--on-accent)を薄めていたため、
-                  基準を満たしていた組み合わせでも実効コントラストが4.5を割っていた
-                  （Issue #198: 技術チップの件数 4.33/4.26）。active時は薄めず .chip.on の
-                  色をそのまま使う。 */}
-              <span className={`text-[10px] ${active.includes(tech.name) ? '' : 'text-faint'}`}>{tech.count}</span>
+              <span className="text-[10px]">{tech.count}</span>
             </button>
           ))}
         </div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2.5">
-        <button type="button" onClick={() => setShowAll((v) => !v)} className="softbtn compact">
-          {showAll ? '折りたたむ' : 'すべての技術を表示'}
-          {!showAll && hiddenCount > 0 && <span className="font-mono text-[11px] text-faint">+{hiddenCount}</span>}
-        </button>
-        {!showAll && hiddenCount > 0 && (
-          <span className="font-mono text-[10.5px] text-faint">
-            1案件のみで使った技術は隠しています（検索欄では全件ヒットします）
-          </span>
-        )}
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/component/pdf/skill-sheet-document.render.node.test.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.render.node.test.tsx
@@ -14,7 +14,7 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { MARKDOWN_REMARK_PLUGINS } from '@/lib/markdown-config';
+import { PDF_REMARK_PLUGINS } from '@/lib/markdown-config';
 
 import PDF_FONT_FAMILY from './constants';
 import { splitForHyphenation } from './fonts';
@@ -147,7 +147,7 @@ function buildContent(): string {
 // SkillSheetDocument 本体と同じ remark パイプラインで markdown を mdast ノード列に変換する。
 // renderBlocks の構造検証テストで、コンポーネントと同じ木を組み立てるために使う。
 function parseMarkdown(content: string): MdNode[] {
-  const processor = unified().use(remarkParse).use(MARKDOWN_REMARK_PLUGINS);
+  const processor = unified().use(remarkParse).use(PDF_REMARK_PLUGINS);
   const tree = processor.runSync(processor.parse(content)) as unknown as MdNode;
   return tree.children ?? [];
 }
@@ -873,6 +873,40 @@ describe('projectBlockToMarkdown → PDF テキスト層（Issue #242）', () =>
       const text = normalizeExtractedText(await extractPdfText(buffer));
       expect(text).toContain('報告書');
       expect(text).toContain('社内');
+    },
+    RENDER_TIMEOUT_MS,
+  );
+
+  it(
+    'D社相当の長文案件を描画して検証用 PDF を書き出せる',
+    async () => {
+      const { writeFileSync } = await import('node:fs');
+      const content = [
+        '### D社 — 配達業務アプリの開発',
+        '',
+        '| 項目 | 内容 |',
+        '| :--- | :--- |',
+        '| 期間 | 2024.04〜2024.12 |',
+        '| 役割 | SE |',
+        '| 技術スタック | TypeScript, Python, Next.js, Chakra UI, GraphQL, FastAPI, PostgreSQL, AWS |',
+        '',
+        '**習得スキル・実績**',
+        '',
+        'GRAPHQL, オニオンアーキテクチャ、クリーンアーキテクチャ、Next.js パフォーマンス最適化、',
+        'Python での Excel 出力',
+        '本案件では、実装をメインで担当しておりました。',
+        'バックエンド',
+        'バックエンドは、Python での Excel 出力を担当致しました。',
+        'Pythonのような型定義が甘めの言語では、デバッグの難易度が少々上がるため、デバッグの開発体験は重要だと感じて',
+        'いました。',
+        'Vscodeのlaunch.json等の設定やDocker上でのDebugポートの設定を行いました。',
+        'フロントエンド',
+        '2024年9月時点で最新のNext.js app routerの実装を担当致しました。',
+      ].join('\n');
+
+      const buffer = await renderToBuffer(<SkillSheetDocument title="エンジニアスキルシート" content={content} />);
+      expect(buffer.subarray(0, PDF_HEADER.length).toString('latin1')).toBe(PDF_HEADER);
+      writeFileSync('/tmp/opencode/dsha.pdf', buffer);
     },
     RENDER_TIMEOUT_MS,
   );

--- a/apps/web/src/component/pdf/skill-sheet-document.render.node.test.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.render.node.test.tsx
@@ -878,9 +878,8 @@ describe('projectBlockToMarkdown → PDF テキスト層（Issue #242）', () =>
   );
 
   it(
-    'D社相当の長文案件を描画して検証用 PDF を書き出せる',
+    'D社相当の長文案件を描画できる',
     async () => {
-      const { writeFileSync } = await import('node:fs');
       const content = [
         '### D社 — 配達業務アプリの開発',
         '',
@@ -906,7 +905,7 @@ describe('projectBlockToMarkdown → PDF テキスト層（Issue #242）', () =>
 
       const buffer = await renderToBuffer(<SkillSheetDocument title="エンジニアスキルシート" content={content} />);
       expect(buffer.subarray(0, PDF_HEADER.length).toString('latin1')).toBe(PDF_HEADER);
-      writeFileSync('/tmp/opencode/dsha.pdf', buffer);
+      expect(buffer.subarray(-1024).toString('latin1')).toContain('%%EOF');
     },
     RENDER_TIMEOUT_MS,
   );

--- a/apps/web/src/component/pdf/skill-sheet-document.tsx
+++ b/apps/web/src/component/pdf/skill-sheet-document.tsx
@@ -4,7 +4,7 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
 import { DESIGN_TOKENS_LIGHT } from '@/lib/design-tokens';
-import { isSafeLinkHref, MARKDOWN_REMARK_PLUGINS } from '@/lib/markdown-config';
+import { isSafeLinkHref, PDF_REMARK_PLUGINS } from '@/lib/markdown-config';
 import PDF_FONT_FAMILY from './constants';
 
 // @react-pdf/textkit の getNodes() は、非空白シラブルの直後が厳密に半角スペース ' ' で
@@ -597,13 +597,10 @@ export interface SkillSheetDocumentProps {
  * フォント登録は呼び出し側で行う前提（ブラウザ: pdf/fonts.ts / Node: 検証スクリプト）。
  */
 export const SkillSheetDocument = ({ title, content }: SkillSheetDocumentProps) => {
-  // remark-breaks を加えてビューアと同じく単一改行（ソフトブレーク）を改行として扱う。
-  // remark-breaks は tree トランスフォーマのため parse だけでは適用されない。
-  // runSync まで通してプラグインの変換フェーズを実行する。
-  // プラグイン構成は MARKDOWN_REMARK_PLUGINS（ビューア側と共通）を使う。ここだけ独自に
-  // 組むと、プラグインを足したときに画面と PDF の解釈がズレる（remarkCjkFriendly の
-  // 取りこぼしで実際に発生した、#138 のレビュー指摘）。
-  const processor = unified().use(remarkParse).use(MARKDOWN_REMARK_PLUGINS);
+  // 単独改行は markdown 既定どおり空白扱い。remark-breaks は行を短く切って
+  // @react-pdf の Text 内 \n と重なりを起こすため使わない。
+  // GFM と CJK 強調はビューアと同じプラグインを使う。
+  const processor = unified().use(remarkParse).use(PDF_REMARK_PLUGINS);
   const tree = processor.runSync(processor.parse(content)) as unknown as MdNode;
 
   return (

--- a/apps/web/src/lib/markdown-config.ts
+++ b/apps/web/src/lib/markdown-config.ts
@@ -71,3 +71,7 @@ export const MARKDOWN_SANITIZE_SCHEMA = {
 // （実データで確認: 「すべて**.htaccess**で記載」が画面にアスタリスクごと出る、#138）。
 // CJK 向けに flanking 規則を緩めるプラグインを挟んで解決する。
 export const MARKDOWN_REMARK_PLUGINS = [remarkGfm, remarkBreaks, remarkCjkFriendly];
+
+// PDF は remark-breaks を入れない。単独改行を <br> にすると @react-pdf の Text 内 \n と
+// 重なって文字が重なる（D社本文で再現）。GFM と CJK 強調はビューアと同じにする。
+export const PDF_REMARK_PLUGINS = [remarkGfm, remarkCjkFriendly];

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,7 +9,8 @@
     "./blocks": "./src/blocks.ts",
     "./process": "./src/process.ts",
     "./tech-area": "./src/tech-area.ts",
-    "./sanitize-html": "./src/sanitize-html.ts"
+    "./sanitize-html": "./src/sanitize-html.ts",
+    "./text": "./src/text.ts"
   },
   "scripts": {
     "db:generate": "drizzle-kit generate",

--- a/packages/db/scripts/unwrap-emphasis.ts
+++ b/packages/db/scripts/unwrap-emphasis.ts
@@ -1,0 +1,93 @@
+/**
+ * 実シートの project 本文から対になった **強調** を外す。
+ * 生成ラベル（**業務内容** 等）はコード側で出すので、保存フィールドだけ対象。
+ *
+ *   ドライラン: pnpm --filter @skillsheet/db exec tsx scripts/unwrap-emphasis.ts
+ *   書き込み:   pnpm --filter @skillsheet/db exec tsx scripts/unwrap-emphasis.ts --write
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isProjectBlockData, type ProjectItem } from '../src/blocks';
+import { unwrapEmphasis } from '../src/text';
+
+const SHEET_ID = '18a79e66-75e2-47e8-922e-d61342bb5233';
+const FIELDS = ['summary', 'duties', 'acquired', 'comment'] as const;
+
+function loadWebEnvLocal(): void {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [resolve(here, '../../../apps/web/.env.local'), resolve(here, '../../../.env.local')];
+  for (const envPath of candidates) {
+    if (!existsSync(envPath)) continue;
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) continue;
+      const key = trimmed.slice(0, eqIndex).trim();
+      let value = trimmed.slice(eqIndex + 1).trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      if (process.env[key] === undefined) process.env[key] = value;
+    }
+    return;
+  }
+}
+loadWebEnvLocal();
+
+function unwrapItem(item: ProjectItem): { item: ProjectItem; hits: string[] } {
+  const hits: string[] = [];
+  const next = { ...item };
+  for (const field of FIELDS) {
+    const raw = next[field];
+    if (typeof raw !== 'string' || raw.length === 0) continue;
+    const cleaned = unwrapEmphasis(raw);
+    if (cleaned !== raw) {
+      hits.push(field);
+      next[field] = cleaned;
+    }
+  }
+  return { item: next, hits };
+}
+
+async function main(): Promise<void> {
+  const write = process.argv.includes('--write');
+  const { getSkillSheetById, saveSkillSheetBlocks } = await import('../src/skillsheet');
+
+  const sheet = await getSkillSheetById(SHEET_ID);
+  const backupDir = '/tmp/skillsheet-unwrap';
+  mkdirSync(backupDir, { recursive: true });
+  const backupPath = `${backupDir}/${SHEET_ID}.json`;
+  writeFileSync(backupPath, JSON.stringify(sheet.blocks, null, 2));
+  console.log('BACKUP', backupPath);
+
+  let changedItems = 0;
+  const nextBlocks = sheet.blocks.map((block) => {
+    if (block.type !== 'project' || !isProjectBlockData(block.data)) return { type: block.type, data: block.data };
+    const items = block.data.items.map((item) => {
+      const { item: next, hits } = unwrapItem(item);
+      if (hits.length > 0) {
+        changedItems += 1;
+        console.log('UNWRAP', item.title, hits.join(','));
+      }
+      return next;
+    });
+    return { type: block.type as const, data: { ...block.data, items } };
+  });
+
+  console.log('CHANGED_ITEMS', changedItems);
+  if (!write) {
+    console.log('DRY RUN — DB へは書き込んでいません（--write で実行すると保存します）');
+    return;
+  }
+  await saveSkillSheetBlocks(sheet.title, nextBlocks, SHEET_ID);
+  console.log('SAVED', SHEET_ID);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/db/src/blocks.ts
+++ b/packages/db/src/blocks.ts
@@ -12,6 +12,7 @@ import { flattenTech, formatMonthToken, formatPeriodDisplay, normalizeProcess, P
 import { sanitizeMarkdown, sanitizeScriptAndStyle } from './sanitize-html';
 // tech-area.ts はこのファイルから型のみを取り込むため、実行時の循環は発生しない。
 import { resolveProjectArea } from './tech-area';
+import { collapseSoftBreaks } from './text';
 
 export type BlockType = 'markdown' | 'table' | 'skills' | 'experience' | 'profile' | 'stats' | 'project';
 
@@ -751,20 +752,20 @@ export function projectBlockToMarkdown(data: ProjectBlockData, opts?: { includeH
       lines.push('');
       lines.push('**業務内容**');
       lines.push('');
-      lines.push(asInlineMarkdown(item.duties.trim()));
+      lines.push(asInlineMarkdown(collapseSoftBreaks(item.duties.trim())));
     }
     if (item.acquired.trim()) {
       lines.push('');
       lines.push('**習得スキル・実績**');
       lines.push('');
-      lines.push(asInlineMarkdown(item.acquired.trim()));
+      lines.push(asInlineMarkdown(collapseSoftBreaks(item.acquired.trim())));
     }
     // 案件コメント（ProjectItem.comment）。案件1件あたり数百文字の本文で、
     // 画面では InlineMarkdown で描画されているのに PDF には出力先が無く、
     // 最も情報量の多い文章が丸ごと欠落していた（#242）。
     if (item.comment?.trim()) {
       lines.push('');
-      lines.push(asInlineMarkdown(item.comment.trim()));
+      lines.push(asInlineMarkdown(collapseSoftBreaks(item.comment.trim())));
     }
     lines.push('');
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,3 +5,4 @@ export * from './process';
 export * from './real-volume-demo';
 export * from './schema';
 export * from './skillsheet';
+export * from './text';

--- a/packages/db/src/text.test.ts
+++ b/packages/db/src/text.test.ts
@@ -23,6 +23,10 @@ describe('collapseSoftBreaks', () => {
   it('リスト項目の折り返し行は項目に接続する', () => {
     expect(collapseSoftBreaks('1. 前半\n後半')).toBe('1. 前半 後半');
   });
+
+  it('Setext 見出しの下線はつなげない', () => {
+    expect(collapseSoftBreaks('Setext 見出し\n===\n本文')).toBe('Setext 見出し\n===\n本文');
+  });
 });
 
 describe('unwrapEmphasis', () => {

--- a/packages/db/src/text.test.ts
+++ b/packages/db/src/text.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { collapseSoftBreaks, unwrapEmphasis } from './text';
+
+describe('collapseSoftBreaks', () => {
+  it('段落内の単独改行を空白に潰す', () => {
+    expect(collapseSoftBreaks('前半\n後半')).toBe('前半 後半');
+  });
+
+  it('空行は段落境界として残す', () => {
+    expect(collapseSoftBreaks('一段落\n\n二段落')).toBe('一段落\n\n二段落');
+  });
+
+  it('番号リストの行はつなげない', () => {
+    expect(collapseSoftBreaks('1. 指摘した\n2. ありそうだと感じた')).toBe('1. 指摘した\n2. ありそうだと感じた');
+  });
+
+  it('箇条書きの行はつなげない', () => {
+    expect(collapseSoftBreaks('- 前\n- 後')).toBe('- 前\n- 後');
+    expect(collapseSoftBreaks('• 前\n• 後')).toBe('• 前\n• 後');
+  });
+
+  it('リスト項目の折り返し行は項目に接続する', () => {
+    expect(collapseSoftBreaks('1. 前半\n後半')).toBe('1. 前半 後半');
+  });
+});
+
+describe('unwrapEmphasis', () => {
+  it('対になった ** だけ外す', () => {
+    expect(unwrapEmphasis('出来るできないを**指摘**し')).toBe('出来るできないを指摘し');
+  });
+});

--- a/packages/db/src/text.ts
+++ b/packages/db/src/text.ts
@@ -1,6 +1,7 @@
 const LIST_LINE = /^\s*(?:[-*•]|\d+[.)])\s/;
+const SETEXT_UNDERLINE = /^\s*(?:={2,}|-{3,})\s*$/;
 
-/** 段落内の単独改行を空白に潰す。空行は段落、リスト行は行のまま残す。 */
+/** 段落内の単独改行を空白に潰す。空行は段落、リスト行と Setext 下線は行のまま残す。 */
 export function collapseSoftBreaks(text: string): string {
   return text
     .replace(/\r\n/g, '\n')
@@ -10,11 +11,12 @@ export function collapseSoftBreaks(text: string): string {
       for (const raw of para.split('\n')) {
         const line = raw.trim();
         if (line.length === 0) continue;
-        if (out.length === 0 || LIST_LINE.test(line)) {
+        const prev = out[out.length - 1] ?? '';
+        if (out.length === 0 || LIST_LINE.test(line) || SETEXT_UNDERLINE.test(line) || SETEXT_UNDERLINE.test(prev)) {
           out.push(line);
           continue;
         }
-        out[out.length - 1] = `${out[out.length - 1]} ${line}`;
+        out[out.length - 1] = `${prev} ${line}`;
       }
       return out.join('\n');
     })

--- a/packages/db/src/text.ts
+++ b/packages/db/src/text.ts
@@ -1,0 +1,27 @@
+const LIST_LINE = /^\s*(?:[-*•]|\d+[.)])\s/;
+
+/** 段落内の単独改行を空白に潰す。空行は段落、リスト行は行のまま残す。 */
+export function collapseSoftBreaks(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .split(/\n{2,}/)
+    .map((para) => {
+      const out: string[] = [];
+      for (const raw of para.split('\n')) {
+        const line = raw.trim();
+        if (line.length === 0) continue;
+        if (out.length === 0 || LIST_LINE.test(line)) {
+          out.push(line);
+          continue;
+        }
+        out[out.length - 1] = `${out[out.length - 1]} ${line}`;
+      }
+      return out.join('\n');
+    })
+    .join('\n\n');
+}
+
+/** インライン強調 `**…**` を外す。対にならない `**` は残さない。 */
+export function unwrapEmphasis(text: string): string {
+  return text.replace(/\*\*([^*]+)\*\*/g, '$1');
+}


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #257
close #258
close #259
close #260
close #261

Refs #249
Refs #253
Refs #254
Refs #255
Refs #256

### 概要

案件詳細の技術一覧が多すぎて見える問題を直します。
技術は検索して選ぶ形にしました。案件の検索欄はそのままです。

案件カードは1列にして余白を広げました。
原稿の途中改行は空白に潰します。番号リストはつなぎません。

PDFは途中改行を強制改行にしていた処理をやめました。
D社の本文で出して、文字の重なりが無いことを確認しています。

本文の不要な太字を外すスクリプトも足しています。
本番データへの適用は、環境変数を置いたあとに別途実行します。

### 見て欲しいポイント

- 技術の選択欄と、案件の検索欄が分かれていること
- PDFのD社本文で文字が重ならないこと
- 番号付きの行が1行に潰れないこと

### 見なくてもよいポイント

- 太字を外すスクリプト本体。実行は今回のPRではしません
- テスト用に書き出すD社PDFの経路

### その他(あれば)

このマシンにDB接続情報が無く、実ビューアでの操作確認はできていません。
単体テストと、D社本文のPDF目視までです。

---

### PR チェックポイント

- [ ] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [ ] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)

技術選択の操作感と、PDFの切れ方を見てほしいです。