### PR TITLE
fix: 画像・コピー・検索・キーボード・制御文字の5経路を直す

### DIFF
--- a/apps/web/src/components/blocks/project-section.test.tsx
+++ b/apps/web/src/components/blocks/project-section.test.tsx
@@ -1,0 +1,84 @@
+import type { ProjectBlockData, ProjectItem } from '@skillsheet/db/blocks';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ProjectSection } from './project-section';
+
+// framer-motion はアニメーション専用 props を除いた素の要素に置換する
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: () => {
+        const Passthrough = ({ children, ...props }: { children?: ReactNode }) => {
+          const rest = { ...props } as Record<string, unknown>;
+          for (const key of ['initial', 'animate', 'transition', 'whileHover', 'whileTap', 'exit', 'variants']) {
+            delete rest[key];
+          }
+          return <div {...rest}>{children}</div>;
+        };
+        return Passthrough;
+      },
+    },
+  ),
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useReducedMotion: () => false,
+}));
+
+const EMPTY_TECH = { lang: [], fw: [], db: [], infra: [], tools: [], collab: [] };
+
+function buildItem(overrides: Partial<ProjectItem>): ProjectItem {
+  return {
+    id: 'p1',
+    companyId: 'c1',
+    title: '案件A',
+    scope: '',
+    period: '2025.01 — 2025.06',
+    role: 'エンジニア',
+    team: '5',
+    tech: EMPTY_TECH,
+    process: [],
+    duties: '',
+    acquired: '',
+    comment: '',
+    ...overrides,
+  };
+}
+
+// summary が空文字の案件。カードには duties が出るので、その語で検索できなければ
+// 「見えているのに探せない」状態になる。
+const DATA: ProjectBlockData = {
+  companies: [{ id: 'c1', name: 'Q 社', kind: '', period: '', note: '' }],
+  items: [
+    buildItem({ id: 'p1', title: '案件A', summary: '', duties: '決済基盤のリプレイス' }),
+    buildItem({ id: 'p2', title: '案件B', summary: '社内向け管理画面の改善', duties: '' }),
+  ],
+};
+
+describe('ProjectSection の検索', () => {
+  it('summary が空文字でも、カードに出ている duties の語で絞り込める', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={DATA} showProcess={false} showTimeline={false} />);
+
+    // 前提: 検索前は両方見えている。
+    expect(screen.getByText('案件A')).toBeInTheDocument();
+    expect(screen.getByText('案件B')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), '決済基盤');
+
+    expect(screen.getByText('案件A')).toBeInTheDocument();
+    expect(screen.queryByText('案件B')).not.toBeInTheDocument();
+  });
+
+  it('summary が入っている案件は従来どおり summary の語で絞り込める', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={DATA} showProcess={false} showTimeline={false} />);
+
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), '管理画面');
+
+    expect(screen.getByText('案件B')).toBeInTheDocument();
+    expect(screen.queryByText('案件A')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/blocks/project-section.tsx
+++ b/apps/web/src/components/blocks/project-section.tsx
@@ -90,7 +90,9 @@ export function ProjectSection({
         projectAreaText(item.scope, item.tech),
         item.role,
         company?.name ?? '',
-        item.summary ?? item.duties,
+        // 表示側（project-card.tsx）は `summary?.trim() || duties`。`??` だと空文字の
+        // summary が採用され、カードに出ている duties の語で検索してもヒットしない。
+        item.summary?.trim() || item.duties,
         ...tech,
       ]
         .join(' ')

--- a/apps/web/src/components/blocks/tech-filter.test.tsx
+++ b/apps/web/src/components/blocks/tech-filter.test.tsx
@@ -92,6 +92,18 @@ describe('TechFilter', () => {
     expect(onToggle).toHaveBeenCalledWith(ALL[0].name);
   });
 
+  it('未選択から ArrowUp を押すと末尾の候補が選ばれる（末尾から2番目に飛ばない）', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(<TechFilter all={ALL} active={[]} count={3} total={3} {...noop} onToggle={onToggle} />);
+
+    const input = screen.getByLabelText('技術を選ぶ');
+    await user.click(input);
+    await user.keyboard('{ArrowUp}{Enter}');
+
+    expect(onToggle).toHaveBeenCalledWith(ALL[ALL.length - 1].name);
+  });
+
   it('矢印キーで移動中の候補を aria-activedescendant が指す', async () => {
     const user = userEvent.setup();
     render(<TechFilter all={ALL} active={[]} count={3} total={3} {...noop} />);

--- a/apps/web/src/components/blocks/tech-filter.tsx
+++ b/apps/web/src/components/blocks/tech-filter.tsx
@@ -109,7 +109,9 @@ export function TechFilter({ all, active, query, onQueryChange, onToggle, onClea
             } else if (e.key === 'ArrowUp' && matches.length > 0) {
               e.preventDefault();
               setOpen(true);
-              setHi((hi - 1 + matches.length) % matches.length);
+              // 未選択は hi = -1。素直に剰余を取ると (-1-1+n)%n = n-2 で末尾から
+              // 2番目が選ばれる。WAI-ARIA の combobox は未選択からの ↑ で末尾へ行く。
+              setHi(hi < 0 ? matches.length - 1 : (hi - 1 + matches.length) % matches.length);
             } else if (e.key === 'Escape') {
               setOpen(false);
               setHi(-1);

--- a/apps/web/src/components/code-block.test.tsx
+++ b/apps/web/src/components/code-block.test.tsx
@@ -6,6 +6,14 @@ import { renderWithProviders } from '@/test/render-with-providers';
 
 import CodeBlock from './code-block';
 
+// コピー失敗の通知先。実際の toast は Toaster の描画に依存するので、呼ばれたことだけを見る。
+// renderWithProviders が同じモジュールの Toaster を描画するため、部分モックにする。
+const toastError = vi.fn();
+vi.mock('sonner', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('sonner')>();
+  return { ...actual, toast: { ...actual.toast, error: (...args: unknown[]) => toastError(...args) } };
+});
+
 // framer-motion をモック（CodeBlock 自体は未使用だが、依存の安全のため）
 vi.mock('framer-motion', () => ({
   motion: new Proxy(
@@ -75,6 +83,25 @@ describe('CodeBlock', () => {
       await waitFor(async () => {
         expect(await navigator.clipboard.readText()).toBe('const greeting = "Hello, World!";');
       });
+    });
+
+    it('クリップボードが使えないとき、失敗が toast で伝わりコピー済み表示にならない', async () => {
+      const user = userEvent.setup();
+      // 平文 HTTP 配信や権限拒否では writeText が reject する。捕捉していないと
+      // 未処理の rejection になり、利用者には「押しても何も起きない」だけが残る。
+      const writeText = vi
+        .spyOn(navigator.clipboard, 'writeText')
+        .mockRejectedValue(new DOMException('denied', 'NotAllowedError'));
+
+      renderCodeBlock();
+      await user.click(screen.getByRole('button', { name: 'コードをコピー' }));
+
+      await waitFor(() => {
+        expect(toastError).toHaveBeenCalledWith('コピーできませんでした。手動で選択してコピーしてください。');
+      });
+      // 失敗したのに「コピーしました」表示へ切り替わらない。
+      expect(screen.getByRole('button', { name: 'コードをコピー' })).toBeInTheDocument();
+      writeText.mockRestore();
     });
   });
 

--- a/apps/web/src/components/code-block.tsx
+++ b/apps/web/src/components/code-block.tsx
@@ -20,6 +20,7 @@ import yaml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-async-light';
 import vs from 'react-syntax-highlighter/dist/esm/styles/prism/vs';
 import vscDarkPlus from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -71,7 +72,16 @@ const CodeBlock = memo(function CodeBlock({ children, className }: CodeBlockProp
 
   const handleCopy = async () => {
     const code = String(children).replace(/\n$/, '');
-    await navigator.clipboard.writeText(code);
+    try {
+      // navigator.clipboard はセキュアコンテキスト（HTTPS / localhost）限定で、
+      // 平文 HTTP 配信では undefined になる。権限拒否でも reject する。
+      // 捕捉しないと未処理の rejection になり、利用者には「押しても何も起きない」
+      // だけが残る（成功時の状態変化にも到達しない）。
+      await navigator.clipboard.writeText(code);
+    } catch {
+      toast.error('コピーできませんでした。手動で選択してコピーしてください。');
+      return;
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), COPIED_RESET_MS);
   };

--- a/apps/web/src/components/inline-markdown.test.tsx
+++ b/apps/web/src/components/inline-markdown.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { InlineMarkdown } from './inline-markdown';
 
@@ -56,5 +56,15 @@ describe('InlineMarkdown', () => {
     expect(container.textContent ?? '').not.toContain('alert(1)');
     expect(container.textContent ?? '').not.toContain('<script>');
     expect(container.textContent ?? '').toContain('A'.repeat(50));
+  });
+
+  it('リンクに HAST の node が DOM 属性として載らない（React の unknown prop 警告を出さない）', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<InlineMarkdown content="[公式サイト](https://example.com)を参照。" />);
+    const link = screen.getByRole('link', { name: '公式サイト' });
+
+    expect(link.hasAttribute('node')).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/apps/web/src/components/inline-markdown.tsx
+++ b/apps/web/src/components/inline-markdown.tsx
@@ -49,7 +49,9 @@ export function InlineMarkdown({ content, className, linksTabbable = true }: Inl
           img: ({ alt }) => (alt ? alt : null),
           // Tailwind preflight がリンクの色・下線をリセットするため明示的に指定しないと、
           // 周囲の地の文と見分けが付かず発見性が無くなる（レビュー指摘）。
-          a: ({ children, ...props }) => (
+          // react-markdown 10 はカスタムコンポーネントへ HAST の `node` を渡す。
+          // そのまま spread すると DOM 属性として <a> に載り、React の警告になる。
+          a: ({ children, node: _node, ...props }) => (
             <a
               {...props}
               tabIndex={linksTabbable ? undefined : -1}

--- a/apps/web/src/components/pdf/glyph-coverage.node.test.tsx
+++ b/apps/web/src/components/pdf/glyph-coverage.node.test.tsx
@@ -59,4 +59,48 @@ describe('glyph-coverage（Noto Sans JP の収録表）', () => {
     // 改行・タブは cmap に無いがレイアウトに必要なのでそのまま残す。
     expect(toRenderableText('あ\nい\tう')).toBe('あ\nい\tう');
   });
+
+  it('改行・タブ・CR 以外の C0 制御文字は落とす（紙面に見えないゴミを残さない）', () => {
+    // NUL / BEL / ESC などはフォントに字形が無く、cmap 判定にも掛からないまま
+    // そのまま PDF に載っていた。ASCII だけの文字列は早期リターンに入るため、
+    // 早期リターン側の判定も同時に固定する。
+    expect(toRenderableText('a\u0000b')).toBe('ab');
+    expect(toRenderableText('\u0007警告\u001b')).toBe('警告');
+    expect(toRenderableText('DEL\u007f')).toBe('DEL');
+    // レイアウトに必要な3文字は残る（上と同じ経路を通っても消えない）。
+    expect(toRenderableText('a\u0000b\nc\td\re')).toBe('ab\nc\td\re');
+  });
+});
+
+describe('truetype-cmap（壊れたフォントの読み取り）', () => {
+  /** cmap の format 4 サブテーブルだけを持つ最小の sfnt を組み立てる。 */
+  function buildFontWithFormat4(segCountX2: number, subtableBytes: number): Buffer {
+    const cmapAt = 12 + 16;
+    const subtableAt = cmapAt + 4 + 8;
+    const font = Buffer.alloc(subtableAt + subtableBytes);
+    font.writeUInt16BE(1, 4); // numTables
+    font.write('cmap', 12, 'latin1');
+    font.writeUInt32BE(cmapAt, 12 + 8); // table offset
+    font.writeUInt32BE(4 + 8 + subtableBytes, 12 + 12); // table length
+    font.writeUInt16BE(1, cmapAt + 2); // numSubtables
+    font.writeUInt16BE(3, cmapAt + 4); // platform: Windows
+    font.writeUInt16BE(1, cmapAt + 6); // encoding: BMP
+    font.writeUInt32BE(subtableAt - cmapAt, cmapAt + 8); // subtable offset（cmap 先頭から）
+    font.writeUInt16BE(4, subtableAt); // format
+    if (subtableBytes >= 8) font.writeUInt16BE(segCountX2, subtableAt + 6);
+    return font;
+  }
+
+  it('segCount が実体より大きくても RangeError にならず、読める分で打ち切る', () => {
+    // 壊れた（あるいは切り詰められた）フォントは segCountX2 に実体より大きな値を書ける。
+    // 境界チェックが無いと readUInt16BE が RangeError を投げ、収録表の検証ごと落ちる。
+    const font = buildFontWithFormat4(0x1000, 32);
+    expect(() => readCoveredCodePoints(font)).not.toThrow();
+    expect(readCoveredCodePoints(font).size).toBe(0);
+  });
+
+  it('format 4 のヘッダすら入っていないサブテーブルでも落ちない', () => {
+    const font = buildFontWithFormat4(2, 4);
+    expect(() => readCoveredCodePoints(font)).not.toThrow();
+  });
 });

--- a/apps/web/src/components/pdf/glyph-coverage.ts
+++ b/apps/web/src/components/pdf/glyph-coverage.ts
@@ -287,16 +287,24 @@ export const MISSING_GLYPH_PLACEHOLDER = '\u3013';
 // 有無では防げないので、補助面は一律で代替表記に倒す。
 const SUPPLEMENTARY_PLANE_START = 0x10000;
 
+/** 改行・タブ・CR だけは Text 側が扱うので残す。それ以外の C0 制御文字は落とす。 */
+function isLayoutControl(codePoint: number): boolean {
+  return codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+}
+
 /**
  * PDF に載せる前に、登録フォントが描けない文字を安全な代替へ置き換える。
  * 描ける文字しか残らないため、無関係なグリフが重なって直後の文字まで潰す
- * （Issue #263 E）ことが構造的に起こらなくなる。
+ * （Issue #263 E）ことが構造的に起こらなくなる。制御文字は改行・タブ・CR だけを
+ * 通し、残り（NUL 等）は落とす。
  */
 export function toRenderableText(text: string): string {
   // ASCII だけの文字列が大半なので、走査前に安価な判定で早期リターンする。
+  // `> 0x7e` だけを見ると NUL 等の C0 制御文字が素通りする（安全化の契約が崩れる）。
   let needsWork = false;
   for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) > 0x7e) {
+    const code = text.charCodeAt(i);
+    if (code > 0x7e || (code < 0x20 && !isLayoutControl(code))) {
       needsWork = true;
       break;
     }
@@ -306,16 +314,18 @@ export function toRenderableText(text: string): string {
   let out = '';
   for (const ch of text) {
     const codePoint = ch.codePointAt(0) ?? 0;
+    // 改行・タブ・CR は Text 側で扱うのでそのまま通す（cmap には載らない）。
+    if (isLayoutControl(codePoint)) {
+      out += ch;
+      continue;
+    }
+    // それ以外の C0 制御文字は、置換文字にすると見えないゴミが紙面に出るので落とす。
+    if (codePoint < 0x20 || codePoint === 0x7f) continue;
     if (codePoint < SUPPLEMENTARY_PLANE_START && isRenderableCodePoint(codePoint)) {
       out += ch;
       continue;
     }
     if (isInvisibleFormatCodePoint(codePoint)) continue;
-    // 改行・タブは Text 側で扱うのでそのまま通す（cmap には載らない）。
-    if (ch === '\n' || ch === '\t' || ch === '\r') {
-      out += ch;
-      continue;
-    }
     out += MISSING_GLYPH_PLACEHOLDER;
   }
   return out;

--- a/apps/web/src/components/pdf/truetype-cmap.ts
+++ b/apps/web/src/components/pdf/truetype-cmap.ts
@@ -25,6 +25,8 @@ function findTable(font: Buffer, wanted: string): { offset: number; length: numb
 }
 
 function readFormat4(font: Buffer, at: number, out: Set<number>): void {
+  // format 4 のヘッダは 14 バイト。ここが読めない時点で壊れているので何もしない。
+  if (at + 14 > font.length) return;
   const segCountX2 = font.readUInt16BE(at + 6);
   const segCount = segCountX2 / 2;
   const endAt = at + 14;
@@ -32,6 +34,10 @@ function readFormat4(font: Buffer, at: number, out: Set<number>): void {
   const deltaAt = startAt + segCountX2;
   const rangeAt = deltaAt + segCountX2;
   for (let seg = 0; seg < segCount; seg++) {
+    // segCountX2 は 16bit 生値なので、壊れたフォントでは実体より大きな配列を宣言できる。
+    // readUInt16BE は範囲外で例外を投げるため、readFormat12 と同じく黙って打ち切る
+    // （読める分だけ拾えれば収録表の突き合わせには足りる）。
+    if (rangeAt + seg * 2 + 2 > font.length) break;
     const end = font.readUInt16BE(endAt + seg * 2);
     const start = font.readUInt16BE(startAt + seg * 2);
     if (start > end) continue;

--- a/apps/web/src/components/skill-sheet-viewer.test.tsx
+++ b/apps/web/src/components/skill-sheet-viewer.test.tsx
@@ -1,5 +1,6 @@
 import type { Block } from '@skillsheet/db/blocks';
 import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -24,6 +25,13 @@ vi.mock('framer-motion', () => ({
   ),
   AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
   useReducedMotion: () => false,
+}));
+
+// Lightbox 本体は jsdom で描画しても開いているスライドを機械的に読み取れないため、
+// 受け取った index と slides をそのまま属性に出すスタブに置き換える。
+vi.mock('yet-another-react-lightbox', () => ({
+  default: ({ open, slides, index }: { open: boolean; slides: { src: string }[]; index: number }) =>
+    open ? <div data-testid="lightbox" data-index={index} data-src={slides[index]?.src ?? ''} /> : null,
 }));
 
 const DETAILS_CONTENT = `## テストセクション
@@ -259,5 +267,20 @@ describe('SkillSheetViewer', () => {
     // 固定 240px の minmax だけだと 320px 幅で列自体がコンテナよりはみ出す
     // （実機/Playwright 計測で確認済み）。min() でコンテナ幅を上限にキャップする。
     expect(grid.className).toContain('minmax(min(240px,100%),1fr)');
+  });
+
+  it('相対パスの画像を押すと、押した画像そのものが Lightbox で開く', async () => {
+    const user = userEvent.setup();
+    // 画面の <img src> は絶対URLへ解決されるので、Markdown の生値（相対パス）と
+    // そのまま比較すると必ず -1 になり、別のスライドが開いていた。
+    const content = '![一枚目](/uploads/a.png)\n\n![二枚目](/uploads/b.png)\n';
+    render(<SkillSheetViewer skillSheet={{ title: 'テスト', content }} />);
+
+    const second = await screen.findByAltText('二枚目');
+    await user.click(second);
+
+    const lightbox = await screen.findByTestId('lightbox');
+    expect(lightbox).toHaveAttribute('data-index', '1');
+    expect(lightbox.getAttribute('data-src')).toContain('/uploads/b.png');
   });
 });

--- a/apps/web/src/components/skill-sheet-viewer.tsx
+++ b/apps/web/src/components/skill-sheet-viewer.tsx
@@ -304,8 +304,12 @@ const SkillSheetViewer = ({ skillSheet, blocks, compareMode = false, views }: Sk
       .filter((img) => isSafeImageSrc(img.src));
     setLightboxImages(images);
 
-    const index = images.findIndex((img) => img.src === src);
-    setCurrentImageIndex(index);
+    // img.src は絶対URLに解決済み。src は Markdown の生値で相対パスもあり得るため、
+    // 揃えずに比較すると `/uploads/a.png` のような画像で必ず -1 になり、押したのとは
+    // 別のスライドが開く（Lightbox に -1 を渡すことにもなる）。
+    const resolved = new URL(src, window.location.href).href;
+    const index = images.findIndex((img) => img.src === resolved);
+    setCurrentImageIndex(index < 0 ? 0 : index);
     setLightboxOpen(true);
   }, []);
 


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #284

### 概要

どれもエラーを出さずに静かに期待と違う結果になる経路を直しました。7件すべてについて、
**直す前のコードへ戻すと落ちる**ことを機械的に確認した回帰テストを対にして入れています。

| 経路 | 直す前に起きていたこと | 直した内容 |
| --- | --- | --- |
| 画像クリック | `<img src>` は絶対URLに解決済みなので、Markdown の生値（相対パス）と比較すると `/uploads/a.png` のような画像で必ず `-1` になり、押したのとは別のスライドが開いていた（Lightbox に `-1` を渡してもいた） | 比較前に絶対URLへ揃え、見つからないときも `-1` を渡さない |
| コピー | `navigator.clipboard` はセキュアコンテキスト限定で、平文 HTTP や権限拒否では reject する。捕捉していないため未処理の rejection になり、利用者には「押しても何も起きない」だけが残っていた | 捕捉して既存の toast で伝える |
| 案件検索 | 表示側は `summary?.trim() \|\| duties` なのに検索側は `summary ?? duties` で、空文字の `summary` を持つ案件は**カードに出ている `duties` の語で検索してもヒットしなかった** | フォールバック規則を表示側に揃える |
| 技術を選ぶ欄 | 未選択（`hi = -1`）からの ↑ は `(-1-1+n)%n = n-2` で末尾から2番目に飛んでいた | WAI-ARIA の combobox どおり末尾へ回り込ませる |
| PDF の制御文字 | 改行・タブ・CR 以外の C0 制御文字（NUL / BEL / ESC / DEL）が素通りしていた。ASCII だけの文字列は早期リターンに入るため、そこも同時に漏れていた | 早期リターン側の判定も含めて落とす |
| `readFormat4` | `readFormat12` にはある境界チェックが無く、壊れた cmap で `RangeError` を投げて収録表の検証ごと落ちる | 同じ形の境界チェックを入れ、読める分で打ち切る |
| `inline-markdown` | react-markdown 10 が渡す HAST の `node` をそのまま `<a>` へ spread しており、DOM 属性として載っていた | 分割代入で落とす |

### 見て欲しいポイント

- [ ] **回帰テストが空虚でないこと**。7件それぞれについて、修正だけを元へ戻して該当テストを走らせ、全件が落ちることを確認済みです（下表）。
- [ ] 案件検索のフォールバック規則が `project-card.tsx:26` と一字一句同じ式になっていること。ここが再びずれると「見えているのに探せない」が戻ります。
- [ ] `toRenderableText` の**早期リターン側**も直していること。ここだけ直し忘れると ASCII 文字列中の NUL が素通りし続けます。

| 戻した修正 | 該当テスト | 結果 |
| --- | --- | --- |
| lightbox 絶対URL化 | `skill-sheet-viewer.test.tsx` | 落ちる |
| コピー失敗の捕捉 | `code-block.test.tsx` | 落ちる |
| 案件検索の summary フォールバック | `project-section.test.tsx`（新規） | 落ちる |
| 未選択からの ArrowUp | `tech-filter.test.tsx` | 落ちる |
| inline-markdown の node 除去 | `inline-markdown.test.tsx` | 落ちる |
| C0 制御文字の除去 | `glyph-coverage.node.test.tsx` | 落ちる |
| `readFormat4` の境界チェック | `glyph-coverage.node.test.tsx` | 落ちる |

### 見なくてもよいポイント

- [ ] `code-block.test.tsx` の `sonner` 部分モック。`renderWithProviders` が同じモジュールの `Toaster` を描画するため `importOriginal` を挟んだだけで、意味は変えていません。
- [ ] `skill-sheet-viewer.test.tsx` の Lightbox スタブ。jsdom では開いているスライドを機械的に読めないため、受け取った `index` / `slides` を属性に出すだけの置き換えです。

### その他(あれば)

ローカルゲートは4種とも exit 0（`pnpm run lint` / `pnpm -r type-check` / `pnpm -r --if-present test` = 854 件全緑 / `pnpm build`）。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外） — 本文に `close #284`
- [x] 複数の変更が 1 つの PR に入り込んでいないか — SBI #284 が列挙した7件のみ
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか — 依存の追加・変更なし
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例） — 該当なし

### レビュー観点

- [x] 想定通りに動作するか
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPBoc75HosYVAtJzye7ZCx)_