### PR TITLE
fix: 案件カードの役割の位置を揃え、直った不具合2件が戻ったら落ちるテストを足す

### DIFF
--- a/apps/web/src/components/blocks/project-card.test.tsx
+++ b/apps/web/src/components/blocks/project-card.test.tsx
@@ -81,6 +81,34 @@ describe('ProjectCard', () => {
     expect(screen.queryByText(/参画/)).not.toBeInTheDocument();
   });
 
+  it('役割は会社・人数・期間と同じメタ行に1行で出る', () => {
+    render(<ProjectCard item={buildItem({})} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+
+    const metaLine = screen.getByText('役割').parentElement;
+    expect(metaLine?.tagName).toBe('P');
+    expect(metaLine).toHaveTextContent('フルスタックエンジニア · Q 社（自社サービス事業会社） · 13 名');
+  });
+
+  it('タイトルが長くても役割は独立要素にならない（右上ブロックに分離していた回帰の防止）', () => {
+    // 旧実装はヘッダーを flex-wrap の2カラムにし、役割だけを右カラムの div に単独で置いていた。
+    // タイトルが長い案件だけ右カラムが2行目へ落ち、役割の位置が案件ごとに変わっていた。
+    // 「役割だけを持つ要素が存在しない」＝メタ行に畳まれている、が構造上の判定になる。
+    const longTitle = '散らばったスキルシートを一枚に束ねる管理基盤の設計と実装、および配信経路の整理';
+    render(<ProjectCard item={buildItem({ title: longTitle })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+
+    expect(screen.queryByText('フルスタックエンジニア')).not.toBeInTheDocument();
+    expect(screen.getByText('役割').parentElement).toHaveTextContent(
+      'フルスタックエンジニア · Q 社（自社サービス事業会社） · 13 名',
+    );
+  });
+
+  it('役割が空なら「役割」ラベルを出さず、会社・人数・期間だけのメタ行にする', () => {
+    render(<ProjectCard item={buildItem({ role: '' })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+
+    expect(screen.queryByText('役割')).not.toBeInTheDocument();
+    expect(screen.getByText(/Q 社（自社サービス事業会社） · 13 名/)).toBeInTheDocument();
+  });
+
   it('コメントは italic を使わない（#152 S-2: 和文長文が合成斜体になっていた）', () => {
     const comment = '長めのコメント本文がここに入ります。';
     render(<ProjectCard item={buildItem({ comment })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);

--- a/apps/web/src/components/blocks/project-card.tsx
+++ b/apps/web/src/components/blocks/project-card.tsx
@@ -25,50 +25,54 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
   const duration = sanitizeHtml(item.duration?.trim() || deriveDuration(item.period));
   const summary = item.summary?.trim() || item.duties;
   const area = resolveProjectArea(item.scope, item.tech);
+  const meta = [
+    item.role && sanitizeHtml(item.role),
+    sanitizeHtml(company?.name),
+    item.team && formatTeamSize(item.team),
+    duration,
+  ]
+    .filter(Boolean)
+    .join(' · ');
 
   return (
     <article className="flex min-w-0 flex-col gap-6 rounded-[var(--radius-lg)] border border-border bg-card px-7 py-7 transition-colors duration-150 hover:border-primary">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="mb-1 flex items-center gap-2">
-            {/* bg-primary は on-accent と組むとライトテーマで3.74と WCAG AA 未達（Issue #198）。 */}
-            <span className="rounded-[var(--radius)] bg-primary-dark px-1.5 py-px font-mono text-[11px] text-on-accent">
-              {String(no).padStart(2, '0')}
-            </span>
-            <span className="font-mono text-[11.5px] text-faint">
-              {formatPeriodDisplay(item.period) || '(期間未入力)'}
-            </span>
-          </div>
-          <h3 className="text-[17px] leading-snug text-foreground">{sanitizeHtml(item.title) || '(タイトル未入力)'}</h3>
-          {/* 導出値には必ず「技術領域」を添える。タイトル直下という位置だけで読み手は
+      <div className="min-w-0">
+        <div className="mb-1 flex items-center gap-2">
+          {/* bg-primary は on-accent と組むとライトテーマで3.74と WCAG AA 未達（Issue #198）。 */}
+          <span className="rounded-[var(--radius)] bg-primary-dark px-1.5 py-px font-mono text-[11px] text-on-accent">
+            {String(no).padStart(2, '0')}
+          </span>
+          <span className="font-mono text-[11.5px] text-faint">
+            {formatPeriodDisplay(item.period) || '(期間未入力)'}
+          </span>
+        </div>
+        <h3 className="text-[17px] leading-snug text-foreground">{sanitizeHtml(item.title) || '(タイトル未入力)'}</h3>
+        {/* 導出値には必ず「技術領域」を添える。タイトル直下という位置だけで読み手は
               「担当した領域」と受け取るが、技術スタックから言えるのは「その技術がどの領域か」まで。
               取り込んだ scope は本人の言葉なのでラベルを付けない（tech-area.ts 参照）。 */}
-          {area.text && (
-            <p className="mt-0.5 text-[12.5px] text-muted-foreground">
-              {area.derived && <span className="kicker mr-1.5">技術領域</span>}
-              {sanitizeHtml(area.text)}
-            </p>
-          )}
-          {/* 会社概要文（CompanyInfo.note）。従来どこにも描画先が無く、ビューア・PDF・バックアップの
+        {area.text && (
+          <p className="mt-0.5 text-[12.5px] text-muted-foreground">
+            {area.derived && <span className="kicker mr-1.5">技術領域</span>}
+            {sanitizeHtml(area.text)}
+          </p>
+        )}
+        {/* 役割・会社・人数・期間の1行。以前はヘッダーを flex-wrap の2カラムにして役割を
+              右上に置いていたが、タイトルが長い案件だけ右カラムが2行目へ落ち、役割の位置が
+              案件ごとに変わって見えていた。1カラムのメタ行に畳むと位置が構造的に固定される。 */}
+        {meta && (
+          <p className="mt-1 font-mono text-[11.5px] text-faint">
+            {item.role && <span className="kicker mr-1.5">役割</span>}
+            {meta}
+          </p>
+        )}
+        {/* 会社概要文（CompanyInfo.note）。従来どこにも描画先が無く、ビューア・PDF・バックアップの
               全経路で欠落していた（#139）。projectBlockToMarkdown 側も同じ位置づけで出力する。
               空白のみの値は projectBlockToMarkdown と同じく trim() 後に判定する。 */}
-          {company?.note?.trim() && (
-            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground/80">
-              {sanitizeHtml(company.note.trim())}
-            </p>
-          )}
-        </div>
-        {/* shrink-0 だと flex item の既定 min-width:auto（コンテンツの折返し前の幅が下限）が効き、
-            320px では役割・会社名の長文が折り返さずカード幅を押し広げていた（#143）。
-            min-w-0 に変えて行として折り返せるようにする。 */}
-        <div className="min-w-0 text-right">
-          {item.role && <div className="text-[12.5px] text-foreground">{sanitizeHtml(item.role)}</div>}
-          <div className="mt-0.5 font-mono text-[11.5px] text-faint">
-            {[sanitizeHtml(company?.name), item.team && formatTeamSize(item.team), duration]
-              .filter(Boolean)
-              .join(' · ')}
-          </div>
-        </div>
+        {company?.note?.trim() && (
+          <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground/80">
+            {sanitizeHtml(company.note.trim())}
+          </p>
+        )}
       </div>
 
       {summary && (

--- a/apps/web/src/components/blocks/project-section.test.tsx
+++ b/apps/web/src/components/blocks/project-section.test.tsx
@@ -82,3 +82,17 @@ describe('ProjectSection の検索', () => {
     expect(screen.queryByText('案件A')).not.toBeInTheDocument();
   });
 });
+
+describe('ProjectSection のレイアウト', () => {
+  it('案件カードは1列に並べる（多列だとカード1枚が窄まって本文が読めない）', () => {
+    const { container } = render(<ProjectSection data={DATA} showProcess={false} showTimeline={false} />);
+
+    const cards = container.querySelectorAll('article');
+    expect(cards).toHaveLength(2);
+
+    // カードの親がカード列の grid。ブレークポイント付きの多列指定が復活していないかも見る。
+    const grid = cards[0]?.parentElement;
+    expect(grid?.className).toContain('grid-cols-1');
+    expect(grid?.className).not.toMatch(/grid-cols-[2-9]/);
+  });
+});

--- a/apps/web/src/lib/markdown-config.test.ts
+++ b/apps/web/src/lib/markdown-config.test.ts
@@ -1,0 +1,26 @@
+import remarkBreaks from 'remark-breaks';
+import remarkCjkFriendly from 'remark-cjk-friendly';
+import remarkGfm from 'remark-gfm';
+import { describe, expect, it } from 'vitest';
+
+import { MARKDOWN_REMARK_PLUGINS, PDF_REMARK_PLUGINS } from './markdown-config';
+
+// PDF の行重なりは「remark-breaks が単独改行を <br> にする」ことが原因で、症状は
+// レンダリング後の座標にしか出ない。@react-pdf を動かすテストは重いうえ %PDF が
+// 出れば通ってしまうので、原因そのもの（プラグイン構成）を直接固定しておく。
+describe('remark プラグイン構成', () => {
+  it('PDF 側は remark-breaks を含まない（<br> と Text 内の改行が二重になり行が重なる）', () => {
+    expect(PDF_REMARK_PLUGINS).not.toContain(remarkBreaks);
+  });
+
+  it('ビューア側は remark-breaks を含む（入力どおりの改行で読ませる）', () => {
+    expect(MARKDOWN_REMARK_PLUGINS).toContain(remarkBreaks);
+  });
+
+  it('GFM と CJK 強調は画面と PDF で同じにする', () => {
+    for (const plugins of [MARKDOWN_REMARK_PLUGINS, PDF_REMARK_PLUGINS]) {
+      expect(plugins).toContain(remarkGfm);
+      expect(plugins).toContain(remarkCjkFriendly);
+    }
+  });
+});


### PR DESCRIPTION
## 目的

案件カードの役割（SEやPLなど）が、案件ごとに違う場所に出ていたのを直します。

## 対応内容

役割はこれまでカード見出しの右上に単独で置いていました。
見出しが左右2枠の横並びで、タイトルが長い案件だけ右の枠が2行目に折り返されます。
そのため役割の位置が案件ごとに動いていました。

右の枠をやめ、役割を会社・人数・期間と同じ1行に入れました。
横並びが無くなるので、タイトルの長さで位置が変わることはなくなります。

あわせて、すでに直っている2件について、同じ壊れ方が戻ったときに落ちるテストを足しました。

- PDF を作るときに、原文の改行をそのまま行送りへ置き換えないこと。
  置き換えると文字の行どうしが重なって読めなくなります。
- 案件カードを縦1列に並べること。2列以上に戻すとカード1枚が細くなり、本文が読めません。

## 確認手順

1. 開発サーバーを起動し、閲覧画面の案件詳細を開く
2. タイトルの短い案件と長い案件で、役割の位置が同じことを見る

## 実測

ブラウザを自動操作して、表示中の案件カード32枚それぞれで役割の座標を取りました。
このコミットの状態では、32枚すべてカード左端から29px、上端から102pxに揃っています。
修正前は左端からの距離が29pxから782pxまでばらついていました。

比較元は同じ画面の修正前の状態です。デザインカンプは無いので、突き合わせたのは
修正前後の実画面どうしです。判定は PASS。

修正前のコードに戻してテストを流し、追加した4件が落ちることも確かめました。
型チェック、テスト861件、本番ビルドはいずれも通っています。

Closes #289
Closes #290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プロジェクトカードの役割情報を、会社名・人数・期間と同じメタ情報行に統合しました。
  * 長いタイトルでも情報が崩れにくい、1列構成のカードレイアウトに変更しました。
  * 会社概要文をカード内に表示するようにしました。

* **バグ修正**
  * 役割情報が空の場合に、不要なラベルが表示されないようにしました。

* **テスト**
  * カード表示、1列レイアウト、Markdown表示設定に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->