### PR TITLE
案件詳細を会社ごとのセクションに作り替える（Claude Design v3）

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,7 +88,7 @@
   --accent-text: #08665e;
   --accent-soft: #ddf0ed;
   --on-accent: #ffffff;
-  --border-strong: #7f9298;
+  --border-strong: #76898f;
   --bar-round: 1px;
   --head-weight: 600;
 
@@ -153,7 +153,7 @@
   --accent-text: #5eead4;
   --accent-soft: #0c2320;
   --on-accent: #03110f;
-  --border-strong: #526771;
+  --border-strong: #5a6f79;
 
   --danger: #e9695c;
   --danger-soft: #2a1715;

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,9 +9,9 @@
   Console デザイントークン。
   ティール単色 / radius 4px(lg 6px) / 影なしヘアライン / IBM Plex Sans JP。
   ライト: bg #f6f8f8, surface #fff, surface2 #f0f3f3, text #10171a, muted #4a565c,
-          border #dce3e4, accent #0d9488, accentSoft #ecfaf8.
+          border #dce3e4, border-strong #76898f, accent #0d9488, accentSoft #ddf0ed.
   ダーク: bg #0a0d0f, surface #0f1316, surface2 #141a1e, text #e6edf0, muted #98a3aa,
-          border #1d262b, accent #14b8a6, accentSoft #0c2320.
+          border #232d33, border-strong #5a6f79, accent #14b8a6, accentSoft #0c2320.
   WCAG AA:
     muted-text/bg 7.1:1 ✅  primary-dark(link)/bg 5.8:1 ✅  accent-dark/dark-surface 7.8:1 ✅
     primary(btn)/white-text 3.7:1 ⚠ ボタン大テキスト用許容 (large-text 3:1 OK)

--- a/app/globals.css
+++ b/app/globals.css
@@ -85,10 +85,10 @@
   --track: #e6ecec;
   --chip-bg: #eef3f3;
   --chip-text: #34424a;
-  --accent-text: #0b7d72;
-  --accent-soft: #ecfaf8;
+  --accent-text: #08665e;
+  --accent-soft: #ddf0ed;
   --on-accent: #ffffff;
-  --border-strong: #c8d2d4;
+  --border-strong: #7f9298;
   --bar-round: 1px;
   --head-weight: 600;
 
@@ -136,7 +136,7 @@
   /* destructive ボタンの hover（opacity-90 で 4.36:1 に低下）。#ef4444 より明るい赤で
      opacity を使わず不透明のまま 7.05:1 を確保する。 */
   --destructive-hover: #f87171;
-  --border: #1d262b;
+  --border: #232d33;
   --input: #1d262b;
   --ring: #14b8a6;
 
@@ -153,7 +153,7 @@
   --accent-text: #5eead4;
   --accent-soft: #0c2320;
   --on-accent: #03110f;
-  --border-strong: #2b363c;
+  --border-strong: #526771;
 
   --danger: #e9695c;
   --danger-soft: #2a1715;

--- a/scripts/wss-pg-proxy.mjs
+++ b/scripts/wss-pg-proxy.mjs
@@ -4,9 +4,8 @@ import { readFileSync } from 'node:fs';
 import { createServer } from 'node:https';
 import net from 'node:net';
 import process from 'node:process';
-import wsPkg from 'ws';
-
-const { WebSocketServer } = wsPkg;
+// ws は default export ではなく named export で WebSocketServer を出す（default はWebSocket本体）。
+import { WebSocketServer } from 'ws';
 
 const STATE_DIR = process.env.SKILLSHEET_LOCAL_STACK_DIR ?? '/var/lib/postgresql/skillsheet-local-stack';
 

--- a/src/components/blocks/company-jump-nav.test.tsx
+++ b/src/components/blocks/company-jump-nav.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { CompanyInfo } from '@/db/blocks';
+
+import { CompanyJumpNav, type JumpTarget } from './company-jump-nav';
+
+const company = (overrides: Partial<CompanyInfo>): CompanyInfo => ({
+  id: 'c1',
+  name: '会社A',
+  kind: '',
+  period: '',
+  note: '',
+  ...overrides,
+});
+
+describe('CompanyJumpNav', () => {
+  it('会社ごとにアンカーを1つ出す', () => {
+    const targets: JumpTarget[] = [
+      { id: 'co-0', company: company({ id: 'c1', name: 'A社' }), companyId: 'c1', itemCount: 2 },
+      { id: 'co-1', company: company({ id: 'c2', name: 'B社' }), companyId: 'c2', itemCount: 1 },
+    ];
+    render(<CompanyJumpNav targets={targets} />);
+    expect(screen.getByRole('link', { name: /A社/ })).toHaveAttribute('href', '#co-0');
+    expect(screen.getByRole('link', { name: /B社/ })).toHaveAttribute('href', '#co-1');
+  });
+
+  it('同名会社（実データの「受託」×複数を想定）には開始年月を添えて区別する', () => {
+    const targets: JumpTarget[] = [
+      {
+        id: 'co-0',
+        company: company({ id: 'c1', name: '受託', period: '2023.10 — 2024.02' }),
+        companyId: 'c1',
+        itemCount: 1,
+      },
+      {
+        id: 'co-1',
+        company: company({ id: 'c2', name: '受託', period: '2023.07 — 2024.01' }),
+        companyId: 'c2',
+        itemCount: 1,
+      },
+    ];
+    render(<CompanyJumpNav targets={targets} />);
+    const links = screen.getAllByRole('link', { name: /受託/ });
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveTextContent('2023.10—');
+    expect(links[1]).toHaveTextContent('2023.07—');
+  });
+
+  it('会社名が一意なら開始年月を出さない', () => {
+    const targets: JumpTarget[] = [
+      {
+        id: 'co-0',
+        company: company({ id: 'c1', name: 'A社', period: '2020.01 — 2020.12' }),
+        companyId: 'c1',
+        itemCount: 1,
+      },
+    ];
+    render(<CompanyJumpNav targets={targets} />);
+    expect(screen.getByRole('link', { name: /A社/ })).not.toHaveTextContent('2020.01—');
+  });
+
+  it('対象が0件なら何も描画しない', () => {
+    const { container } = render(<CompanyJumpNav targets={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/blocks/company-jump-nav.test.tsx
+++ b/src/components/blocks/company-jump-nav.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CompanyInfo } from '@/db/blocks';
 
 import { CompanyJumpNav, type JumpTarget } from './company-jump-nav';
@@ -13,15 +14,19 @@ const company = (overrides: Partial<CompanyInfo>): CompanyInfo => ({
   ...overrides,
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('CompanyJumpNav', () => {
-  it('会社ごとにアンカーを1つ出す', () => {
+  it('会社ごとにジャンプ用のボタンを1つ出す', () => {
     const targets: JumpTarget[] = [
       { id: 'co-0', company: company({ id: 'c1', name: 'A社' }), companyId: 'c1', itemCount: 2 },
       { id: 'co-1', company: company({ id: 'c2', name: 'B社' }), companyId: 'c2', itemCount: 1 },
     ];
     render(<CompanyJumpNav targets={targets} />);
-    expect(screen.getByRole('link', { name: /A社/ })).toHaveAttribute('href', '#co-0');
-    expect(screen.getByRole('link', { name: /B社/ })).toHaveAttribute('href', '#co-1');
+    expect(screen.getByRole('button', { name: /A社/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /B社/ })).toBeInTheDocument();
   });
 
   it('同名会社（実データの「受託」×複数を想定）には開始年月を添えて区別する', () => {
@@ -40,7 +45,7 @@ describe('CompanyJumpNav', () => {
       },
     ];
     render(<CompanyJumpNav targets={targets} />);
-    const links = screen.getAllByRole('link', { name: /受託/ });
+    const links = screen.getAllByRole('button', { name: /受託/ });
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveTextContent('2023.10—');
     expect(links[1]).toHaveTextContent('2023.07—');
@@ -56,7 +61,49 @@ describe('CompanyJumpNav', () => {
       },
     ];
     render(<CompanyJumpNav targets={targets} />);
-    expect(screen.getByRole('link', { name: /A社/ })).not.toHaveTextContent('2020.01—');
+    expect(screen.getByRole('button', { name: /A社/ })).not.toHaveTextContent('2020.01—');
+  });
+
+  // app/layout.tsx が <base href="{origin}/"> を注入しているため、`href="#id"` は
+  // 「現在のページ + ハッシュ」ではなく「オリジン直下 + ハッシュ」に解決される。
+  // 実機ではこれで閲覧画面から / へ飛ばされ、シートを見失った。二度と戻さないための検査。
+  it('ハッシュだけの <a> を使わない（<base> があるとページ外へ飛ぶ）', () => {
+    const targets: JumpTarget[] = [
+      { id: 'co-0', company: company({ id: 'c1', name: 'A社' }), companyId: 'c1', itemCount: 1 },
+    ];
+    const { container } = render(<CompanyJumpNav targets={targets} />);
+    expect(container.querySelectorAll('a[href^="#"]')).toHaveLength(0);
+  });
+
+  it('押すと対象セクションへスクロールし、フォーカスもそこへ送る', async () => {
+    const user = userEvent.setup();
+    const section = document.createElement('section');
+    section.id = 'co-0';
+    section.tabIndex = -1;
+    section.getBoundingClientRect = () => ({
+      top: 640,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 640,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(section);
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+
+    const targets: JumpTarget[] = [
+      { id: 'co-0', company: company({ id: 'c1', name: 'A社' }), companyId: 'c1', itemCount: 1 },
+    ];
+    render(<CompanyJumpNav targets={targets} />);
+    await user.click(screen.getByRole('button', { name: /A社/ }));
+
+    // SCROLL_OFFSET=80 ぶん手前で止める（sticky topbar に見出しが潜らないように）。
+    expect(scrollTo).toHaveBeenCalledWith({ top: 560, behavior: 'smooth' });
+    expect(document.activeElement).toBe(section);
   });
 
   it('対象が0件なら何も描画しない', () => {

--- a/src/components/blocks/company-jump-nav.tsx
+++ b/src/components/blocks/company-jump-nav.tsx
@@ -14,6 +14,33 @@ interface CompanyJumpNavProps {
   targets: JumpTarget[];
 }
 
+// app/layout.tsx が <base href="{origin}/"> を注入している（Basic 認証つきトンネルで
+// document.baseURI から認証情報を外すため）。<base> があると `href="#id"` は
+// 「現在のページ + ハッシュ」ではなく「オリジン直下 + ハッシュ」に解決され、
+// 閲覧画面から / へ飛ばされてシートを見失う。実機で踏んだ。
+// そのため既存の目次（skill-sheet-viewer.tsx の scrollToHeading）と同じく
+// button + 自前スクロールにする。
+// 見出しが sticky topbar に潜らないよう空ける余白。topbar の実測高さは
+// viewer-topbar.tsx が --viewer-topbar-h として公開している（SP では2段になり倍近く変わる）。
+const HEADROOM = 16;
+const FALLBACK_TOPBAR_HEIGHT = 64;
+
+function scrollOffset(): number {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue('--viewer-topbar-h');
+  const height = Number.parseFloat(raw);
+  return (Number.isFinite(height) ? height : FALLBACK_TOPBAR_HEIGHT) + HEADROOM;
+}
+
+function jumpTo(id: string) {
+  const element = document.getElementById(id);
+  if (!element) return;
+  const y = element.getBoundingClientRect().top + window.scrollY - scrollOffset();
+  window.scrollTo({ top: y, behavior: 'smooth' });
+  // アンカーなら移動していたはずのフォーカスを自前で送る。
+  // これが無いとキーボード利用者は飛んだ先ではなくナビの続きを Tab し続けることになる。
+  element.focus({ preventScroll: true });
+}
+
 /**
  * 「会社から探す」ジャンプナビ。同名の会社（実データでは「受託」が4回登場する）は
  * companyId 単位で別セクションのまま残すため（マージしない、プランの判断参照）、
@@ -41,16 +68,17 @@ export function CompanyJumpNav({ targets }: CompanyJumpNavProps) {
             const [startToken] = splitPeriodRange(t.company?.period ?? '');
             const qual = dup && startToken ? `${formatMonthToken(startToken)}—` : '';
             return (
-              <a
+              <button
                 key={t.id}
-                href={`#${t.id}`}
+                type="button"
+                onClick={() => jumpTo(t.id)}
                 className="inline-flex min-h-11 items-baseline gap-1.5 whitespace-nowrap rounded bg-card px-2.5 py-2 text-[13px] text-foreground hover:text-accent-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                 style={{ border: '1px solid var(--border-strong)' }}
               >
                 <span>{name}</span>
                 {qual && <span className="font-mono text-[11px] text-muted-foreground">{qual}</span>}
                 <span className="font-mono text-[11px] text-muted-foreground">{t.itemCount}</span>
-              </a>
+              </button>
             );
           })}
         </div>

--- a/src/components/blocks/company-jump-nav.tsx
+++ b/src/components/blocks/company-jump-nav.tsx
@@ -20,7 +20,8 @@ interface CompanyJumpNavProps {
 // 閲覧画面から / へ飛ばされてシートを見失う。実機で踏んだ。
 // そのため既存の目次（skill-sheet-viewer.tsx の scrollToHeading）と同じく
 // button + 自前スクロールにする。
-// 見出しが sticky topbar に潜らないよう空ける余白。topbar の実測高さは
+
+// 飛んだ先の見出しが sticky topbar に潜らないよう空ける余白。topbar の実測高さは
 // viewer-topbar.tsx が --viewer-topbar-h として公開している（SP では2段になり倍近く変わる）。
 const HEADROOM = 16;
 const FALLBACK_TOPBAR_HEIGHT = 64;

--- a/src/components/blocks/company-jump-nav.tsx
+++ b/src/components/blocks/company-jump-nav.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import type { CompanyInfo } from '@/db/blocks';
+import { formatMonthToken, splitPeriodRange } from '@/db/process';
+
+export interface JumpTarget {
+  id: string;
+  company: CompanyInfo | undefined;
+  companyId: string;
+  itemCount: number;
+}
+
+interface CompanyJumpNavProps {
+  targets: JumpTarget[];
+}
+
+/**
+ * 「会社から探す」ジャンプナビ。同名の会社（実データでは「受託」が4回登場する）は
+ * companyId 単位で別セクションのまま残すため（マージしない、プランの判断参照）、
+ * ナビ上では名前だけでは見分けられない。開始年月を添えて区別する。
+ */
+export function CompanyJumpNav({ targets }: CompanyJumpNavProps) {
+  if (targets.length === 0) return null;
+
+  const nameCounts = new Map<string, number>();
+  for (const t of targets) {
+    const name = t.company?.name ?? '(不明な会社)';
+    nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+  }
+
+  return (
+    <nav aria-label="会社別ジャンプ" className="mb-5">
+      <details open className="group">
+        <summary className="cursor-pointer select-none py-1.5 text-[13px] text-muted-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
+          会社から探す　<span className="font-mono text-[11px]">{targets.length} 社</span>
+        </summary>
+        <div className="flex flex-wrap gap-1.5 pb-0.5 pt-1.5">
+          {targets.map((t) => {
+            const name = t.company?.name ?? '(不明な会社)';
+            const dup = (nameCounts.get(name) ?? 0) > 1;
+            const [startToken] = splitPeriodRange(t.company?.period ?? '');
+            const qual = dup && startToken ? `${formatMonthToken(startToken)}—` : '';
+            return (
+              <a
+                key={t.id}
+                href={`#${t.id}`}
+                className="inline-flex min-h-11 items-baseline gap-1.5 whitespace-nowrap rounded bg-card px-2.5 py-2 text-[13px] text-foreground hover:text-accent-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                style={{ border: '1px solid var(--border-strong)' }}
+              >
+                <span>{name}</span>
+                {qual && <span className="font-mono text-[11px] text-muted-foreground">{qual}</span>}
+                <span className="font-mono text-[11px] text-muted-foreground">{t.itemCount}</span>
+              </a>
+            );
+          })}
+        </div>
+      </details>
+    </nav>
+  );
+}

--- a/src/components/blocks/company-lane.test.tsx
+++ b/src/components/blocks/company-lane.test.tsx
@@ -30,6 +30,42 @@ describe('CompanyLane', () => {
     expect(secondLeft).toBeGreaterThan(40);
   });
 
+  // 会社期間の外から始まる案件（入力ミス／退職後も続いた案件）で end < start となり、
+  // width: "-43.48%" という不正な CSS が出て帯が消えていた。
+  it('会社期間の外にある案件でも left/width が 0〜100% に収まる', () => {
+    const { container } = render(
+      <CompanyLane
+        companyPeriod="2024.01 — 2024.06"
+        items={[
+          { no: 1, period: '2025.01 — 2025.06', duration: '6ヶ月' },
+          { no: 2, period: '2023.01 — 2023.06', duration: '6ヶ月' },
+        ]}
+      />,
+    );
+    const bars = Array.from(container.querySelectorAll('[style*="left"]')) as HTMLElement[];
+    expect(bars).toHaveLength(2);
+    for (const bar of bars) {
+      const left = Number.parseFloat(bar.style.left);
+      const width = Number.parseFloat(bar.style.width);
+      expect(width).toBeGreaterThan(0);
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(left + width).toBeLessThanOrEqual(100.01);
+    }
+  });
+
+  it('案件の期間が読めないときは帯を描かない（在籍期間まるごとの帯にしない）', () => {
+    const { container } = render(
+      <CompanyLane
+        companyPeriod="2024.01 — 2024.12"
+        items={[
+          { no: 1, period: '読めない期間', duration: '' },
+          { no: 2, period: '2024.07 — 2024.12', duration: '6ヶ月' },
+        ]}
+      />,
+    );
+    expect(container.querySelectorAll('[style*="left"]')).toHaveLength(1);
+  });
+
   it('装飾用途のため aria-hidden を付ける（カード側に同じ番号がテキストで既に出ている）', () => {
     const { container } = render(
       <CompanyLane companyPeriod="2024.01 — 2024.12" items={[{ no: 1, period: '2024.01', duration: '' }]} />,

--- a/src/components/blocks/company-lane.test.tsx
+++ b/src/components/blocks/company-lane.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { CompanyLane } from './company-lane';
+
+describe('CompanyLane', () => {
+  it('会社期間がパースできなければ何も描画しない', () => {
+    const { container } = render(
+      <CompanyLane companyPeriod="不明な期間" items={[{ no: 1, period: '2024.01', duration: '' }]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('会社期間の中に案件の帯を配置する', () => {
+    const { container } = render(
+      <CompanyLane
+        companyPeriod="2024.01 — 2024.12"
+        items={[
+          { no: 1, period: '2024.01 — 2024.06', duration: '6ヶ月' },
+          { no: 2, period: '2024.07 — 2024.12', duration: '6ヶ月' },
+        ]}
+      />,
+    );
+    // 前半案件は左端(0%)から始まり、後半案件はおよそ中間(50%)から始まる。
+    const bars = container.querySelectorAll('[style*="left"]');
+    expect(bars).toHaveLength(2);
+    const firstLeft = Number.parseFloat((bars[0] as HTMLElement).style.left);
+    const secondLeft = Number.parseFloat((bars[1] as HTMLElement).style.left);
+    expect(firstLeft).toBeCloseTo(0, 0);
+    expect(secondLeft).toBeGreaterThan(40);
+  });
+
+  it('装飾用途のため aria-hidden を付ける（カード側に同じ番号がテキストで既に出ている）', () => {
+    const { container } = render(
+      <CompanyLane companyPeriod="2024.01 — 2024.12" items={[{ no: 1, period: '2024.01', duration: '' }]} />,
+    );
+    expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/components/blocks/company-lane.tsx
+++ b/src/components/blocks/company-lane.tsx
@@ -24,6 +24,13 @@ interface CompanyLaneProps {
  * 装飾目的の可視化であり、内容は上のカード一覧に numは同じ番号で既に文字で出ているため、
  * レーン自体は aria-hidden にしてスクリーンリーダーの読み上げ対象から外す。
  */
+// 1ヶ月に満たない案件でも「そこに何かある」と分かる最小幅。
+const MIN_SEGMENT_WIDTH = 4;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
 export function CompanyLane({ companyPeriod, items }: CompanyLaneProps) {
   const bounds = parsePeriodBounds(companyPeriod);
   if (!bounds) return null;
@@ -31,12 +38,20 @@ export function CompanyLane({ companyPeriod, items }: CompanyLaneProps) {
   if (total <= 0) return null;
 
   const segments = items.map((item) => {
-    const itemBounds = parsePeriodBounds(item.period) ?? bounds;
-    const start = Math.max(itemBounds.start, bounds.start);
-    const end = Math.min(Math.max(itemBounds.end, start), bounds.end);
-    const left = ((start - bounds.start) / total) * 100;
-    const width = Math.max(((end - start) / total) * 100, 4);
-    return { no: item.no, duration: item.duration, left, width: Math.min(width, 100 - left) };
+    const itemBounds = parsePeriodBounds(item.period);
+    // 期間が読めない案件に会社の在籍期間を代入すると「在籍期間まるごと担当した」と
+    // 読める帯になってしまう。読めないものは帯を描かず、番号と長さだけ残す。
+    if (!itemBounds) return { no: item.no, duration: item.duration, bar: null };
+
+    // start も会社期間の終端で止める。ここを止めないと、会社期間の外から始まる案件
+    // （データ入力ミスや、退職後も続いた案件）で end < start となり width が負になり、
+    // width: "-43.48%" という不正な CSS が出て帯が消える。
+    const start = clamp(itemBounds.start, bounds.start, bounds.end);
+    const end = clamp(itemBounds.end, start, bounds.end);
+    const width = Math.min(Math.max(((end - start) / total) * 100, MIN_SEGMENT_WIDTH), 100);
+    // 最小幅を足したぶん右にはみ出さないよう left 側を戻す。
+    const left = Math.min(((start - bounds.start) / total) * 100, 100 - width);
+    return { no: item.no, duration: item.duration, bar: { left, width } };
   });
 
   const [startToken, endToken] = splitPeriodRange(companyPeriod);
@@ -56,10 +71,12 @@ export function CompanyLane({ companyPeriod, items }: CompanyLaneProps) {
           >
             <span className="font-mono text-[11px] text-accent-text">{String(seg.no).padStart(2, '0')}</span>
             <div className="relative h-2.5 rounded-full bg-chip-bg">
-              <div
-                className="absolute inset-y-0 rounded-full bg-primary-dark"
-                style={{ left: `${seg.left.toFixed(2)}%`, width: `${seg.width.toFixed(2)}%` }}
-              />
+              {seg.bar && (
+                <div
+                  className="absolute inset-y-0 rounded-full bg-primary-dark"
+                  style={{ left: `${seg.bar.left.toFixed(2)}%`, width: `${seg.bar.width.toFixed(2)}%` }}
+                />
+              )}
             </div>
             <span className="whitespace-nowrap font-mono text-[11px] text-faint">{seg.duration}</span>
           </div>

--- a/src/components/blocks/company-lane.tsx
+++ b/src/components/blocks/company-lane.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { formatMonthToken, parsePeriodBounds, splitPeriodRange } from '@/db/process';
+
+interface LaneItem {
+  /** 表示用の通し番号（カードの番号バッジと同じ値）。 */
+  no: number;
+  period: string;
+  /** 表示用の期間の長さ（例: "3ヶ月"）。無ければ帯にラベルを出さない。 */
+  duration: string;
+}
+
+interface CompanyLaneProps {
+  /** 会社の在籍期間。パースできなければ何も描画しない。 */
+  companyPeriod: string;
+  items: LaneItem[];
+}
+
+/**
+ * 会社の在籍期間を 100% とした帯に、配下の案件を区間として配置するレーン図。
+ * 「同じ会社の中での案件の重なり・順番」を文章で説明せず図で見せる
+ * （プラン: 個人開発には付けない／案件が1件では意味が無い、は呼び出し側の isMulti 判定に委ねる）。
+ *
+ * 装飾目的の可視化であり、内容は上のカード一覧に numは同じ番号で既に文字で出ているため、
+ * レーン自体は aria-hidden にしてスクリーンリーダーの読み上げ対象から外す。
+ */
+export function CompanyLane({ companyPeriod, items }: CompanyLaneProps) {
+  const bounds = parsePeriodBounds(companyPeriod);
+  if (!bounds) return null;
+  const total = bounds.end - bounds.start;
+  if (total <= 0) return null;
+
+  const segments = items.map((item) => {
+    const itemBounds = parsePeriodBounds(item.period) ?? bounds;
+    const start = Math.max(itemBounds.start, bounds.start);
+    const end = Math.min(Math.max(itemBounds.end, start), bounds.end);
+    const left = ((start - bounds.start) / total) * 100;
+    const width = Math.max(((end - start) / total) * 100, 4);
+    return { no: item.no, duration: item.duration, left, width: Math.min(width, 100 - left) };
+  });
+
+  const [startToken, endToken] = splitPeriodRange(companyPeriod);
+  const laneStart = formatMonthToken(startToken);
+  const laneEnd = endToken ? formatMonthToken(endToken) : '現在';
+
+  return (
+    <div
+      aria-hidden="true"
+      className="flex max-w-[var(--measure,72ch)] flex-col gap-1.5 rounded-[var(--radius-lg)] border border-border bg-card px-4 py-3"
+    >
+      <div className="flex flex-col gap-1.5">
+        {segments.map((seg) => (
+          <div
+            key={seg.no}
+            className="grid grid-cols-[26px_1fr_auto] items-center gap-2.5 sm:grid-cols-[30px_1fr_auto]"
+          >
+            <span className="font-mono text-[11px] text-accent-text">{String(seg.no).padStart(2, '0')}</span>
+            <div className="relative h-2.5 rounded-full bg-chip-bg">
+              <div
+                className="absolute inset-y-0 rounded-full bg-primary-dark"
+                style={{ left: `${seg.left.toFixed(2)}%`, width: `${seg.width.toFixed(2)}%` }}
+              />
+            </div>
+            <span className="whitespace-nowrap font-mono text-[11px] text-faint">{seg.duration}</span>
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-[26px_1fr_auto] gap-2.5 sm:grid-cols-[30px_1fr_auto]">
+        <span />
+        <div className="flex justify-between gap-2.5 border-t border-border pt-1">
+          <span className="font-mono text-[11px] text-faint">{laneStart}</span>
+          <span className="font-mono text-[11px] text-faint">{laneEnd}</span>
+        </div>
+        <span />
+      </div>
+    </div>
+  );
+}

--- a/src/components/blocks/company-lane.tsx
+++ b/src/components/blocks/company-lane.tsx
@@ -16,6 +16,13 @@ interface CompanyLaneProps {
   items: LaneItem[];
 }
 
+// 1ヶ月に満たない案件でも「そこに何かある」と分かる最小幅。
+const MIN_SEGMENT_WIDTH = 4;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
 /**
  * 会社の在籍期間を 100% とした帯に、配下の案件を区間として配置するレーン図。
  * 「同じ会社の中での案件の重なり・順番」を文章で説明せず図で見せる
@@ -24,13 +31,6 @@ interface CompanyLaneProps {
  * 装飾目的の可視化であり、内容は上のカード一覧に numは同じ番号で既に文字で出ているため、
  * レーン自体は aria-hidden にしてスクリーンリーダーの読み上げ対象から外す。
  */
-// 1ヶ月に満たない案件でも「そこに何かある」と分かる最小幅。
-const MIN_SEGMENT_WIDTH = 4;
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
-
 export function CompanyLane({ companyPeriod, items }: CompanyLaneProps) {
   const bounds = parsePeriodBounds(companyPeriod);
   if (!bounds) return null;

--- a/src/components/blocks/company-section.test.tsx
+++ b/src/components/blocks/company-section.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { CompanyInfo } from '@/db/blocks';
+
+import { CompanySection } from './company-section';
+
+const company = (overrides: Partial<CompanyInfo>): CompanyInfo => ({
+  id: 'c1',
+  name: '株式会社az',
+  kind: '',
+  period: '',
+  note: '',
+  ...overrides,
+});
+
+describe('CompanySection', () => {
+  it('会社概要文（note）を1回だけ描画する', () => {
+    const c = company({ note: '自社サービスを開発する事業会社。' });
+    render(
+      <CompanySection id="co-0" company={c} totalCount={1} visibleCount={1} searching={false} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.getAllByText('自社サービスを開発する事業会社。')).toHaveLength(1);
+  });
+
+  it('note が空なら何も描画しない', () => {
+    const c = company({ note: '' });
+    render(
+      <CompanySection id="co-0" company={c} totalCount={1} visibleCount={1} searching={false} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.queryByText(/事業会社/)).not.toBeInTheDocument();
+  });
+
+  it('期間が無い会社に「在籍」を出さない（通年等の嘘をつかない）', () => {
+    const c = company({ period: '' });
+    render(
+      <CompanySection id="co-0" company={c} totalCount={1} visibleCount={1} searching={false} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.queryByText(/在籍/)).not.toBeInTheDocument();
+  });
+
+  it('期間があれば「在籍 {period}（Nヶ月）」を出す', () => {
+    const c = company({ period: '2020.06 — 2021.08' });
+    render(
+      <CompanySection id="co-0" company={c} totalCount={1} visibleCount={1} searching={false} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.getByText(/在籍 2020.06 — 2021.08/)).toBeInTheDocument();
+  });
+
+  it('検索中は「一致 N / 案件 M 件」、非検索時は「案件 M 件」を出す', () => {
+    const c = company({});
+    const { rerender } = render(
+      <CompanySection id="co-0" company={c} totalCount={3} visibleCount={1} searching={true} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.getByText('一致 1 / 案件 3 件')).toBeInTheDocument();
+
+    rerender(
+      <CompanySection id="co-0" company={c} totalCount={3} visibleCount={3} searching={false} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.getByText('案件 3 件')).toBeInTheDocument();
+  });
+
+  it('個人開発は在籍表記を出さない', () => {
+    const c = company({ kind: '個人開発', period: '2020.06 — 2021.08' });
+    render(
+      <CompanySection id="co-0" company={c} totalCount={1} visibleCount={1} searching={false} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.queryByText(/在籍/)).not.toBeInTheDocument();
+  });
+
+  it('会社が未登録（所属不明）のときは "(不明な会社)" を見出しに出す', () => {
+    render(
+      <CompanySection id="co-x" company={undefined} totalCount={1} visibleCount={1} searching={false} laneItems={[]}>
+        <div>card</div>
+      </CompanySection>,
+    );
+    expect(screen.getByRole('heading', { name: '(不明な会社)' })).toBeInTheDocument();
+  });
+});

--- a/src/components/blocks/company-section.tsx
+++ b/src/components/blocks/company-section.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { CompanyInfo } from '@/db/blocks';
+import { deriveDuration } from '@/db/process';
+import { collapseSoftBreaks } from '@/db/text';
+import { sanitizeHtml } from '@/util/sanitize-html';
+import { InlineMarkdown } from '../inline-markdown';
+import { CompanyLane } from './company-lane';
+
+export interface CompanyLaneItem {
+  no: number;
+  period: string;
+  duration: string;
+}
+
+interface CompanySectionProps {
+  id: string;
+  company: CompanyInfo | undefined;
+  /** 検索前の会社配下の案件数。 */
+  totalCount: number;
+  /** 検索後にこのセクションで見えている案件数。 */
+  visibleCount: number;
+  /** 検索中か（件数表示を「一致 N / 案件 M 件」にするか「案件 M 件」にするかの分岐）。 */
+  searching: boolean;
+  /** レーン図に渡す案件一覧。検索中は絞り込み後、検索していないときは全件（呼び出し側で決める）。 */
+  laneItems: CompanyLaneItem[];
+  /** 配下の ProjectCard 一覧（呼び出し側で番号・ハイライトを解決済みのまま渡す）。 */
+  children: ReactNode;
+}
+
+// 個人開発は「在籍」という言葉が実態と合わないため在籍期間・レーンを出さない
+// （プラン: 「同じ会社の中での移動」は在籍のある参画先だけの話）。
+const NO_TENURE_KIND = '個人開発';
+
+/**
+ * 会社1件分のセクション。会社見出しは sticky にして、長いカード一覧をスクロールしても
+ * 「いまどの会社を見ているか」を保つ。会社概要文（company.note）はここで1回だけ描画する
+ * （従来 ProjectCard 側で所属案件ごとに再掲されていたのを解消：見づらさの原因の1つ）。
+ */
+export function CompanySection({
+  id,
+  company,
+  totalCount,
+  visibleCount,
+  searching,
+  laneItems,
+  children,
+}: CompanySectionProps) {
+  const name = company?.name?.trim() || '(不明な会社)';
+  const kind = company?.kind?.trim() ?? '';
+  const period = company?.period?.trim() ?? '';
+  const note = company?.note?.trim() ?? '';
+  const showTenure = !!period && kind !== NO_TENURE_KIND;
+  const tenureLength = showTenure ? deriveDuration(period) : '';
+  const countLabel = searching ? `一致 ${visibleCount} / 案件 ${totalCount} 件` : `案件 ${totalCount} 件`;
+  const showLane = kind !== NO_TENURE_KIND && laneItems.length >= 2 && !!period;
+
+  return (
+    <section id={id} aria-label={period ? `${name}（${period}）` : name} className="flex flex-col gap-4 scroll-mt-20">
+      {/* topbar（sticky top-0 z-40）の下に潜らないよう top-16（既存の目次と同じオフセット）。
+          topbar の実測高さが変わった場合はここも合わせて調整する（実機確認手順参照）。 */}
+      <div
+        className="sticky top-16 z-20 flex flex-wrap items-baseline gap-x-3.5 gap-y-1 bg-background py-2.5 shadow-[var(--sticky-shadow,0_8px_14px_-12px_rgba(16,23,26,0.35))]"
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
+        <h2 className="text-[19px] font-semibold leading-snug text-foreground text-pretty">{sanitizeHtml(name)}</h2>
+        {kind && (
+          <span
+            className="whitespace-nowrap rounded text-[11px] leading-relaxed"
+            style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', padding: '2px 8px' }}
+          >
+            {sanitizeHtml(kind)}
+          </span>
+        )}
+        {showTenure && (
+          <span className="whitespace-nowrap font-mono text-[12px] leading-relaxed text-foreground">
+            在籍 {period}
+            {tenureLength && `（${tenureLength}）`}
+          </span>
+        )}
+        <span className="whitespace-nowrap font-mono text-[12px] leading-relaxed text-muted-foreground">
+          {countLabel}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        {note && (
+          <InlineMarkdown
+            content={collapseSoftBreaks(note)}
+            className="max-w-[72ch] text-[15px] leading-[1.8] text-foreground text-pretty"
+          />
+        )}
+        {showLane && <CompanyLane companyPeriod={period} items={laneItems} />}
+      </div>
+
+      <div className="flex flex-col gap-5">{children}</div>
+    </section>
+  );
+}

--- a/src/components/blocks/company-section.tsx
+++ b/src/components/blocks/company-section.tsx
@@ -63,7 +63,9 @@ export function CompanySection({
     <section
       id={id}
       tabIndex={-1}
-      aria-label={period ? `${name}（${period}）` : name}
+      // 表示テキストと同じ sanitizeHtml を通す。素通しだと、名前に生タグが混ざった
+      // シートで見出しの読みと支援技術に渡る名前が食い違う。
+      aria-label={period ? `${sanitizeHtml(name)}（${sanitizeHtml(period)}）` : sanitizeHtml(name)}
       className="flex flex-col gap-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
       style={{ scrollMarginTop: 'calc(var(--viewer-topbar-h, 4rem) + 16px)' }}
     >

--- a/src/components/blocks/company-section.tsx
+++ b/src/components/blocks/company-section.tsx
@@ -57,14 +57,26 @@ export function CompanySection({
   const showLane = kind !== NO_TENURE_KIND && laneItems.length >= 2 && !!period;
 
   return (
-    <section id={id} aria-label={period ? `${name}（${period}）` : name} className="flex flex-col gap-4 scroll-mt-20">
-      {/* topbar（sticky top-0 z-40）の下に潜らないよう top-16（既存の目次と同じオフセット）。
-          topbar の実測高さが変わった場合はここも合わせて調整する（実機確認手順参照）。 */}
+    // tabIndex={-1}: ジャンプナビは <base> の都合でアンカーではなく button + 自前スクロール
+    // （company-jump-nav.tsx 参照）。ネイティブのアンカー移動なら付いてきたフォーカスを
+    // 自前で送れるよう、プログラム的なフォーカス先にしておく。
+    <section
+      id={id}
+      tabIndex={-1}
+      aria-label={period ? `${name}（${period}）` : name}
+      className="flex flex-col gap-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+      style={{ scrollMarginTop: 'calc(var(--viewer-topbar-h, 4rem) + 16px)' }}
+    >
       <div
-        className="sticky top-16 z-20 flex flex-wrap items-baseline gap-x-3.5 gap-y-1 bg-background py-2.5 shadow-[var(--sticky-shadow,0_8px_14px_-12px_rgba(16,23,26,0.35))]"
-        style={{ borderBottom: '1px solid var(--border)' }}
+        className="sticky z-20 flex flex-wrap items-baseline gap-x-3.5 gap-y-1 bg-background py-2.5 shadow-[var(--sticky-shadow,0_8px_14px_-12px_rgba(16,23,26,0.35))]"
+        // top は topbar（sticky top-0 z-40）の実測高さに追従させる。viewer-topbar.tsx が
+        // ResizeObserver で --viewer-topbar-h を出している。SP では topbar が2段になり
+        // 126px まで伸びるため、固定の top-16（64px）だと見出しが topbar の下に隠れた。
+        style={{ top: 'var(--viewer-topbar-h, 4rem)', borderBottom: '1px solid var(--border)' }}
       >
-        <h2 className="text-[19px] font-semibold leading-snug text-foreground text-pretty">{sanitizeHtml(name)}</h2>
+        {/* SectionHead（「案件詳細」）が h2。会社はその子、案件カードのタイトルはさらに子（h4）。
+            全部 h2 だとスクリーンリーダーの見出しジャンプで親子関係が消える。 */}
+        <h3 className="text-[19px] font-semibold leading-snug text-foreground text-pretty">{sanitizeHtml(name)}</h3>
         {kind && (
           <span
             className="whitespace-nowrap rounded text-[11px] leading-relaxed"

--- a/src/components/blocks/project-card.test.tsx
+++ b/src/components/blocks/project-card.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { ProjectItem } from '@/db/blocks';
 
@@ -93,12 +93,32 @@ describe('ProjectCard', () => {
     expect(screen.getByRole('button', { name: '閉じる' })).toBeInTheDocument();
   });
 
-  it('技術スタックは6バケットのラベル付きで出す', () => {
+  // ラベルと参照するデータキーの対応を入れ替えても、ラベルの存在と技術名の存在を
+  // 別々に見るだけのテストは緑のまま通ってしまう。行ごとに中を見て対応を固定する。
+  it('技術スタックは6バケットのラベル付きで、ラベルとデータキーの対応が合っている', () => {
     const tech = { ...EMPTY_TECH, lang: ['TypeScript'], fw: ['Next.js'] };
     render(<ProjectCard item={buildItem({ tech })} no={1} activeTech={[]} />);
-    expect(screen.getByText('使用言語')).toBeInTheDocument();
-    expect(screen.getByText('フレームワーク・ライブラリ')).toBeInTheDocument();
+
+    const langRow = screen.getByText('使用言語').parentElement as HTMLElement;
+    expect(within(langRow).getByText('TypeScript')).toBeInTheDocument();
+    expect(within(langRow).queryByText('Next.js')).not.toBeInTheDocument();
+
+    const fwRow = screen.getByText('フレームワーク・ライブラリ').parentElement as HTMLElement;
+    expect(within(fwRow).getByText('Next.js')).toBeInTheDocument();
+    expect(within(fwRow).queryByText('TypeScript')).not.toBeInTheDocument();
+  });
+
+  // 元データの「該当なし」プレースホルダ。実データでは 9 個の `-` チップが画面に出ていた。
+  it('技術スタックの「該当なし」プレースホルダ（- / ー / —）はチップにしない', () => {
+    const tech = { ...EMPTY_TECH, lang: ['TypeScript'], tools: ['-'], collab: ['ー'], db: ['—'], infra: ['  '] };
+    render(<ProjectCard item={buildItem({ tech })} no={1} activeTech={[]} />);
+
     expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    // ラベル行ごと出さない（空のラベルだけが残るのも同じくノイズ）。
+    expect(screen.queryByText('開発ツール')).not.toBeInTheDocument();
+    expect(screen.queryByText('コラボレーションツール')).not.toBeInTheDocument();
+    expect(screen.queryByText('データベース')).not.toBeInTheDocument();
+    expect(screen.queryByText('クラウド・インフラ')).not.toBeInTheDocument();
   });
 
   it('本文の色はすべて foreground に統一し、muted-foreground を本文色として使わない（見づらさの原因2の再発防止）', () => {

--- a/src/components/blocks/project-card.test.tsx
+++ b/src/components/blocks/project-card.test.tsx
@@ -1,18 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import type { CompanyInfo, ProjectItem } from '@/db/blocks';
+import type { ProjectItem } from '@/db/blocks';
 
 import { ProjectCard } from './project-card';
 
 const EMPTY_TECH = { lang: [], fw: [], db: [], infra: [], tools: [], collab: [] };
-
-const COMPANY: CompanyInfo = {
-  id: 'c1',
-  name: 'Q 社（自社サービス事業会社）',
-  kind: '',
-  period: '',
-  note: '',
-};
 
 function buildItem(overrides: Partial<ProjectItem>): ProjectItem {
   return {
@@ -34,28 +26,39 @@ function buildItem(overrides: Partial<ProjectItem>): ProjectItem {
 
 describe('ProjectCard', () => {
   it('チーム人数は既に単位が付いていればそのまま出す（単位を二重に足さない）', () => {
-    render(<ProjectCard item={buildItem({})} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+    render(<ProjectCard item={buildItem({})} no={1} activeTech={[]} />);
     expect(screen.getByText(/13 名/)).toBeInTheDocument();
     expect(screen.queryByText(/名名/)).not.toBeInTheDocument();
   });
 
   it('チーム人数が単位なしの数値のみ（ビルダーのplaceholder「例：13」通りの入力）なら「名」を補う', () => {
-    render(<ProjectCard item={buildItem({ team: '13' })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+    render(<ProjectCard item={buildItem({ team: '13' })} no={1} activeTech={[]} />);
     expect(screen.getByText(/13名/)).toBeInTheDocument();
+  });
+
+  it('チーム規模が未入力なら — で欠損を明示する', () => {
+    render(<ProjectCard item={buildItem({ team: '' })} no={1} activeTech={[]} />);
+    const dt = screen.getByText('チーム規模');
+    expect(dt.nextElementSibling).toHaveTextContent('—');
   });
 
   it('summary の "- " 箇条書きを <ul><li> として描画する（Markdown 未解釈だった回帰の防止）', () => {
     const summary = '- iOS / Android アプリの機能開発\n- バックエンドの機能実装';
-    render(<ProjectCard item={buildItem({ summary })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+    render(<ProjectCard item={buildItem({ summary })} no={1} activeTech={[]} />);
 
     const items = screen.getAllByRole('listitem');
     expect(items).toHaveLength(2);
     expect(items[0]).toHaveTextContent('iOS / Android アプリの機能開発');
   });
 
+  it('担当業務セクションにラベルが付く', () => {
+    render(<ProjectCard item={buildItem({ duties: '要件整理から実装まで担当。' })} no={1} activeTech={[]} />);
+    expect(screen.getByText('担当業務')).toBeInTheDocument();
+  });
+
   it('comment の "**強調**" を太字要素として描画し、"**" を画面に残さない', () => {
     const comment = '**動かして**みないと気が済まない性格です。';
-    render(<ProjectCard item={buildItem({ comment })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+    render(<ProjectCard item={buildItem({ comment })} no={1} activeTech={[]} />);
 
     expect(screen.getByText('動かして', { selector: 'strong' })).toBeInTheDocument();
     expect(screen.queryByText(/\*\*/)).not.toBeInTheDocument();
@@ -63,30 +66,45 @@ describe('ProjectCard', () => {
 
   it('acquired の改行を保ったまま Markdown として描画する', () => {
     const acquired = '1行目\n2行目';
-    render(<ProjectCard item={buildItem({ acquired })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
+    render(<ProjectCard item={buildItem({ acquired })} no={1} activeTech={[]} />);
 
     expect(screen.getByText(/1行目/)).toBeInTheDocument();
     expect(screen.getByText(/2行目/)).toBeInTheDocument();
   });
 
-  it('会社概要文（company.note）が読める（#139: 従来どこにも描画されなかった）', () => {
-    const company: CompanyInfo = { ...COMPANY, note: '大手SIベンダーにて複数の先進的なプロジェクトに参画。' };
-    render(<ProjectCard item={buildItem({})} no={1} company={company} activeTech={[]} tech={[]} />);
-    expect(screen.getByText('大手SIベンダーにて複数の先進的なプロジェクトに参画。')).toBeInTheDocument();
+  it('コメントが2段落以下なら「続きを読む」ボタンを出さない', () => {
+    const comment = '1段落目です。\n\n2段落目です。';
+    render(<ProjectCard item={buildItem({ comment })} no={1} activeTech={[]} />);
+    expect(screen.queryByRole('button', { name: /続きを読む/ })).not.toBeInTheDocument();
   });
 
-  it('会社概要文が無ければ何も描画しない', () => {
-    render(<ProjectCard item={buildItem({})} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
-    // COMPANY.note は '' なので note 由来の要素は無い（他の空文字チェックとの区別のため件数で確認）。
-    expect(screen.queryByText(/参画/)).not.toBeInTheDocument();
+  it('コメントが3段落以上なら先頭2段落だけ見せ「続きを読む（残りN）」で全文を開く', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    const comment = '1段落目。\n\n2段落目。\n\n3段落目。';
+    render(<ProjectCard item={buildItem({ comment })} no={1} activeTech={[]} />);
+
+    expect(screen.getByText('1段落目。')).toBeInTheDocument();
+    expect(screen.queryByText('3段落目。')).not.toBeInTheDocument();
+    const toggle = screen.getByRole('button', { name: '続きを読む（残り 1）' });
+
+    await user.click(toggle);
+    expect(screen.getByText('3段落目。')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '閉じる' })).toBeInTheDocument();
   });
 
-  it('コメントは italic を使わない（#152 S-2: 和文長文が合成斜体になっていた）', () => {
-    const comment = '長めのコメント本文がここに入ります。';
-    render(<ProjectCard item={buildItem({ comment })} no={1} company={COMPANY} activeTech={[]} tech={[]} />);
-    const commentText = screen.getByText(/長めのコメント本文/);
-    // InlineMarkdown が p でラップするので、その祖先を辿って italic クラスが無いことを確認する。
-    const wrapper = commentText.closest('div');
-    expect(wrapper?.className).not.toContain('italic');
+  it('技術スタックは6バケットのラベル付きで出す', () => {
+    const tech = { ...EMPTY_TECH, lang: ['TypeScript'], fw: ['Next.js'] };
+    render(<ProjectCard item={buildItem({ tech })} no={1} activeTech={[]} />);
+    expect(screen.getByText('使用言語')).toBeInTheDocument();
+    expect(screen.getByText('フレームワーク・ライブラリ')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+  });
+
+  it('本文の色はすべて foreground に統一し、muted-foreground を本文色として使わない（見づらさの原因2の再発防止）', () => {
+    const summary = '要約テキスト。';
+    render(<ProjectCard item={buildItem({ summary })} no={1} activeTech={[]} />);
+    const body = screen.getByText('要約テキスト。');
+    expect(body.className).not.toContain('text-muted-foreground');
   });
 });

--- a/src/components/blocks/project-card.tsx
+++ b/src/components/blocks/project-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import type { ProjectItem } from '@/db/blocks';
-import { deriveDuration, formatPeriodDisplay, normalizeProcess } from '@/db/process';
+import { deriveDuration, formatPeriodDisplay, isEmptyTechValue, normalizeProcess } from '@/db/process';
 import { resolveProjectArea } from '@/db/tech-area';
 import { collapseSoftBreaks } from '@/db/text';
 import { formatTeamSize } from '@/util/format-team-size';
@@ -57,9 +57,13 @@ export const ProjectCard = ({ item, no, activeTech }: ProjectCardProps) => {
     commentOpen ? commentParagraphs : commentParagraphs.slice(0, COMMENT_PREVIEW_PARAGRAPHS)
   ).join('\n\n');
 
+  // flattenTech（検索・レーン用）と同じ除外規則を通す。ここを filter(Boolean) だけにすると
+  // 元データの「該当なし」プレースホルダ（`-` / `ー` / `—`）がそのまま技術チップとして並び、
+  // DB の JSON に非文字列が紛れていれば React の子要素として描画できず落ちる。
+  // 実データでは 9 個の `-` チップが画面に出ていた。
   const techGroups = TECH_BUCKET_LABELS.map(({ key, label }) => ({
     label,
-    items: item.tech[key].filter(Boolean),
+    items: (item.tech[key] ?? []).filter((value) => !isEmptyTechValue(value)),
   })).filter((g) => g.items.length > 0);
 
   return (
@@ -77,7 +81,7 @@ export const ProjectCard = ({ item, no, activeTech }: ProjectCardProps) => {
             {formatPeriodDisplay(item.period) || '(期間未入力)'}
           </span>
         </div>
-        <h3 className="text-[17px] leading-snug text-foreground">{sanitizeHtml(item.title) || '(タイトル未入力)'}</h3>
+        <h4 className="text-[17px] leading-snug text-foreground">{sanitizeHtml(item.title) || '(タイトル未入力)'}</h4>
         {/* 導出値には必ず「技術領域」を添える。タイトル直下という位置だけで読み手は
             「担当した領域」と受け取るが、技術スタックから言えるのは「その技術がどの領域か」まで。
             取り込んだ scope は本人の言葉なのでラベルを付けない（tech-area.ts 参照）。 */}

--- a/src/components/blocks/project-card.tsx
+++ b/src/components/blocks/project-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import type { CompanyInfo, ProjectItem } from '@/db/blocks';
+import { useState } from 'react';
+import type { ProjectItem } from '@/db/blocks';
 import { deriveDuration, formatPeriodDisplay, normalizeProcess } from '@/db/process';
 import { resolveProjectArea } from '@/db/tech-area';
 import { collapseSoftBreaks } from '@/db/text';
@@ -13,79 +14,146 @@ interface ProjectCardProps {
   item: ProjectItem;
   /** フィルタ前の全件配列基準の通し番号。絞り込んでも変わらない。 */
   no: number;
-  company: CompanyInfo | undefined;
   /** ハイライト対象の技術（TechFilterで選択中のチップ）。 */
   activeTech: string[];
-  /** flattenTech 済みの技術一覧。 */
-  tech: string[];
 }
 
-export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCardProps) => {
+// ProjectTech の6バケットの表示ラベル。flattenTech と同じ固定順で並べる。
+// app/builder/editor-constants.ts の TECH_CATEGORIES と同じラベル文言に揃える
+// （エディタ側の入力カテゴリ名と閲覧側の表示名が食い違うと、同じ技術が
+// 画面ごとに違う分類名で見えることになる）。
+const TECH_BUCKET_LABELS: { key: keyof ProjectItem['tech']; label: string }[] = [
+  { key: 'lang', label: '使用言語' },
+  { key: 'fw', label: 'フレームワーク・ライブラリ' },
+  { key: 'db', label: 'データベース' },
+  { key: 'infra', label: 'クラウド・インフラ' },
+  { key: 'tools', label: '開発ツール' },
+  { key: 'collab', label: 'コラボレーションツール' },
+];
+
+// コメントの「要約＋展開」用に空行で段落を割る。既定は先頭2段落まで表示する。
+const COMMENT_PREVIEW_PARAGRAPHS = 2;
+
+/**
+ * ラベル＋上罫線で階層を作るカード。本文はすべて --foreground に統一し、
+ * 色の濃淡ではなくラベルで「これは何の情報か」を示す（見づらさの原因2への対処）。
+ * 会社名・会社概要文（company.note）はセクション見出し（CompanySection）側へ移したため、
+ * ここでは扱わない。
+ */
+export const ProjectCard = ({ item, no, activeTech }: ProjectCardProps) => {
+  const [commentOpen, setCommentOpen] = useState(false);
   const normalized = normalizeProcess(item.process);
   const duration = sanitizeHtml(item.duration?.trim() || deriveDuration(item.period));
   const summary = item.summary?.trim() || item.duties;
   const area = resolveProjectArea(item.scope, item.tech);
 
+  const commentParagraphs = item.comment
+    ? collapseSoftBreaks(item.comment)
+        .split(/\n{2,}/)
+        .filter(Boolean)
+    : [];
+  const hasMoreComment = commentParagraphs.length > COMMENT_PREVIEW_PARAGRAPHS;
+  const commentShownText = (
+    commentOpen ? commentParagraphs : commentParagraphs.slice(0, COMMENT_PREVIEW_PARAGRAPHS)
+  ).join('\n\n');
+
+  const techGroups = TECH_BUCKET_LABELS.map(({ key, label }) => ({
+    label,
+    items: item.tech[key].filter(Boolean),
+  })).filter((g) => g.items.length > 0);
+
   return (
-    <article className="flex min-w-0 flex-col gap-6 rounded-[var(--radius-lg)] border border-border bg-card px-7 py-7 transition-colors duration-150 hover:border-primary">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="mb-1 flex items-center gap-2">
-            {/* bg-primary は on-accent と組むとライトテーマで3.74と WCAG AA 未達（Issue #198）。 */}
-            <span className="rounded-[var(--radius)] bg-primary-dark px-1.5 py-px font-mono text-[11px] text-on-accent">
-              {String(no).padStart(2, '0')}
-            </span>
-            <span className="font-mono text-[11.5px] text-faint">
-              {formatPeriodDisplay(item.period) || '(期間未入力)'}
-            </span>
-          </div>
-          <h3 className="text-[17px] leading-snug text-foreground">{sanitizeHtml(item.title) || '(タイトル未入力)'}</h3>
-          {/* 導出値には必ず「技術領域」を添える。タイトル直下という位置だけで読み手は
-              「担当した領域」と受け取るが、技術スタックから言えるのは「その技術がどの領域か」まで。
-              取り込んだ scope は本人の言葉なのでラベルを付けない（tech-area.ts 参照）。 */}
-          {area.text && (
-            <p className="mt-0.5 text-[12.5px] text-muted-foreground">
-              {area.derived && <span className="kicker mr-1.5">技術領域</span>}
-              {sanitizeHtml(area.text)}
-            </p>
-          )}
-          {/* 会社概要文（CompanyInfo.note）。従来どこにも描画先が無く、ビューア・PDF・バックアップの
-              全経路で欠落していた（#139）。projectBlockToMarkdown 側も同じ位置づけで出力する。
-              空白のみの値は projectBlockToMarkdown と同じく trim() 後に判定する。 */}
-          {company?.note?.trim() && (
-            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground/80">
-              {sanitizeHtml(company.note.trim())}
-            </p>
-          )}
+    <article
+      className="flex min-w-0 flex-col gap-4 rounded-[var(--radius-lg)] bg-card px-6 py-6 transition-colors duration-150 hover:border-primary"
+      style={{ border: '1px solid var(--border)' }}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+          {/* bg-primary は on-accent と組むとライトテーマで3.74と WCAG AA 未達（Issue #198）。 */}
+          <span className="rounded-[var(--radius)] bg-primary-dark px-1.5 py-px font-mono text-[11px] text-on-accent">
+            {String(no).padStart(2, '0')}
+          </span>
+          <span className="font-mono text-[11.5px] text-muted-foreground">
+            {formatPeriodDisplay(item.period) || '(期間未入力)'}
+          </span>
         </div>
-        {/* shrink-0 だと flex item の既定 min-width:auto（コンテンツの折返し前の幅が下限）が効き、
-            320px では役割・会社名の長文が折り返さずカード幅を押し広げていた（#143）。
-            min-w-0 に変えて行として折り返せるようにする。 */}
-        <div className="min-w-0 text-right">
-          {item.role && <div className="text-[12.5px] text-foreground">{sanitizeHtml(item.role)}</div>}
-          <div className="mt-0.5 font-mono text-[11.5px] text-faint">
-            {[sanitizeHtml(company?.name), item.team && formatTeamSize(item.team), duration]
-              .filter(Boolean)
-              .join(' · ')}
+        <h3 className="text-[17px] leading-snug text-foreground">{sanitizeHtml(item.title) || '(タイトル未入力)'}</h3>
+        {/* 導出値には必ず「技術領域」を添える。タイトル直下という位置だけで読み手は
+            「担当した領域」と受け取るが、技術スタックから言えるのは「その技術がどの領域か」まで。
+            取り込んだ scope は本人の言葉なのでラベルを付けない（tech-area.ts 参照）。 */}
+        {area.text && (
+          <p className="text-[12.5px] text-muted-foreground">
+            {area.derived && <span className="kicker mr-1.5">技術領域</span>}
+            {sanitizeHtml(area.text)}
+          </p>
+        )}
+        {/* 未入力を黙って落とすと「役割の記載が無い案件」と区別できない。— で欠損を明示する。 */}
+        <dl className="flex flex-wrap gap-x-7 gap-y-2.5">
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <dt className="text-[12px] text-muted-foreground">期間</dt>
+            <dd className="text-[14px] text-foreground">
+              {formatPeriodDisplay(item.period) || '—'}
+              {duration && `（${duration}）`}
+            </dd>
           </div>
-        </div>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <dt className="text-[12px] text-muted-foreground">役割</dt>
+            <dd className="text-[14px] text-foreground break-words">{item.role ? sanitizeHtml(item.role) : '—'}</dd>
+          </div>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <dt className="text-[12px] text-muted-foreground">チーム規模</dt>
+            <dd className="text-[14px] text-foreground">{item.team ? formatTeamSize(item.team) : '—'}</dd>
+          </div>
+        </dl>
       </div>
 
       {summary && (
-        <InlineMarkdown
-          content={collapseSoftBreaks(summary)}
-          className="break-words text-[15px] leading-[1.9] text-muted-foreground"
-        />
+        <div
+          className="flex flex-col gap-2"
+          style={{ borderTop: '1px solid var(--border)', paddingTop: 'var(--gap-in-card, 16px)' }}
+        >
+          <span className="text-[13px] text-muted-foreground">担当業務</span>
+          <InlineMarkdown
+            content={collapseSoftBreaks(summary)}
+            className="break-words text-[15px] leading-[1.9] text-foreground"
+          />
+        </div>
       )}
 
-      {tech.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {tech.map((t) => (
-            // 押せないラベルなので .chip ではなく .techtag。検索一致時だけ強調する。
-            <span key={t} className={`techtag ${activeTech.includes(t) ? 'hit' : ''}`}>
-              {t}
-            </span>
-          ))}
+      {item.acquired && (
+        <div
+          className="flex flex-col gap-2"
+          style={{ borderTop: '1px solid var(--border)', paddingTop: 'var(--gap-in-card, 16px)' }}
+        >
+          <span className="text-[13px] text-muted-foreground">習得スキル</span>
+          <InlineMarkdown
+            content={collapseSoftBreaks(item.acquired)}
+            className="break-words text-[15px] leading-[1.9] text-foreground"
+          />
+        </div>
+      )}
+
+      {item.comment && (
+        <div
+          className="flex flex-col items-start gap-2.5"
+          style={{ borderTop: '1px solid var(--border)', paddingTop: 'var(--gap-in-card, 16px)' }}
+        >
+          <span className="text-[13px] text-muted-foreground">コメント</span>
+          <InlineMarkdown
+            content={commentShownText}
+            className="break-words text-[15px] leading-[1.9] text-foreground"
+          />
+          {hasMoreComment && (
+            <button
+              type="button"
+              onClick={() => setCommentOpen((v) => !v)}
+              aria-expanded={commentOpen}
+              className="min-h-11 whitespace-nowrap rounded px-3.5 py-2 text-[13px] text-accent-text hover:bg-accent-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              style={{ border: '1px solid var(--border-strong)' }}
+            >
+              {commentOpen ? '閉じる' : `続きを読む（残り ${commentParagraphs.length - COMMENT_PREVIEW_PARAGRAPHS}）`}
+            </button>
+          )}
         </div>
       )}
 
@@ -100,27 +168,40 @@ export const ProjectCard = ({ item, no, company, activeTech, tech }: ProjectCard
         </div>
       )}
 
-      <div className="mt-0.5 border-t border-border pt-3.5">
+      <div
+        className="flex flex-col gap-2"
+        style={{ borderTop: '1px solid var(--border)', paddingTop: 'var(--gap-in-card, 16px)' }}
+      >
+        <span className="text-[13px] text-muted-foreground">
+          担当工程　<span className="font-mono">{normalized.done.filter(Boolean).length} / 7</span>
+        </span>
         <ProcessStepper done={normalized.done} />
       </div>
 
-      {item.acquired && (
-        <div className="text-sm">
-          <p className="mb-1 font-mono text-[11px] tracking-[0.1em] text-accent-text">≪習得スキル・実績≫</p>
-          <InlineMarkdown
-            content={collapseSoftBreaks(item.acquired)}
-            className="break-words leading-relaxed text-foreground/80"
-          />
+      {techGroups.length > 0 && (
+        <div
+          className="flex flex-col gap-2.5"
+          style={{ borderTop: '1px solid var(--border)', paddingTop: 'var(--gap-in-card, 16px)' }}
+        >
+          <span className="text-[13px] text-muted-foreground">技術スタック</span>
+          <div className="flex flex-col gap-1.5">
+            {techGroups.map((g) => (
+              <div
+                key={g.label}
+                className="grid grid-cols-[88px_1fr] items-baseline gap-x-3.5 gap-y-1.5 sm:grid-cols-[110px_1fr]"
+              >
+                <span className="text-[12px] text-muted-foreground">{g.label}</span>
+                <div className="flex min-w-0 flex-wrap gap-1.5">
+                  {g.items.map((t) => (
+                    <span key={t} className={`techtag ${activeTech.includes(t) ? 'hit' : ''}`}>
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
-      )}
-
-      {/* #152 S-2: 無条件 italic だと100〜918字の和文長文が合成斜体になり読みにくかった。
-          引用の意味合いは左罫線だけで十分表現できているので italic は外す。 */}
-      {item.comment && (
-        <InlineMarkdown
-          content={collapseSoftBreaks(item.comment)}
-          className="whitespace-pre-line break-words border-l-2 border-primary pl-3 text-sm text-muted-foreground"
-        />
       )}
     </article>
   );

--- a/src/components/blocks/project-section.test.tsx
+++ b/src/components/blocks/project-section.test.tsx
@@ -190,6 +190,24 @@ describe('ProjectSection の検索（AND/OR・全角正規化）', () => {
     expect(screen.queryByText('案件B')).not.toBeInTheDocument();
   });
 
+  // 日本語入力のまま打つと演算子も全角になる。正規化前に判定していたころは
+  // 「ＡＮＤ」が演算子と認識されず、黙って OR 検索になっていた。
+  it('全角の「ＡＮＤ」も演算子として扱う', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={DATA2} showProcess={false} showTimeline={false} />);
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), '決済基盤　ＡＮＤ　管理画面');
+    expect(screen.queryByText('案件A')).not.toBeInTheDocument();
+    expect(screen.queryByText('案件B')).not.toBeInTheDocument();
+  });
+
+  it('全角の「ＯＲ」は検索語ではなく演算子として捨てる', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={DATA2} showProcess={false} showTimeline={false} />);
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), '決済基盤　ＯＲ　管理画面');
+    expect(screen.getByText('案件A')).toBeInTheDocument();
+    expect(screen.getByText('案件B')).toBeInTheDocument();
+  });
+
   it('全角英数字でも半角データにヒットする（NFKC 正規化）', async () => {
     const user = userEvent.setup();
     render(<ProjectSection data={DATA2} showProcess={false} showTimeline={false} />);

--- a/src/components/blocks/project-section.test.tsx
+++ b/src/components/blocks/project-section.test.tsx
@@ -6,26 +6,37 @@ import type { ProjectBlockData, ProjectItem } from '@/db/blocks';
 
 import { ProjectSection } from './project-section';
 
-// framer-motion はアニメーション専用 props を除いた素の要素に置換する
-vi.mock('framer-motion', () => ({
-  motion: new Proxy(
-    {},
-    {
-      get: () => {
-        const Passthrough = ({ children, ...props }: { children?: ReactNode }) => {
-          const rest = { ...props } as Record<string, unknown>;
-          for (const key of ['initial', 'animate', 'transition', 'whileHover', 'whileTap', 'exit', 'variants']) {
-            delete rest[key];
+// framer-motion はアニメーション専用 props を除いた素の要素に置換する。
+// Proxy の get トラップが毎回新しいコンポーネント関数を返すと、React はそれを
+// 「別のコンポーネント型」とみなして <motion.section> 配下を再マウントしてしまう
+// （state が変わるたびに検索入力がフォーカスごと作り直され、2文字目以降の入力が
+// 効かなくなる回帰があった。本番の framer-motion は同じキーに対し安定した参照を
+// 返すため実機では起きないが、このモックでは明示的にキャッシュする必要がある）。
+vi.mock('framer-motion', () => {
+  const cache = new Map<string | symbol, (props: { children?: ReactNode }) => ReactNode>();
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          if (!cache.has(prop)) {
+            const Passthrough = ({ children, ...props }: { children?: ReactNode }) => {
+              const rest = { ...props } as Record<string, unknown>;
+              for (const key of ['initial', 'animate', 'transition', 'whileHover', 'whileTap', 'exit', 'variants']) {
+                delete rest[key];
+              }
+              return <div {...rest}>{children}</div>;
+            };
+            cache.set(prop, Passthrough);
           }
-          return <div {...rest}>{children}</div>;
-        };
-        return Passthrough;
+          return cache.get(prop);
+        },
       },
-    },
-  ),
-  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
-  useReducedMotion: () => false,
-}));
+    ),
+    AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+    useReducedMotion: () => false,
+  };
+});
 
 const EMPTY_TECH = { lang: [], fw: [], db: [], infra: [], tools: [], collab: [] };
 
@@ -80,5 +91,101 @@ describe('ProjectSection の検索', () => {
 
     expect(screen.getByText('案件B')).toBeInTheDocument();
     expect(screen.queryByText('案件A')).not.toBeInTheDocument();
+  });
+});
+
+describe('ProjectSection の会社グルーピング', () => {
+  const TWO_COMPANY_DATA: ProjectBlockData = {
+    companies: [
+      { id: 'c1', name: 'A社', kind: '', period: '2024.01 — 2024.06', note: 'A社の概要文。' },
+      { id: 'c2', name: 'B社', kind: '', period: '2023.01 — 2023.06', note: '' },
+    ],
+    items: [
+      buildItem({ id: 'p1', companyId: 'c1', title: '案件A-1', duties: 'A社の1件目' }),
+      buildItem({ id: 'p2', companyId: 'c1', title: '案件A-2', duties: 'A社の2件目' }),
+      buildItem({ id: 'p3', companyId: 'c2', title: '案件B-1', duties: 'B社の1件目' }),
+    ],
+  };
+
+  it('会社ごとに見出しが出て、data.companies の順で並ぶ', () => {
+    render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
+    const headings = screen.getAllByRole('heading', { level: 2, name: /A社|B社/ });
+    expect(headings.map((h) => h.textContent)).toEqual(['A社', 'B社']);
+  });
+
+  it('会社概要文は会社セクションに1回だけ出る（同じ会社の案件が2件あっても重複しない）', () => {
+    render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
+    expect(screen.getAllByText('A社の概要文。')).toHaveLength(1);
+  });
+
+  it('検索で0件になった会社のセクションは見出しごと消える', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), 'A社の1件目');
+    expect(screen.getByRole('heading', { level: 2, name: 'A社' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2, name: 'B社' })).not.toBeInTheDocument();
+  });
+
+  it('companies に無い companyId の案件は「(不明な会社)」としてまとまる', () => {
+    const data: ProjectBlockData = {
+      companies: [{ id: 'c1', name: 'A社', kind: '', period: '', note: '' }],
+      items: [
+        buildItem({ id: 'p1', companyId: 'c1', title: '案件A' }),
+        buildItem({ id: 'p2', companyId: 'ghost', title: '案件不明' }),
+      ],
+    };
+    render(<ProjectSection data={data} showProcess={false} showTimeline={false} />);
+    expect(screen.getByRole('heading', { level: 2, name: '(不明な会社)' })).toBeInTheDocument();
+    expect(screen.getByText('案件不明')).toBeInTheDocument();
+  });
+
+  it('会社から探すジャンプナビが会社ごとのリンクを出す', () => {
+    render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
+    expect(screen.getByRole('link', { name: /A社/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /B社/ })).toBeInTheDocument();
+  });
+});
+
+describe('ProjectSection の検索（AND/OR・全角正規化）', () => {
+  const DATA2: ProjectBlockData = {
+    companies: [{ id: 'c1', name: 'Q 社', kind: '', period: '', note: '' }],
+    items: [
+      buildItem({
+        id: 'p1',
+        title: '案件A',
+        summary: '決済基盤の開発',
+        tech: { ...EMPTY_TECH, lang: ['TypeScript'] },
+      }),
+      buildItem({
+        id: 'p2',
+        title: '案件B',
+        summary: '管理画面の改善',
+        tech: { ...EMPTY_TECH, lang: ['Python'] },
+      }),
+    ],
+  };
+
+  it('スペース区切りは OR（どちらかの語を含めばヒット）', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={DATA2} showProcess={false} showTimeline={false} />);
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), '決済基盤 管理画面');
+    expect(screen.getByText('案件A')).toBeInTheDocument();
+    expect(screen.getByText('案件B')).toBeInTheDocument();
+  });
+
+  it('AND を挟むとすべての語を含む案件だけに絞る', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={DATA2} showProcess={false} showTimeline={false} />);
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), '決済基盤 AND 管理画面');
+    expect(screen.queryByText('案件A')).not.toBeInTheDocument();
+    expect(screen.queryByText('案件B')).not.toBeInTheDocument();
+  });
+
+  it('全角英数字でも半角データにヒットする（NFKC 正規化）', async () => {
+    const user = userEvent.setup();
+    render(<ProjectSection data={DATA2} showProcess={false} showTimeline={false} />);
+    await user.type(screen.getByLabelText('案件・技術・役割を検索'), 'ＴｙｐｅＳｃｒｉｐｔ');
+    expect(screen.getByText('案件A')).toBeInTheDocument();
+    expect(screen.queryByText('案件B')).not.toBeInTheDocument();
   });
 });

--- a/src/components/blocks/project-section.test.tsx
+++ b/src/components/blocks/project-section.test.tsx
@@ -109,7 +109,7 @@ describe('ProjectSection の会社グルーピング', () => {
 
   it('会社ごとに見出しが出て、data.companies の順で並ぶ', () => {
     render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
-    const headings = screen.getAllByRole('heading', { level: 2, name: /A社|B社/ });
+    const headings = screen.getAllByRole('heading', { level: 3, name: /A社|B社/ });
     expect(headings.map((h) => h.textContent)).toEqual(['A社', 'B社']);
   });
 
@@ -122,8 +122,8 @@ describe('ProjectSection の会社グルーピング', () => {
     const user = userEvent.setup();
     render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
     await user.type(screen.getByLabelText('案件・技術・役割を検索'), 'A社の1件目');
-    expect(screen.getByRole('heading', { level: 2, name: 'A社' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { level: 2, name: 'B社' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'A社' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: 'B社' })).not.toBeInTheDocument();
   });
 
   it('companies に無い companyId の案件は「(不明な会社)」としてまとまる', () => {
@@ -135,14 +135,23 @@ describe('ProjectSection の会社グルーピング', () => {
       ],
     };
     render(<ProjectSection data={data} showProcess={false} showTimeline={false} />);
-    expect(screen.getByRole('heading', { level: 2, name: '(不明な会社)' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: '(不明な会社)' })).toBeInTheDocument();
     expect(screen.getByText('案件不明')).toBeInTheDocument();
+  });
+
+  // 全部 h2 だと、スクリーンリーダーの見出しジャンプで「案件詳細」と各社が同列に並び、
+  // 視覚的な親子関係が読み取れなくなる。案件詳細(h2) > 会社(h3) > 案件(h4) を固定する。
+  it('見出しの階層が 案件詳細(h2) > 会社(h3) > 案件(h4) になっている', () => {
+    render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
+    expect(screen.getByRole('heading', { level: 2, name: '案件詳細' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'A社' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: '案件A-1' })).toBeInTheDocument();
   });
 
   it('会社から探すジャンプナビが会社ごとのリンクを出す', () => {
     render(<ProjectSection data={TWO_COMPANY_DATA} showProcess={false} showTimeline={false} />);
-    expect(screen.getByRole('link', { name: /A社/ })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /B社/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /A社/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /B社/ })).toBeInTheDocument();
   });
 });
 

--- a/src/components/blocks/project-section.tsx
+++ b/src/components/blocks/project-section.tsx
@@ -3,8 +3,11 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import { type ReactNode, useMemo, useState } from 'react';
 import { filterVisibleProjectData, type ProjectBlockData } from '@/db/blocks';
-import { flattenTech } from '@/db/process';
+import { type CompanyGroup, groupByCompany, UNASSIGNED_COMPANY_ID } from '@/db/blocks/group-by-company';
+import { deriveDuration, flattenTech } from '@/db/process';
 import { projectAreaText } from '@/db/tech-area';
+import { CompanyJumpNav, type JumpTarget } from './company-jump-nav';
+import { CompanySection } from './company-section';
 import { ProcessOverview } from './process-overview';
 import { ProjectCard } from './project-card';
 import { SectionHead } from './section-head';
@@ -41,7 +44,28 @@ function FadeUpSection({ children }: { children: ReactNode }) {
   );
 }
 
-// project ブロックを「工程の俯瞰・案件詳細（技術フィルタ付き）・タイムライン」の
+// 全角英数（ＴｙｐｅＳｃｒｉｐｔ 等）で検索しても半角のデータにヒットするよう、比較前に
+// NFKC 正規化してから小文字化する。toLowerCase だけでは全角はそのまま別文字として扱われる。
+function normalizeSearchText(s: string): string {
+  return s.normalize('NFKC').toLowerCase();
+}
+
+/**
+ * Gmail 風の検索クエリ解釈。スペース区切りは OR、"AND" と明示したときだけ全語必須。
+ * 演算子語（and/or、大小問わず）自体は検索語から除く。
+ */
+function parseQuery(raw: string): { terms: string[]; matchAll: boolean } {
+  const tokens = raw
+    .trim()
+    .split(/[\s　]+/)
+    .filter(Boolean);
+  const isOperator = (t: string) => /^(and|or)$/i.test(t);
+  const terms = tokens.filter((t) => !isOperator(t)).map(normalizeSearchText);
+  const matchAll = tokens.some((t) => /^and$/i.test(t));
+  return { terms, matchAll };
+}
+
+// project ブロックを「工程の俯瞰・案件詳細（会社ごと・技術フィルタ付き）・タイムライン」の
 // 3セクションへ投影するダッシュボード。新ブロック型を増やさず、既存の project データの
 // ビュー層としてのみ実装する。
 export function ProjectSection({
@@ -78,28 +102,39 @@ export function ProjectSection({
       .map(([name, count]) => ({ name, count }));
   }, [itemsWithNo]);
 
+  const { terms, matchAll } = useMemo(() => parseQuery(query), [query]);
+  const searching = terms.length > 0 || activeTech.length > 0;
+
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
     return itemsWithNo.filter(({ item, tech }) => {
       const techOk = activeTech.length === 0 || tech.some((t) => activeTech.includes(t));
       if (!techOk) return false;
-      if (!q) return true;
+      if (terms.length === 0) return true;
       const company = companyMap.get(item.companyId);
-      const haystack = [
-        item.title,
-        projectAreaText(item.scope, item.tech),
-        item.role,
-        company?.name ?? '',
-        // 表示側（project-card.tsx）は `summary?.trim() || duties`。`??` だと空文字の
-        // summary が採用され、カードに出ている duties の語で検索してもヒットしない。
-        item.summary?.trim() || item.duties,
-        ...tech,
-      ]
-        .join(' ')
-        .toLowerCase();
-      return haystack.includes(q);
+      const haystack = normalizeSearchText(
+        [
+          item.title,
+          projectAreaText(item.scope, item.tech),
+          item.role,
+          company?.name ?? '',
+          // 表示側（project-card.tsx）は `summary?.trim() || duties`。`??` だと空文字の
+          // summary が採用され、カードに出ている duties の語で検索してもヒットしない。
+          item.summary?.trim() || item.duties,
+          ...tech,
+        ].join(' '),
+      );
+      return matchAll ? terms.every((t) => haystack.includes(t)) : terms.some((t) => haystack.includes(t));
     });
-  }, [itemsWithNo, activeTech, query, companyMap]);
+  }, [itemsWithNo, activeTech, terms, matchAll, companyMap]);
+
+  // クエリに一致した技術は、選択中（activeTech）でなくてもカードのチップを強調する
+  // （何が検索語に当たったのかカード内で分かるようにする）。
+  const queryMatchedTech = useMemo(() => {
+    if (terms.length === 0) return new Set<string>();
+    return new Set(
+      allTech.map((t) => t.name).filter((name) => terms.some((t) => normalizeSearchText(name).includes(t))),
+    );
+  }, [allTech, terms]);
 
   const toggleTech = (t: string) => {
     setActiveTech((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
@@ -109,6 +144,30 @@ export function ProjectSection({
     setQuery('');
   };
 
+  // 会社ごとにグルーピングする。companyId 単位のまま分ける（名前でマージしない）。
+  // filtered（絞り込み後）と全件（絞り込み前）の両方を会社単位でグループ化し、
+  // レーン図には「検索中は絞り込み後、検索していなければ全件」を渡す。
+  const groupsFiltered = useMemo(
+    () => groupByCompany(visible.companies, filtered, (x) => x.item.companyId),
+    [visible.companies, filtered],
+  );
+  const groupsAll = useMemo(
+    () => groupByCompany(visible.companies, itemsWithNo, (x) => x.item.companyId),
+    [visible.companies, itemsWithNo],
+  );
+  const allGroupById = useMemo(() => new Map(groupsAll.map((g) => [g.companyId, g])), [groupsAll]);
+
+  // 検索で0件になった会社はセクションごと出さない。検索していない会社は
+  // 案件0件（未割当）でも会社見出し自体は残す（エディタで会社だけ先に作れるため）。
+  const sections = groupsFiltered.filter((g) => g.items.length > 0 || !searching);
+
+  const jumpTargets: JumpTarget[] = sections.map((g) => ({
+    id: `company-${g.companyId === UNASSIGNED_COMPANY_ID ? 'unassigned' : g.companyId}`,
+    company: g.company,
+    companyId: g.companyId,
+    itemCount: g.items.length,
+  }));
+
   // 可視案件が0件なら（会社だけ残っていても）表示するものが無いため何も描画しない。
   if (visible.items.length === 0) return null;
   if (!showProcess && !showProjects && !showTimeline) return null;
@@ -117,6 +176,11 @@ export function ProjectSection({
   // タイムラインへ持ち込まない（消したい方法が無いまま案件が消えて見えるのを防ぐ）。
   const timelineItems = showProjects ? filtered.map((x) => x.item) : visible.items;
   const timelineActiveTech = showProjects ? activeTech : [];
+
+  const searchHint =
+    searching && matchAll
+      ? 'AND が入っているので、すべての語を含む案件だけを表示しています。'
+      : 'スペース区切りはどれかを含む案件（OR）。AND と書くとすべて含む案件だけに絞ります。';
 
   return (
     <div className="space-y-10">
@@ -140,21 +204,49 @@ export function ProjectSection({
               onClear={clear}
               count={filtered.length}
               total={itemsWithNo.length}
+              hint={searchHint}
             />
           </div>
-          <div className="grid grid-cols-1 gap-5">
-            {filtered.map(({ item, no, tech }) => (
-              <ProjectCard
-                key={item.id}
-                item={item}
-                no={no}
-                company={companyMap.get(item.companyId)}
-                activeTech={activeTech}
-                tech={tech}
-              />
-            ))}
-            {filtered.length === 0 && (
-              <p className="col-span-full rounded border border-dashed border-border py-8 text-center text-sm text-muted-foreground">
+
+          <CompanyJumpNav targets={jumpTargets} />
+
+          <div className="flex flex-col gap-10">
+            {sections.map((group: CompanyGroup<(typeof filtered)[number]>) => {
+              const id = `company-${group.companyId === UNASSIGNED_COMPANY_ID ? 'unassigned' : group.companyId}`;
+              const allGroup = allGroupById.get(group.companyId);
+              const totalCount = allGroup?.items.length ?? group.items.length;
+              const laneSourceItems = searching ? group.items : (allGroup?.items ?? group.items);
+              const laneItems = laneSourceItems.map(({ item, no }) => ({
+                no,
+                period: item.period,
+                duration: item.duration?.trim() || deriveDuration(item.period),
+              }));
+              return (
+                <CompanySection
+                  key={group.companyId}
+                  id={id}
+                  company={group.company}
+                  totalCount={totalCount}
+                  visibleCount={group.items.length}
+                  searching={searching}
+                  laneItems={laneItems}
+                >
+                  {group.items.map(({ item, no, tech }) => (
+                    <ProjectCard
+                      key={item.id}
+                      item={item}
+                      no={no}
+                      activeTech={[...activeTech, ...tech.filter((t) => queryMatchedTech.has(t))]}
+                    />
+                  ))}
+                </CompanySection>
+              );
+            })}
+            {sections.length === 0 && (
+              <p
+                className="rounded border border-dashed py-8 text-center text-sm text-muted-foreground"
+                style={{ borderColor: 'var(--border-strong)' }}
+              >
                 条件に一致する案件がありません
               </p>
             )}
@@ -168,7 +260,10 @@ export function ProjectSection({
           {/* Timeline は 0 件で null を返すため、見出しだけが残って下が真っ白になっていた。
               案件詳細と同じ空状態を出して「絞り込みの結果ゼロ件」だと分かるようにする。 */}
           {timelineItems.length === 0 ? (
-            <p className="rounded border border-dashed border-border py-8 text-center text-sm text-muted-foreground">
+            <p
+              className="rounded border border-dashed py-8 text-center text-sm text-muted-foreground"
+              style={{ borderColor: 'var(--border-strong)' }}
+            >
               条件に一致する案件がありません
             </p>
           ) : (

--- a/src/components/blocks/project-section.tsx
+++ b/src/components/blocks/project-section.tsx
@@ -129,6 +129,10 @@ export function ProjectSection({
 
   // クエリに一致した技術は、選択中（activeTech）でなくてもカードのチップを強調する
   // （何が検索語に当たったのかカード内で分かるようにする）。
+  // 部分一致なのは意図的。上の絞り込み（haystack.includes）も部分一致で、`java` は
+  // JavaScript の案件を拾う。ここだけ完全一致にすると「ヒットしたのに何も光らない」
+  // カードが出て、強調が「なぜ当たったか」を説明する役目を果たさなくなる。
+  // 部分一致の是非は絞り込み側の仕様なので、変えるならセットで別途変える。
   const queryMatchedTech = useMemo(() => {
     if (terms.length === 0) return new Set<string>();
     return new Set(

--- a/src/components/blocks/project-section.tsx
+++ b/src/components/blocks/project-section.tsx
@@ -55,13 +55,16 @@ function normalizeSearchText(s: string): string {
  * 演算子語（and/or、大小問わず）自体は検索語から除く。
  */
 function parseQuery(raw: string): { terms: string[]; matchAll: boolean } {
+  // 演算子判定の前に正規化する。日本語入力のまま打つと全角の「ＡＮＤ」になりやすく、
+  // 正規化前に判定すると演算子と認識されず、黙って OR 検索になる。
   const tokens = raw
     .trim()
     .split(/[\s　]+/)
-    .filter(Boolean);
-  const isOperator = (t: string) => /^(and|or)$/i.test(t);
-  const terms = tokens.filter((t) => !isOperator(t)).map(normalizeSearchText);
-  const matchAll = tokens.some((t) => /^and$/i.test(t));
+    .filter(Boolean)
+    .map(normalizeSearchText);
+  const isOperator = (t: string) => t === 'and' || t === 'or';
+  const terms = tokens.filter((t) => !isOperator(t));
+  const matchAll = tokens.some((t) => t === 'and');
   return { terms, matchAll };
 }
 

--- a/src/components/blocks/tech-filter.test.tsx
+++ b/src/components/blocks/tech-filter.test.tsx
@@ -121,4 +121,14 @@ describe('TechFilter', () => {
     expect(document.getElementById(activeId as string)).toHaveAttribute('role', 'option');
     expect(document.getElementById(activeId as string)).toHaveAttribute('aria-selected', 'true');
   });
+  // globals.css の `* { border-color: var(--border) }` は Tailwind のレイヤー外にあり、
+  // border-border-strong のようなユーティリティを詳細度に関係なく打ち負かす（実機で確認）。
+  // クラスに戻すと枠線は --border（対 surface2 で 1.17:1）へ静かに戻り、
+  // WCAG 1.4.11 の 3:1 を割ったまま誰も気付かない。inline style であることを固定する。
+  it('検索欄の枠線は inline style で --border-strong を指定する（クラスでは効かない）', () => {
+    render(<TechFilter all={ALL} active={[]} count={3} total={3} {...noop} />);
+    for (const label of ['案件・技術・役割を検索', '技術を選ぶ']) {
+      expect(screen.getByLabelText(label).style.borderColor).toBe('var(--border-strong)');
+    }
+  });
 });

--- a/src/components/blocks/tech-filter.tsx
+++ b/src/components/blocks/tech-filter.tsx
@@ -18,12 +18,24 @@ interface TechFilterProps {
   onClear: () => void;
   count: number;
   total: number;
+  /** 検索欄の下に出すヒント文。 */
+  hint?: string;
 }
 
 const SUGGESTION_LIMIT = 40;
 
 // 案件テキスト検索と、技術の検索選択は別コントロール。チップ雲は出さない。
-export function TechFilter({ all, active, query, onQueryChange, onToggle, onClear, count, total }: TechFilterProps) {
+export function TechFilter({
+  all,
+  active,
+  query,
+  onQueryChange,
+  onToggle,
+  onClear,
+  count,
+  total,
+  hint,
+}: TechFilterProps) {
   const [techQuery, setTechQuery] = useState('');
   const [open, setOpen] = useState(false);
   const [hi, setHi] = useState(-1);
@@ -83,6 +95,8 @@ export function TechFilter({ all, active, query, onQueryChange, onToggle, onClea
           </button>
         )}
       </div>
+
+      {hint && <p className="text-[11.5px] leading-relaxed text-muted-foreground">{hint}</p>}
 
       <div className="relative min-w-[220px] max-w-[420px]">
         <input

--- a/src/components/blocks/tech-filter.tsx
+++ b/src/components/blocks/tech-filter.tsx
@@ -83,7 +83,15 @@ export function TechFilter({
             // focus-visible:ring-2 を追加してキーボード操作時にリングが見えるようにする。
             // placeholder の色指定が無いと UA 既定（currentColor 50%）にフォールバックし、
             // ライトテーマで 3.35:1（WCAG AA 未達）になっていた（#152 S-4）。
-            className="min-h-11 w-full rounded-[var(--radius)] border border-border bg-surface2 py-[9px] pl-[30px] pr-3 text-[13px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary focus:bg-card focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            // 枠線は --border（対 surface2 で 1.17:1）だと「そこに入力欄がある」と分からない。
+            // 操作要素なので WCAG 1.4.11 の 3:1 を満たす --border-strong を使う。
+            // border-* ユーティリティではなく inline style なのは、globals.css の
+            // `* { border-color: var(--border) }` が Tailwind のレイヤー外にあり、
+            // 詳細度に関係なくレイヤー内のユーティリティを打ち負かすため（実機で確認）。
+            // 同じ理由で以前からここの focus:border-primary は一度も効いていなかったので外した。
+            // フォーカスの視認は focus-visible:ring-2 と focus:bg-card が担う。
+            className="min-h-11 w-full rounded-[var(--radius)] border bg-surface2 py-[9px] pl-[30px] pr-3 text-[13px] text-foreground placeholder:text-muted-foreground outline-none focus:bg-card focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            style={{ borderColor: 'var(--border-strong)' }}
           />
         </div>
         <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
@@ -138,7 +146,8 @@ export function TechFilter({
             setOpen(false);
             setHi(-1);
           }}
-          className="min-h-11 w-full rounded-[var(--radius)] border border-border bg-surface2 py-[9px] px-3 text-[13px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary focus:bg-card focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          className="min-h-11 w-full rounded-[var(--radius)] border bg-surface2 py-[9px] px-3 text-[13px] text-foreground placeholder:text-muted-foreground outline-none focus:bg-card focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          style={{ borderColor: 'var(--border-strong)' }}
         />
         {open && matches.length > 0 && (
           <div

--- a/src/components/viewer-topbar.tsx
+++ b/src/components/viewer-topbar.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import { ArrowLeft, FileDown, Loader2, Moon, PencilLine, Sun } from 'lucide-react';
 import Link from 'next/link';
+import { useEffect, useRef } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -53,6 +54,27 @@ export function ViewerTopbar({
   reserveEditSlot = false,
 }: ViewerTopbarProps) {
   const { mode, toggleTheme } = useThemeMode();
+  const headerRef = useRef<HTMLElement>(null);
+
+  // 会社セクションの sticky 見出し（company-section.tsx）は、この topbar の実測高さぶん
+  // 下げないと下に潜る。高さは幅と内容で変わり（実測: 1280px 幅で 64px、375px 幅では
+  // 2段になって 126px）、固定値の top-16 では SP で 62px ぶん隠れていた。
+  // 実測値を CSS 変数で公開して追従させる。
+  useEffect(() => {
+    const element = headerRef.current;
+    if (!element) return;
+    const apply = () => {
+      document.documentElement.style.setProperty('--viewer-topbar-h', `${element.offsetHeight}px`);
+    };
+    apply();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(apply);
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+      document.documentElement.style.removeProperty('--viewer-topbar-h');
+    };
+  }, []);
 
   const editButton = canEdit ? (
     <Tooltip>
@@ -150,6 +172,7 @@ export function ViewerTopbar({
 
   return (
     <motion.header
+      ref={headerRef}
       initial={{ y: -100 }}
       animate={{ y: 0 }}
       transition={{ duration: 0.5, ease: 'easeOut' }}

--- a/src/db/blocks/group-by-company.test.ts
+++ b/src/db/blocks/group-by-company.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { groupByCompany, UNASSIGNED_COMPANY_ID } from './group-by-company';
+import type { CompanyInfo } from './index';
+
+const company = (overrides: Partial<CompanyInfo>): CompanyInfo => ({
+  id: 'c1',
+  name: '会社A',
+  kind: '',
+  period: '',
+  note: '',
+  ...overrides,
+});
+
+describe('groupByCompany', () => {
+  it('data.companies の並び順でグループを返す', () => {
+    const companies = [company({ id: 'c2', name: 'B' }), company({ id: 'c1', name: 'A' })];
+    const items = [
+      { id: 'p1', companyId: 'c1' },
+      { id: 'p2', companyId: 'c2' },
+    ];
+    const groups = groupByCompany(companies, items, (i) => i.companyId);
+    expect(groups.map((g) => g.companyId)).toEqual(['c2', 'c1']);
+    expect(groups[0].items).toEqual([items[1]]);
+    expect(groups[1].items).toEqual([items[0]]);
+  });
+
+  it('案件が0件の会社も空配列のグループとして残る（同名会社の分裂を潰さないため）', () => {
+    const companies = [company({ id: 'c1' }), company({ id: 'c2', name: '受託' })];
+    const groups = groupByCompany(companies, [], () => '');
+    expect(groups).toHaveLength(2);
+    expect(groups[1].items).toEqual([]);
+  });
+
+  it('同名の会社を companyId 単位で別グループのまま保つ（マージしない）', () => {
+    const companies = [
+      company({ id: 'c1', name: '受託', period: '2023.10 — 2024.02' }),
+      company({ id: 'c2', name: '受託', period: '2023.07 — 2024.01' }),
+    ];
+    const items = [
+      { id: 'p1', companyId: 'c1' },
+      { id: 'p2', companyId: 'c2' },
+    ];
+    const groups = groupByCompany(companies, items, (i) => i.companyId);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].company?.period).toBe('2023.10 — 2024.02');
+    expect(groups[1].company?.period).toBe('2023.07 — 2024.01');
+  });
+
+  it('companies に無い companyId の案件は「所属不明」として末尾へまとめる', () => {
+    const companies = [company({ id: 'c1' })];
+    const items = [
+      { id: 'p1', companyId: 'c1' },
+      { id: 'p2', companyId: 'ghost' },
+      { id: 'p3', companyId: 'ghost' },
+    ];
+    const groups = groupByCompany(companies, items, (i) => i.companyId);
+    expect(groups).toHaveLength(2);
+    expect(groups[1].companyId).toBe(UNASSIGNED_COMPANY_ID);
+    expect(groups[1].company).toBeUndefined();
+    expect(groups[1].items.map((i) => i.id)).toEqual(['p2', 'p3']);
+  });
+
+  it('所属不明の案件が無ければ末尾グループを作らない', () => {
+    const companies = [company({ id: 'c1' })];
+    const groups = groupByCompany(companies, [{ id: 'p1', companyId: 'c1' }], (i) => i.companyId);
+    expect(groups).toHaveLength(1);
+  });
+});

--- a/src/db/blocks/group-by-company.ts
+++ b/src/db/blocks/group-by-company.ts
@@ -1,0 +1,43 @@
+/**
+ * 案件データを「会社ごと」にまとめる純粋関数。
+ * app/builder/project-nav.tsx の byCompany（エディタのナビ）と同じ規則:
+ * data.companies の並びを正とし、会社に属さない（companyId が companies に無い）
+ * 案件は「所属不明」として末尾へまとめる。
+ *
+ * 閲覧側（project-section.tsx）はフィルタ後の `{ item, no, tech }` ラッパ配列を渡すため、
+ * companyId を取り出す関数をジェネリックに受け取る。
+ */
+
+import type { CompanyInfo } from './index';
+
+export interface CompanyGroup<T> {
+  /** company が undefined のとき「所属不明」グループ（末尾に1つだけ生まれる）。 */
+  company: CompanyInfo | undefined;
+  companyId: string;
+  items: T[];
+}
+
+/** 所属不明グループの companyId として使う固定値。実データの id とは衝突しない前提の予約語。 */
+export const UNASSIGNED_COMPANY_ID = '__unassigned__';
+
+export function groupByCompany<T>(
+  companies: CompanyInfo[],
+  items: T[],
+  getCompanyId: (item: T) => string,
+): CompanyGroup<T>[] {
+  const order: CompanyGroup<T>[] = companies.map((company) => ({ company, companyId: company.id, items: [] }));
+  const byId = new Map(order.map((group) => [group.companyId, group]));
+  const unassigned: T[] = [];
+
+  for (const item of items) {
+    const companyId = getCompanyId(item);
+    const group = byId.get(companyId);
+    if (group) group.items.push(item);
+    else unassigned.push(item);
+  }
+
+  if (unassigned.length > 0) {
+    order.push({ company: undefined, companyId: UNASSIGNED_COMPANY_ID, items: unassigned });
+  }
+  return order;
+}

--- a/src/db/process.test.ts
+++ b/src/db/process.test.ts
@@ -9,6 +9,7 @@ import {
   formatPeriodRange,
   labelsForProcessIndex,
   normalizeProcess,
+  parsePeriodBounds,
   parsePeriodToRange,
   parseStart,
   parseTokenToDate,
@@ -145,6 +146,35 @@ describe('sortByStartDesc', () => {
     const items = [{ p: '2020.1' }, { p: '2025.1' }, { p: '不明' }, { p: '2023.1' }];
     const sorted = sortByStartDesc(items, (i) => i.p);
     expect(sorted.map((i) => i.p)).toEqual(['2025.1', '2023.1', '2020.1', '不明']);
+  });
+});
+
+describe('parsePeriodBounds', () => {
+  it('範囲表記を開始・終了の小数年へ変換する', () => {
+    expect(parsePeriodBounds('2020.04〜2023.03')).toEqual({ start: 2020 + 3 / 12, end: 2023 + 2 / 12 });
+  });
+
+  it('「現在」終端は現在時刻を終端にする', () => {
+    const now = new Date();
+    const result = parsePeriodBounds('2020.04 — 現在');
+    expect(result).not.toBeNull();
+    expect(result?.end).toBeCloseTo(now.getFullYear() + now.getMonth() / 12, 5);
+  });
+
+  it('単月表記（区切りなし）は start === end の1点区間にする', () => {
+    expect(parsePeriodBounds('2024.01')).toEqual({ start: 2024, end: 2024 });
+  });
+
+  it('終了が空欄（区切りはあるが未入力）も start === end にする', () => {
+    expect(parsePeriodBounds('2024.01〜')).toEqual({ start: 2024, end: 2024 });
+  });
+
+  it('開始が読めなければ null', () => {
+    expect(parsePeriodBounds('不明な期間')).toBeNull();
+  });
+
+  it('空文字は null', () => {
+    expect(parsePeriodBounds('')).toBeNull();
   });
 });
 

--- a/src/db/process.ts
+++ b/src/db/process.ts
@@ -317,7 +317,7 @@ const EMPTY_TECH_PLACEHOLDERS = new Set(['-', 'ー', '—']);
 // 非文字列が紛れた場合は trim() で例外にする代わりに「該当なし」と同じ扱いで除外する
 // （文字列以外を技術名としてそのままチップ表示に流すと、React の子要素として
 // 描画できず落ちる可能性がある）。
-function isEmptyTechValue(value: unknown): boolean {
+export function isEmptyTechValue(value: unknown): boolean {
   if (typeof value !== 'string') return true;
   const trimmed = value.trim();
   return trimmed === '' || EMPTY_TECH_PLACEHOLDERS.has(trimmed);

--- a/src/db/process.ts
+++ b/src/db/process.ts
@@ -90,6 +90,27 @@ export function hasPeriodRangeSeparator(period: string): boolean {
   return RANGE_SEPARATORS.some((sep) => period.includes(sep));
 }
 
+/**
+ * period を会社レーン図用の数値区間へ変換する。単位は parseYearMonth と同じ「小数年」
+ * （年 + (月-1)/12）。終了トークンが「現在」を含む場合は現在時刻を終端にする
+ * （deriveDuration の「継続中」判定と同じ規則）。終了トークンが無い単月表記は
+ * start === end の1点区間として扱う。どちらのトークンも読めなければ null。
+ * 新しいパーサは書かず、既存の splitPeriodRange / parseYearMonth をそのまま使う。
+ */
+export function parsePeriodBounds(period: string): { start: number; end: number } | null {
+  const [startToken, endToken] = splitPeriodRange(period);
+  const start = parseYearMonth(startToken);
+  if (start === null) return null;
+  if (/現在/.test(endToken)) {
+    const now = new Date();
+    return { start, end: now.getFullYear() + now.getMonth() / 12 };
+  }
+  if (!endToken) return { start, end: start };
+  const end = parseYearMonth(endToken);
+  if (end === null) return null;
+  return { start, end: Math.max(end, start) };
+}
+
 // YYYY-MM-DD / YYYY.MM / YYYY年M月 / YYYY-MM / YYYY の順で試す。すべて失敗したら null。
 function parseYearMonth(token: string): number | null {
   if (!token) return null;

--- a/src/test/contrast.test.ts
+++ b/src/test/contrast.test.ts
@@ -82,6 +82,7 @@ function readTokens(block: string) {
     warnSoft: extractToken(block, 'warn-soft'),
     surface2: extractToken(block, 'surface2'),
     borderStrong: extractToken(block, 'border-strong'),
+    chipBgToken: extractToken(block, 'chip-bg'),
   };
 }
 
@@ -89,10 +90,16 @@ const light = readTokens(lightBlock);
 const dark = readTokens(darkBlock);
 
 const AA_NORMAL_TEXT = 4.5;
-// WCAG 1.4.11（非テキストのコントラスト）。操作要素（検索欄・ボタン・ジャンプナビ・
-// 空状態の破線）の枠線に使う --border-strong はここを満たす必要がある。文字色と違い
-// 3:1 で足りる。旧値（ダーク1.51:1 / ライト1.54:1）はここが無かったため誰にも検知されなかった。
+// WCAG 1.4.11（非テキストのコントラスト）。操作要素・境界の枠線に使う --border-strong は
+// ここを満たす必要がある。文字色と違い 3:1 で足りる。
+// 旧値（ダーク1.51:1 / ライト1.54:1）はこの検査が無かったため誰にも検知されなかった。
 const AA_NON_TEXT = 3.0;
+
+// --border-strong が実際に載る面を全部列挙する。--background / --card だけ見ていたときは
+// app/builder/editor.css の .scope-opt（background: var(--surface2) の上に border-strong）が
+// 2.9:1 で漏れていた。track / chip-bg は現状 border-strong を載せていないが、
+// 「どの面に置いても 3:1 を割らない」を不変条件にしておく方が事故が起きない。
+const BORDER_STRONG_SURFACES = ['background', 'card', 'surface2', 'muted', 'track', 'chipBgToken'] as const;
 
 describe('globals.css のコントラスト比（WCAG AA 回帰防止）', () => {
   it('light: --muted-foreground が --background / --card に対し AA(4.5:1) を満たす', () => {
@@ -157,9 +164,13 @@ describe('globals.css のコントラスト比（WCAG AA 回帰防止）', () =>
       expect(contrastRatio(t.mutedForeground, t.surface2)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
     });
 
-    it(`${themeName}: --border-strong が --background / --card に対し 非テキストAA(3:1, WCAG 1.4.11) を満たす`, () => {
-      expect(contrastRatio(t.borderStrong, t.background)).toBeGreaterThanOrEqual(AA_NON_TEXT);
-      expect(contrastRatio(t.borderStrong, t.card)).toBeGreaterThanOrEqual(AA_NON_TEXT);
+    it(`${themeName}: --border-strong が枠線の載る面すべてに対し 非テキストAA(3:1, WCAG 1.4.11) を満たす`, () => {
+      for (const surface of BORDER_STRONG_SURFACES) {
+        expect({ surface, ratio: contrastRatio(t.borderStrong, t[surface]) >= AA_NON_TEXT }).toEqual({
+          surface,
+          ratio: true,
+        });
+      }
     });
   }
 });

--- a/src/test/contrast.test.ts
+++ b/src/test/contrast.test.ts
@@ -81,6 +81,7 @@ function readTokens(block: string) {
     warnStrong: extractToken(block, 'warn-strong'),
     warnSoft: extractToken(block, 'warn-soft'),
     surface2: extractToken(block, 'surface2'),
+    borderStrong: extractToken(block, 'border-strong'),
   };
 }
 
@@ -88,6 +89,10 @@ const light = readTokens(lightBlock);
 const dark = readTokens(darkBlock);
 
 const AA_NORMAL_TEXT = 4.5;
+// WCAG 1.4.11（非テキストのコントラスト）。操作要素（検索欄・ボタン・ジャンプナビ・
+// 空状態の破線）の枠線に使う --border-strong はここを満たす必要がある。文字色と違い
+// 3:1 で足りる。旧値（ダーク1.51:1 / ライト1.54:1）はここが無かったため誰にも検知されなかった。
+const AA_NON_TEXT = 3.0;
 
 describe('globals.css のコントラスト比（WCAG AA 回帰防止）', () => {
   it('light: --muted-foreground が --background / --card に対し AA(4.5:1) を満たす', () => {
@@ -150,6 +155,11 @@ describe('globals.css のコントラスト比（WCAG AA 回帰防止）', () =>
     it(`${themeName}: --foreground / --muted-foreground が --surface2 に対し AA を満たす`, () => {
       expect(contrastRatio(t.foreground, t.surface2)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
       expect(contrastRatio(t.mutedForeground, t.surface2)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+    });
+
+    it(`${themeName}: --border-strong が --background / --card に対し 非テキストAA(3:1, WCAG 1.4.11) を満たす`, () => {
+      expect(contrastRatio(t.borderStrong, t.background)).toBeGreaterThanOrEqual(AA_NON_TEXT);
+      expect(contrastRatio(t.borderStrong, t.card)).toBeGreaterThanOrEqual(AA_NON_TEXT);
     });
   }
 });


### PR DESCRIPTION
## Issue リンク / Link to Issue

close #

### 概要

閲覧画面の案件詳細セクションを、案件32件がフラットに並ぶ構造から**会社ごとのセクション**へ作り替えました。あわせて `--border-strong` が WCAG 1.4.11（非テキストコントラスト3:1）を満たしていなかった不具合を修正しています。

**背景**: 「デザインがちょっと見づらい」という申告に対し、Claude Design で作成した `スキルシート 案件詳細 v3 全件.dc.html` を実装しました。原因は色ではなく構造で、(1) 会社の切れ目が無く会社概要文が案件ごとに再掲されていたこと、(2) カードの本文色が4種類あり階層の基準が無かったことの2点でした。

### 変更内容

- **会社グルーピング** (`src/db/blocks/group-by-company.ts`): companyId単位でグループ化。同名会社はマージしない（実データに「受託」が4回登場するため）。ジャンプナビでは開始年月で区別
- **会社セクション** (`company-section.tsx` / `company-jump-nav.tsx` / `company-lane.tsx`): sticky見出し・在籍期間・在籍レーン図・会社概要文（1回だけ）
- **ProjectCard**: 会社名・会社概要文を除去し、ラベル＋上罫線の構造へ。本文色を `--foreground` に統一。コメントは「要約＋展開」、技術スタックは6バケット分類表示（エディタ側 `editor-constants.ts` と同じラベルに揃えた）
- **検索**: NFKC正規化 + AND/OR対応、ヒント文追加
- **アクセシビリティ修正**: `--border-strong` の非テキストコントラストが実測でダーク1.51:1 / ライト1.54:1しかなくWCAG 1.4.11未達だったため是正。`contrast.test.ts` にガードを追加し、旧値に戻すと実際に赤くなることを確認済み
- **見出し階層**: 案件詳細(h2) > 会社(h3) > 案件(h4)
- `src/db/process.ts` に `parsePeriodBounds` を追加（既存の `splitPeriodRange`/`parseYearMonth` を包むのみ、新規パーサなし）
- `scripts/wss-pg-proxy.mjs`: `ws` パッケージのexport形状変更に追随する1行修正（ローカル検証環境が起動できなくなっていたのを実機確認中に発見）

### 2コミット目：自己レビューで見つけて直した6件

多角レビュー（a11y / ロジック / 検索 / テストの偽グリーン / 実画面）と敵対検証を回し、
**実機またはテストのミューテーションで再現を確認できたものだけ**を直しました。

| # | 症状 | 原因 | 直し方 |
|---|---|---|---|
| 1 | 会社チップを押すと**シート一覧へ飛ばされる** | `app/layout.tsx` が `<base href="{origin}/">` を注入しているため `href="#id"` が「オリジン直下+ハッシュ」に解決される | 既存の目次と同じ button + 自前スクロールへ。アンカーなら移動していたフォーカスも自前で送る |
| 2 | `--border-strong` が `--surface2` 上で 2.91/2.96:1 と**3:1未達のまま** | `--background`/`--card` しか見ていなかった。`editor.css` の `.scope-opt` は `--surface2` 上に載る | `#76898f` / `#5a6f79` に変更。枠線が載りうる面（background/card/surface2/muted/track/chip-bg）すべてを検査 |
| 3 | **案件検索欄の枠線が 1.17:1** で見えない | `contrast.test.ts` のコメントが「検索欄は `--border-strong`」と誤って主張していたが、実装は `--border` のままだった | `--border-strong` を適用。`border-*` ユーティリティは `* { border-color: var(--border) }`（Tailwindレイヤー外）に負けるため inline style で指定し、その事実をテストで固定 |
| 4 | **SP で会社見出しが topbar に隠れる** | topbar は 1280px で 64px、375px では2段になり 126px。固定の `top-16` では 62px 潜っていた | 実測高さを `--viewer-topbar-h` として公開し sticky の top を追従させる |
| 5 | 会社期間の外にある案件で**レーンの帯が消える** | `width: "-43.48%"` という不正な CSS になっていた | 始点も会社期間の終端でクランプ。期間が読めない案件は「在籍期間まるごと」の帯にせず帯を描かない |
| 6 | 技術スタックに **`-` のチップが並ぶ**（実データで9個） | `filter(Boolean)` だけで `flattenTech` の除外規則を通していなかった | `isEmptyTechValue` を共有 |

テスト側も、技術バケットの**ラベルとデータキーの対応を入れ替えても緑のまま通っていた**ため、行の中を見て対応を固定するテストに直しました（入れ替えると赤くなることを確認済み）。

**議論して直さなかったもの**: 技術チップの強調が部分一致で `java` → `JavaScript` も光る件。絞り込み側（既存仕様）も部分一致のため、ここだけ完全一致にすると「ヒットしたのに何も光らないカード」が出て強調の役目を果たさなくなります。変えるなら絞り込みとセットで別途、という判断をコードにコメントとして残しました。

### 見て欲しいポイント

- [ ] `company-jump-nav.tsx` を button にした判断（`<base>` の制約でアンカーが使えない）
- [ ] `viewer-topbar.tsx` の `--viewer-topbar-h` の公開方法（ResizeObserver）
- [ ] `src/test/contrast.test.ts` の非テキストコントラストガードの対象面の選び方

### 見なくてもよいポイント

- [ ] `timeline.tsx` / `process-overview.tsx` は変更していません
- [ ] PDF出力（`projectBlockToMarkdown`）は変更していません

### その他

- 実データ（19社/32案件）をローカルPostgreSQLに投入し、ダーク/ライト両テーマ・320px/375px幅・検索AND/OR・全角入力で実機確認済み（実データはコミットしていません）
- 実機で計測した値: 検索欄の枠線 `rgb(118,137,143)` = `--border-strong` / プレースホルダチップ 0個 / 375px で会社見出しの上端 126px = topbar 下端 126px（重なりなし）
- `pnpm lint` / `type-check` / `test`（jsdom 528 + node 318 + pdf 52 = 898件）/ `build` すべて green

---

### PR チェックポイント

- [x] 複数の変更が1つのPRに入り込んでいないか（トークン修正・会社グルーピング・検索改善は同一Issueの一体作業として実施）
- [x] 開発環境修正（`scripts/wss-pg-proxy.mjs`）は本文に明記

### レビュー観点

- [ ] 想定通りに動作するか
- [ ] より良い書き方はないか？
- [ ] より良い設計はないか？


---
_Generated by [Claude Code](https://claude.ai/code/session_01CT4TWvmTcVoYHAu1WYNGya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 案件を会社ごとに整理し、会社別ジャンプナビゲーションを追加しました。
  * 在籍期間と案件期間をタイムライン形式で表示します。
  * 検索で案件内容・担当業務・会社名を対象に、OR／AND検索や全角文字検索に対応しました。
  * 案件詳細に担当業務、習得スキル、チーム規模、コメント展開機能を追加しました。

* **改善**
  * 検索ヒント、空状態表示、技術タグの強調表示を追加しました。
  * ライト／ダークテーマのアクセント色と境界色を調整し、コントラストを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->