### PR TITLE
fix(pdf): 会社見出しだけがページの末尾に取り残されるのを直す

### DIFF
--- a/src/components/pdf/company-heading.tsx
+++ b/src/components/pdf/company-heading.tsx
@@ -133,6 +133,7 @@ export function CompanyHeading({
   company,
   onFirstPage,
   railStyle,
+  minPresenceAhead = MIN_PRESENCE_AHEAD,
 }: {
   company: PrintCompany;
   /**
@@ -151,6 +152,12 @@ export function CompanyHeading({
    * （`subPageNumber` を持つ呼び出し）を 1 回拾えば「会社の開始ページ」が確定する。
    */
   onFirstPage?: (pageProps: PageRenderProps) => void;
+  /**
+   * 見出しの後ろに要求する高さ（pt）。既定は 240。
+   * 会社の最初のカードが 1 ページに収まる大きさのときは、呼び出し側がその見積り高さを
+   * 渡す（見出しだけがページの末尾に取り残されるのを防ぐ）。
+   */
+  minPresenceAhead?: number;
 }) {
   const isLatest = company.isLatest;
   // デザインの右端「詳細版 ×N」は出さない。内部の分類結果で、読む側には意味が無い。
@@ -170,7 +177,7 @@ export function CompanyHeading({
     // `wrap={false}` を付けたこの View は**このコンポーネントの根**でなければならない。
     // 上にもう 1 枚 View を挟むと、残り高さが 54〜14pt のときページ送りではなく圧縮が
     // 走り、帯の余白が潰れて 2 行目がフッター（下から 46pt）に食い込む（実測）。
-    <View style={railStyle} wrap={false} minPresenceAhead={MIN_PRESENCE_AHEAD}>
+    <View style={railStyle} wrap={false} minPresenceAhead={minPresenceAhead}>
       {onFirstPage && (
         <DynamicView
           render={(pageProps) => {

--- a/src/components/pdf/print-document.tsx
+++ b/src/components/pdf/print-document.tsx
@@ -105,7 +105,10 @@ const MAX_ROOM_AFTER_HEADING = PRINT_SIZE.cardMaxSinglePageHeight - HEADING_BLOC
 
 function requiredRoomAfterHeading(company: PrintCompany): number | undefined {
   const first = company.projects[0];
-  if (!first?.fitsOnePage) return undefined;
+  // 見積り（estimatedHeight / fitsOnePage）は**詳細版カードの寸法**なので、簡約版には当てない
+  // （レビュー指摘）。簡約版は 1 段目の行だけを分割禁止にして 2 段目は割れる作りなので、
+  // 見出しの直後に必ず中身が乗る。取り残される心配が無いぶん、既定の要求で足りる。
+  if (first?.level !== 'detail' || !first.fitsOnePage) return undefined;
   return Math.min(first.estimatedHeight + PRINT_SIZE.cardGap, MAX_ROOM_AFTER_HEADING);
 }
 

--- a/src/components/pdf/print-document.tsx
+++ b/src/components/pdf/print-document.tsx
@@ -85,6 +85,31 @@ const styles = StyleSheet.create({
 type Tracker = ReturnType<typeof createSpanTracker>;
 
 /**
+ * 会社見出しの後ろに要求する高さ（pt）。
+ *
+ * 最初のカードが 1 ページに収まる大きさのときは、**そのカードごと入る高さ**を要求する。
+ * 固定値（240pt）だけだと、見出しは残り 300pt のページに乗るのに、分割禁止の 500pt の
+ * カードは丸ごと次ページへ行き、見出しと会社概要だけがページの末尾に取り残される
+ * （実測: 42 ページ版の p19、E 社の見出しの下が 1 枚まるごと白かった）。
+ *
+ * 1 ページに収まらないカード（`fitsOnePage === false`）は分割されて見出しの直後から
+ * 描かれ始めるので、取り残されない。その場合は既定の 240pt でよい。
+ *
+ * 上限を置くのは、要求が満たせない大きさになると「送っても解決しない」からで、
+ * その時は 240pt と同じ挙動に落ちる。見出し 1 つ分（帯 + 概要 2 行）を実測で約 110pt と
+ * 見て、本文の高さ 754pt から引いた残りを上限にする。カードの見積りは安全側に大きめへ
+ * 振ってあるので、上限に当たったカードも実際の高さでは収まることが多い。
+ */
+const HEADING_BLOCK_HEIGHT = 110;
+const MAX_ROOM_AFTER_HEADING = PRINT_SIZE.cardMaxSinglePageHeight - HEADING_BLOCK_HEIGHT;
+
+function requiredRoomAfterHeading(company: PrintCompany): number | undefined {
+  const first = company.projects[0];
+  if (!first?.fitsOnePage) return undefined;
+  return Math.min(first.estimatedHeight + PRINT_SIZE.cardGap, MAX_ROOM_AFTER_HEADING);
+}
+
+/**
  * 簡約表 1 区間ぶん。列ヘッダーは先頭案件と 1 つの `wrap={false}` 単位に束ねて、
  * データ行 0 件のまま列ヘッダーだけが改ページするのを防ぐ（project-card-compact.tsx の
  * leadingHeader コメント参照）。2 ページ目以降の継続ヘッダーは、先頭案件が実際に乗った
@@ -168,6 +193,7 @@ function CompanySection({
       <CompanyHeading
         company={company}
         railStyle={styles.companyRail}
+        minPresenceAhead={requiredRoomAfterHeading(company)}
         onFirstPage={(pageProps) => companySpanTracker.markStart(company.id, company.name, pageProps)}
       />
       <View style={styles.companyBody}>

--- a/src/components/pdf/print-view-model.ts
+++ b/src/components/pdf/print-view-model.ts
@@ -124,6 +124,11 @@ export interface PrintProject {
    * 見積りは `estimateProjectCardHeight` 参照。
    */
   fitsOnePage: boolean;
+  /**
+   * 詳細版カード 1 枚の見積り高さ（pt）。会社見出しが「最初のカードごと」次ページへ
+   * 送られるべきかの判定に使う（print-document.tsx の CompanySection）。
+   */
+  estimatedHeight: number;
 }
 
 export interface PrintCompany {
@@ -629,9 +634,16 @@ function buildProject(
   const duties = markdownText(item.summary) || markdownText(item.duties);
   const acquired = markdownText(item.acquired);
   const comment = markdownText(item.comment);
-  const fitsOnePage =
-    estimateProjectCardHeight({ title, companyLabel, metaRows, techGroups, duties, acquired, comment }) <=
-    PRINT_SIZE.cardMaxSinglePageHeight;
+  const estimatedHeight = estimateProjectCardHeight({
+    title,
+    companyLabel,
+    metaRows,
+    techGroups,
+    duties,
+    acquired,
+    comment,
+  });
+  const fitsOnePage = estimatedHeight <= PRINT_SIZE.cardMaxSinglePageHeight;
 
   return {
     id: item.id,
@@ -651,6 +663,7 @@ function buildProject(
     compactNote: firstSentence(duties || comment),
     level,
     fitsOnePage,
+    estimatedHeight,
   };
 }
 


### PR DESCRIPTION
会社の見出しだけがページの末尾に取り残され、1 枚まるごと白くなる件を直す。

見出しの後ろに要求する高さが 240pt 固定だったため、残り 300pt のページに見出しは乗るのに、
分割禁止の 500pt のカードは丸ごと次ページへ行っていた（実測: 42 ページ版の p19、E 社）。

最初のカードが 1 ページに収まる大きさのときは、**そのカードごと入る高さ**を要求する。
入らなければ見出しごと次ページへ送られ、見出しとカードが必ず一緒に出る。1 ページに
収まらないカードは分割されて見出しの直後から描かれ始めるので、従来どおり 240pt でよい。

| | ページ数 | 平均の埋まり具合 | 見出しだけで終わるページ |
|---|---|---|---|
| 前 | 42 | 87% | 2 枚 |
| 今回 | 45 | 80% | 1 枚 |

残る 1 枚（B 社）は、見出しと最初のカードの合計が 1 ページの高さを超えるため、どこへ
送っても収まらない。必ず改ページする版でも同じ位置に出ていた。

## 検証

- 型検査 / biome / vitest 3 本（580 + 351 + 88）すべて緑
- 実データ 45 ページ・合成フィクスチャ 29 ページとも品質検査 10 項目すべて緑
- 20 ページ（直った E 社）と 36 ページ（残る B 社）を画像で目視

比較元: 直前に本番へ入った 42 ページ版
判定: PASS
照合していない理由: 45 ページのうち目視は 2 枚。残りは 10 項目の機械検査のみ

<!-- no-sbi: PDF を見た本人の指摘への対応。issue は起票していない -->
<!-- brevity-ok -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - PDF出力時、会社見出しと最初の案件カードがページをまたいで不自然に分割されにくくなりました。
  - 案件カードのサイズに応じて、見出し後に必要な余白を自動調整します。
  - 先頭案件が1ページに収まる場合は、カード全体を同じページに配置しやすくなりました。
  - 収まらない場合は、不要な余白を確保せず従来どおり出力します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->