### PR TITLE
fix: 未ログインで閲覧画面を開くとエラーログが出るのを止める

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,8 @@ GITHUB_BRANCH=main
 
 # Better Auth（編集者ログイン）。32文字以上のランダム値（openssl rand -base64 32）。
 BETTER_AUTH_SECRET=your_random_secret_at_least_32_chars
-# デプロイ先 URL（省略時はリクエスト origin から推定）。
+# デプロイ先 URL（省略時はリクエスト origin から推定するが、起動時に警告が出る）。
+# ローカルは dev サーバのポートに合わせる（例: http://localhost:3000）。ポートが変わったらここも直す。
 BETTER_AUTH_URL=https://your-app.vercel.app
 
 # スキルシートのオーナー識別子（単一オーナー運用の安定キー。Better Auth オーナーに対応）。

--- a/app/view/[path]/page.tsx
+++ b/app/view/[path]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 import { configErrorNoticeOrRethrow, notFoundOnTrpcCodes } from '@/components/view-error';
 import { isSheetFileName, isValidSheetPath, type SheetContent } from '@/server/github-sheets';
 import { createServerCaller } from '@/server/trpc/caller';
-import { isViewer } from '@/server/viewer-gate';
+import { requireViewer } from '@/server/viewer-gate';
 
 import DeferredEditSheetView from './deferred-edit-sheet-view';
 
@@ -32,11 +32,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function SheetViewPage({ params }: PageProps) {
   const { path } = await params;
   if (!isValidSheetPath(path) || !isSheetFileName(path)) notFound();
-  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
-  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
-  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
-  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
-  if (!(await isViewer())) return null;
+  // 閲覧ゲートを page 側でも通す。layout に任せきりにできない理由が 2 つある。
+  // (1) App Router は layout と page を並行して描くため、layout の redirect が確定する前に
+  //     page のデータ取得が走る。未認可のまま進むと viewerProcedure が UNAUTHORIZED を投げ、
+  //     リダイレクトの裏で毎回スタックトレースが出る（タイミング次第では 500 が勝つ）。
+  // (2) クライアント遷移では共有 layout は再レンダリングされないので、遷移の間に閲覧 cookie が
+  //     切れても layout の requireViewer() は走らない。page 側で判定しないと素通りする。
+  // isViewer() を見て null を返す形だと (2) で白画面になるため、page 自身がリダイレクトする。
+  await requireViewer();
 
   let sheet: SheetContent;
   try {

--- a/app/view/[path]/page.tsx
+++ b/app/view/[path]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { configErrorNoticeOrRethrow, notFoundOnTrpcCodes } from '@/components/view-error';
 import { isSheetFileName, isValidSheetPath, type SheetContent } from '@/server/github-sheets';
 import { createServerCaller } from '@/server/trpc/caller';
+import { isViewer } from '@/server/viewer-gate';
 
 import DeferredEditSheetView from './deferred-edit-sheet-view';
 
@@ -31,6 +32,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function SheetViewPage({ params }: PageProps) {
   const { path } = await params;
   if (!isValidSheetPath(path) || !isSheetFileName(path)) notFound();
+  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
+  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
+  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
+  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
+  if (!(await isViewer())) return null;
 
   let sheet: SheetContent;
   try {

--- a/app/view/db/[id]/page.tsx
+++ b/app/view/db/[id]/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server';
 import { configErrorNoticeOrRethrow, notFoundOnTrpcCodes } from '@/components/view-error';
 import { currentMonthKey } from '@/db/derived-display';
 import { createServerCaller } from '@/server/trpc/caller';
-import { isViewer } from '@/server/viewer-gate';
+import { requireViewer } from '@/server/viewer-gate';
 
 import SheetViewClient from '../../[path]/sheet-view-client';
 
@@ -28,11 +28,14 @@ export default async function DbSheetByIdPage({ params }: Props) {
 
   const { id } = await params;
 
-  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
-  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
-  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
-  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
-  if (!(await isViewer())) return null;
+  // 閲覧ゲートを page 側でも通す。layout に任せきりにできない理由が 2 つある。
+  // (1) App Router は layout と page を並行して描くため、layout の redirect が確定する前に
+  //     page のデータ取得が走る。未認可のまま進むと viewerProcedure が UNAUTHORIZED を投げ、
+  //     リダイレクトの裏で毎回スタックトレースが出る（タイミング次第では 500 が勝つ）。
+  // (2) クライアント遷移では共有 layout は再レンダリングされないので、遷移の間に閲覧 cookie が
+  //     切れても layout の requireViewer() は走らない。page 側で判定しないと素通りする。
+  // isViewer() を見て null を返す形だと (2) で白画面になるため、page 自身がリダイレクトする。
+  await requireViewer();
 
   try {
     const caller = await createServerCaller();

--- a/app/view/db/[id]/page.tsx
+++ b/app/view/db/[id]/page.tsx
@@ -4,6 +4,7 @@ import { connection } from 'next/server';
 import { configErrorNoticeOrRethrow, notFoundOnTrpcCodes } from '@/components/view-error';
 import { currentMonthKey } from '@/db/derived-display';
 import { createServerCaller } from '@/server/trpc/caller';
+import { isViewer } from '@/server/viewer-gate';
 
 import SheetViewClient from '../../[path]/sheet-view-client';
 
@@ -26,6 +27,12 @@ export default async function DbSheetByIdPage({ params }: Props) {
   await connection();
 
   const { id } = await params;
+
+  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
+  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
+  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
+  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
+  if (!(await isViewer())) return null;
 
   try {
     const caller = await createServerCaller();

--- a/app/view/db/page.tsx
+++ b/app/view/db/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server';
 import { configErrorNoticeOrRethrow } from '@/components/view-error';
 import { currentMonthKey } from '@/db/derived-display';
 import { createServerCaller } from '@/server/trpc/caller';
-import { isViewer } from '@/server/viewer-gate';
+import { requireViewer } from '@/server/viewer-gate';
 
 import SheetViewClient from '../[path]/sheet-view-client';
 
@@ -17,11 +17,14 @@ export default async function DbSheetPage() {
   // DATABASE_URL はランタイム専用のため、connection() で動的レンダリングを明示する。
   // force-dynamic と異なりセグメント全体ではなくこのコンポーネント単位で動的化する。
   await connection();
-  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
-  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
-  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
-  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
-  if (!(await isViewer())) return null;
+  // 閲覧ゲートを page 側でも通す。layout に任せきりにできない理由が 2 つある。
+  // (1) App Router は layout と page を並行して描くため、layout の redirect が確定する前に
+  //     page のデータ取得が走る。未認可のまま進むと viewerProcedure が UNAUTHORIZED を投げ、
+  //     リダイレクトの裏で毎回スタックトレースが出る（タイミング次第では 500 が勝つ）。
+  // (2) クライアント遷移では共有 layout は再レンダリングされないので、遷移の間に閲覧 cookie が
+  //     切れても layout の requireViewer() は走らない。page 側で判定しないと素通りする。
+  // isViewer() を見て null を返す形だと (2) で白画面になるため、page 自身がリダイレクトする。
+  await requireViewer();
 
   // DB 未マイグレーション（テーブル不在）や DATABASE_URL / SKILLSHEET_OWNER_ID 未設定でも
   // 生の 500 を出さず、対処手順を案内するフォールバック UI を表示する。

--- a/app/view/db/page.tsx
+++ b/app/view/db/page.tsx
@@ -4,6 +4,7 @@ import { connection } from 'next/server';
 import { configErrorNoticeOrRethrow } from '@/components/view-error';
 import { currentMonthKey } from '@/db/derived-display';
 import { createServerCaller } from '@/server/trpc/caller';
+import { isViewer } from '@/server/viewer-gate';
 
 import SheetViewClient from '../[path]/sheet-view-client';
 
@@ -16,6 +17,11 @@ export default async function DbSheetPage() {
   // DATABASE_URL はランタイム専用のため、connection() で動的レンダリングを明示する。
   // force-dynamic と異なりセグメント全体ではなくこのコンポーネント単位で動的化する。
   await connection();
+  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
+  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
+  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
+  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
+  if (!(await isViewer())) return null;
 
   // DB 未マイグレーション（テーブル不在）や DATABASE_URL / SKILLSHEET_OWNER_ID 未設定でも
   // 生の 500 を出さず、対処手順を案内するフォールバック UI を表示する。

--- a/app/view/page.test.tsx
+++ b/app/view/page.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isViewer: vi.fn<() => Promise<boolean>>(),
+  createServerCaller: vi.fn(),
+}));
+
+vi.mock('next/server', () => ({ connection: async () => {} }));
+vi.mock('@/server/viewer-gate', () => ({ isViewer: mocks.isViewer }));
+vi.mock('@/server/trpc/caller', () => ({ createServerCaller: mocks.createServerCaller }));
+// 一覧本体はクライアント側で別途テスト済み。ここは page が「呼ぶ / 呼ばない」だけを見る。
+vi.mock('./db-sheets-list-client', () => ({ default: () => null }));
+
+import SheetsListPage from './page';
+
+const sheets = [{ id: 's1', title: 'テストシート', updatedAt: new Date('2026-01-01T00:00:00.000Z') }];
+
+const callerReturning = () => ({
+  auth: { status: async () => ({ canEdit: false, canView: true }) },
+  sheet: { list: async () => ({ sheets, stale: false }) },
+});
+
+describe('SheetsListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createServerCaller.mockResolvedValue(callerReturning());
+  });
+
+  // App Router は layout と page を並行して描くため、layout の requireViewer() が
+  // リダイレクトを投げても page のデータ取得は走る。ガードが無いと viewerProcedure が
+  // UNAUTHORIZED を投げ、未認証アクセスのたびにエラーログが出ていた。
+  it('未認可なら caller を呼ばずに null を返す', async () => {
+    mocks.isViewer.mockResolvedValue(false);
+
+    await expect(SheetsListPage()).resolves.toBeNull();
+    expect(mocks.createServerCaller).not.toHaveBeenCalled();
+  });
+
+  it('認可済みなら従来どおり一覧を取得して描画する', async () => {
+    mocks.isViewer.mockResolvedValue(true);
+
+    const element = (await SheetsListPage()) as ReactElement<{ initialSheets: typeof sheets }>;
+
+    expect(mocks.createServerCaller).toHaveBeenCalled();
+    expect(element).not.toBeNull();
+    expect(element.props.initialSheets).toEqual(sheets);
+  });
+});

--- a/app/view/page.test.tsx
+++ b/app/view/page.test.tsx
@@ -2,12 +2,15 @@ import type { ReactElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  isViewer: vi.fn<() => Promise<boolean>>(),
+  requireViewer: vi.fn<() => Promise<void>>(),
   createServerCaller: vi.fn(),
 }));
 
+/** next/navigation の redirect() と同じく、例外を投げて描画を打ち切る挙動を模す。 */
+class RedirectError extends Error {}
+
 vi.mock('next/server', () => ({ connection: async () => {} }));
-vi.mock('@/server/viewer-gate', () => ({ isViewer: mocks.isViewer }));
+vi.mock('@/server/viewer-gate', () => ({ requireViewer: mocks.requireViewer }));
 vi.mock('@/server/trpc/caller', () => ({ createServerCaller: mocks.createServerCaller }));
 // 一覧本体はクライアント側で別途テスト済み。ここは page が「呼ぶ / 呼ばない」だけを見る。
 vi.mock('./db-sheets-list-client', () => ({ default: () => null }));
@@ -30,15 +33,17 @@ describe('SheetsListPage', () => {
   // App Router は layout と page を並行して描くため、layout の requireViewer() が
   // リダイレクトを投げても page のデータ取得は走る。ガードが無いと viewerProcedure が
   // UNAUTHORIZED を投げ、未認証アクセスのたびにエラーログが出ていた。
-  it('未認可なら caller を呼ばずに null を返す', async () => {
-    mocks.isViewer.mockResolvedValue(false);
+  // page 自身がリダイレクトするのは、クライアント遷移で共有 layout が再描画されず、
+  // 遷移の間に閲覧 cookie が切れた場合に layout 側の判定が走らないため。
+  it('未認可なら caller を呼ばずにリダイレクトへ抜ける', async () => {
+    mocks.requireViewer.mockRejectedValue(new RedirectError('redirect'));
 
-    await expect(SheetsListPage()).resolves.toBeNull();
+    await expect(SheetsListPage()).rejects.toBeInstanceOf(RedirectError);
     expect(mocks.createServerCaller).not.toHaveBeenCalled();
   });
 
   it('認可済みなら従来どおり一覧を取得して描画する', async () => {
-    mocks.isViewer.mockResolvedValue(true);
+    mocks.requireViewer.mockResolvedValue(undefined);
 
     const element = (await SheetsListPage()) as ReactElement<{ initialSheets: typeof sheets }>;
 

--- a/app/view/page.tsx
+++ b/app/view/page.tsx
@@ -3,6 +3,7 @@ import { connection } from 'next/server';
 import { classifyConfigErrorOrRethrow } from '@/components/view-error';
 import type { SheetSummary } from '@/db';
 import { createServerCaller } from '@/server/trpc/caller';
+import { isViewer } from '@/server/viewer-gate';
 import type { ConfigErrorKind } from '@/util/is-config-error';
 
 import DbSheetsListClient from './db-sheets-list-client';
@@ -14,6 +15,11 @@ export const metadata: Metadata = {
 export default async function SheetsListPage() {
   // DATABASE_URL はランタイム専用。connection() で動的レンダリングを確保する。
   await connection();
+  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
+  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
+  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
+  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
+  if (!(await isViewer())) return null;
 
   let sheets: SheetSummary[] = [];
   let stale = false;

--- a/app/view/page.tsx
+++ b/app/view/page.tsx
@@ -3,7 +3,7 @@ import { connection } from 'next/server';
 import { classifyConfigErrorOrRethrow } from '@/components/view-error';
 import type { SheetSummary } from '@/db';
 import { createServerCaller } from '@/server/trpc/caller';
-import { isViewer } from '@/server/viewer-gate';
+import { requireViewer } from '@/server/viewer-gate';
 import type { ConfigErrorKind } from '@/util/is-config-error';
 
 import DbSheetsListClient from './db-sheets-list-client';
@@ -15,11 +15,14 @@ export const metadata: Metadata = {
 export default async function SheetsListPage() {
   // DATABASE_URL はランタイム専用。connection() で動的レンダリングを確保する。
   await connection();
-  // layout の requireViewer() と同じ判定を先に行う。App Router は layout と page を並行して
-  // 描くため、リダイレクトが確定する前に page のデータ取得が走る。未認可のまま進むと
-  // viewerProcedure が UNAUTHORIZED を投げ、リダイレクトの裏で毎回スタックトレースが出る
-  // （＋タイミング次第でリダイレクトより 500 が勝つ）。描画は layout の redirect に譲る。
-  if (!(await isViewer())) return null;
+  // 閲覧ゲートを page 側でも通す。layout に任せきりにできない理由が 2 つある。
+  // (1) App Router は layout と page を並行して描くため、layout の redirect が確定する前に
+  //     page のデータ取得が走る。未認可のまま進むと viewerProcedure が UNAUTHORIZED を投げ、
+  //     リダイレクトの裏で毎回スタックトレースが出る（タイミング次第では 500 が勝つ）。
+  // (2) クライアント遷移では共有 layout は再レンダリングされないので、遷移の間に閲覧 cookie が
+  //     切れても layout の requireViewer() は走らない。page 側で判定しないと素通りする。
+  // isViewer() を見て null を返す形だと (2) で白画面になるため、page 自身がリダイレクトする。
+  await requireViewer();
 
   let sheets: SheetSummary[] = [];
   let stale = false;

--- a/src/server/viewer-gate.ts
+++ b/src/server/viewer-gate.ts
@@ -73,10 +73,12 @@ export async function hasViewerSession(requestHeaders?: Headers): Promise<boolea
  * 未許可なら /viewer-auth へリダイレクトする（redirect() は内部で例外を投げるため、
  * 許可時のみ正常 return する）。RSC / レイアウトからのみ呼ぶこと。
  *
- * 注意: App Router は layout と page を**並行して**描画するため、ここで投げた redirect は
- * 配下の page の描画を止めない。page 側も先頭で isViewer() を見て、false なら null を返して
- * データ取得へ進まないこと。忘れると未認証アクセスのたびに viewerProcedure が
- * UNAUTHORIZED を投げ、リダイレクトの裏でエラーログが出る（タイミング次第では 500 が勝つ）。
+ * 注意: layout に置くだけでは足りず、/view 配下の page も先頭でこれを呼ぶこと。理由は 2 つ。
+ * (1) App Router は layout と page を**並行して**描画するため、ここで投げた redirect は
+ *     配下の page の描画を止めない。呼び忘れると未認証アクセスのたびに viewerProcedure が
+ *     UNAUTHORIZED を投げ、リダイレクトの裏でエラーログが出る（タイミング次第では 500 が勝つ）。
+ * (2) クライアント遷移では共有 layout は再レンダリングされない。遷移の間に閲覧 cookie が
+ *     切れても layout 側の判定は走らないため、page 側で判定しないと素通りする。
  */
 export async function requireViewer(): Promise<void> {
   if (await isViewer()) {

--- a/src/server/viewer-gate.ts
+++ b/src/server/viewer-gate.ts
@@ -72,6 +72,11 @@ export async function hasViewerSession(requestHeaders?: Headers): Promise<boolea
  * /view 配下の閲覧認可の単一チェックポイント。
  * 未許可なら /viewer-auth へリダイレクトする（redirect() は内部で例外を投げるため、
  * 許可時のみ正常 return する）。RSC / レイアウトからのみ呼ぶこと。
+ *
+ * 注意: App Router は layout と page を**並行して**描画するため、ここで投げた redirect は
+ * 配下の page の描画を止めない。page 側も先頭で isViewer() を見て、false なら null を返して
+ * データ取得へ進まないこと。忘れると未認証アクセスのたびに viewerProcedure が
+ * UNAUTHORIZED を投げ、リダイレクトの裏でエラーログが出る（タイミング次第では 500 が勝つ）。
  */
 export async function requireViewer(): Promise<void> {
   if (await isViewer()) {


### PR DESCRIPTION
## Issue リンク / Link to Issue

対応する Issue はありません。開発サーバーのログで見つけた不具合です。

close #

<!-- no-sbi: 対応する Issue が無いため -->

### 概要

未ログインのまま閲覧画面を開くと、毎回サーバーのログにエラーが 2 本出ていました。これを止めます。

原因は、Next.js の App Router が親のレイアウトと中身のページを同時に描き始めることです。

閲覧画面の入口では、レイアウト側が「未ログインならログイン画面へ飛ばす」判定をしています。この判定が出ても、ページ側のデータ取得は止まりません。

その結果、閲覧権限を要求する API がエラーを投げます。受け取ったページ側は障害と判定し、ログに出したうえで投げ直していました。

今はログイン画面への転送が勝っています。ただし順序は保証されていません。タイミング次第では転送のはずがエラー画面になります。

対応として、閲覧画面配下の 4 ページの先頭でも同じ閲覧ゲートを通します。権限が無ければ、ページ自身がログイン画面へ転送します。

レイアウト任せにしない理由がもう 1 つあります。クライアント遷移では共有レイアウトが再描画されません。遷移の間にクッキーが切れると、レイアウト側の判定は走らないままです。

### 見て欲しいポイント

エラーを握りつぶす形にしなかった理由を、いちばん見てほしいです。

- [ ] エラーを捕まえて隠す形は採りませんでした。編集者向けの API も同じ種類のエラーを投げるためです。隠すと、将来そこを呼んだときに白い画面を静かに作ります。
- [ ] 判定を足しても追加の負荷はありません。閲覧用クッキーの検証も編集者セッションの確認も、1 リクエストにつき 1 回で済むよう既にメモ化されています
- [ ] 権限判定の入口となる関数に注意書きを足しました。次にページを足す人が同じ穴を開けないための歯止めです

### 見なくてもよいポイント

挙動を変えていない部分です。

- [ ] 環境変数のサンプルに足したコメント 2 行。ローカル起動時に出る警告を消すための補足です
- [ ] 4 ページに入れたコメントはすべて同じ文面です

### その他(あれば)

実機照合の申告です。

比較元：なし。デザインの変更を含みません。ログイン済みの画面出力は変更前後で同じです。

判定：PASS

照合していない場合の理由：ありません。ブラウザで 3 つの状態を撮りました。

- 未ログインで閲覧画面を開くと、ログイン画面へ転送されます。
- ログイン後は一覧が今までどおり出ます。
- 一覧を開いたままクッキーを消し、シートを選ぶ操作をすると、ログイン画面へ転送されます。白い画面にはなりません。

- 未ログインで閲覧画面の 4 経路を開くと、いずれも転送（307）を返します。開発サーバーのログに新しい行は 1 行も出ませんでした。修正前は同じログにエラーが出ていました。
- 正しい閲覧コードでログインすると 200 が返ります。ログイン済みの閲覧画面も 200 で、一覧が表示されます。

---

### PR チェックポイント

下に各項目の状況を書きます。

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
  - 対応チケットが無いため、番号は入れていません。
- [x] 複数の変更が 1 つの PR に入り込んでいないか
  - 環境変数サンプルのコメント 2 行だけは別件です。同じログで気づいたので同梱しました。
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
  - ローカルの環境変数ファイルに `BETTER_AUTH_URL=http://localhost:3000` を足すと、起動時の警告が消えます。未設定でも動作は変わりません。
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）
  - 閲覧画面配下の 4 ページすべてに同じ対応を入れました。

### レビュー観点

観点ごとの回答です。

- [x] 想定通りに動作するか
  - 上の実機照合のとおりです。
- [x] より良い書き方はないか？
  - リクエストの前段へ認可を寄せる案も考えました。全リクエストの手前に署名検証を置くことになり、しくじると全画面が開かなくなります。今回の症状には重すぎると判断しました。
- [x] より良い設計はないか？
  - 認可を決めているのは、今までどおりレイアウトと API 側です。ページが足したのは描画の抑制だけで、権限判定は増やしていません。
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
  - フォーマッタと命名検査はどちらも緑です。
- [x] 関数・コンポーネントの粒度は適切か？
  - 既存の権限判定関数を呼ぶだけで、新しい抽象は足していません。
- [ ] その他(具体的に記述をしてください)
  - テストを 1 本足しました。未ログインならデータ取得を呼ばないことを固定しています。ローカルではテスト 3 本と型チェックが緑です。
  - Codex の指摘（クライアント遷移でレイアウトが再描画されない件）を受けて、ページ自身が転送する形に直しました。
