### PR TITLE
fix(web): keep tech suggestions above sticky company headings

### DIFF
--- a/src/components/blocks/tech-filter.test.tsx
+++ b/src/components/blocks/tech-filter.test.tsx
@@ -42,6 +42,15 @@ describe('TechFilter', () => {
     expect(screen.getByRole('option', { name: /OnlyOnce/ })).toBeTruthy();
   });
 
+  it('候補パネルは固定会社見出しより前面に表示する', async () => {
+    const user = userEvent.setup();
+    render(<TechFilter all={ALL} active={[]} count={3} total={3} {...noop} />);
+
+    await user.click(screen.getByLabelText('技術を選ぶ'));
+
+    expect(screen.getByRole('listbox')).toHaveClass('z-30');
+  });
+
   it('選んだ技術はチップになり aria-pressed=true になる', async () => {
     const user = userEvent.setup();
     const onToggle = vi.fn();

--- a/src/components/blocks/tech-filter.tsx
+++ b/src/components/blocks/tech-filter.tsx
@@ -134,7 +134,7 @@ export function TechFilter({ all, active, query, onQueryChange, onToggle, onClea
             role="listbox"
             id={listboxId}
             aria-label="技術の候補"
-            className="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-[var(--radius)] border border-border bg-card py-1 shadow-md"
+            className="absolute z-30 mt-1 max-h-64 w-full overflow-auto rounded-[var(--radius)] border border-border bg-card py-1 shadow-md"
           >
             {matches.map((tech, i) => (
               <button


### PR DESCRIPTION
## Issue リンク / Link to Issue

関連Issueなし（候補パネルの表示崩れに対するhotfix）

### 概要

案件詳細の技術候補パネルが、スクロール時に固定表示される会社見出しの背面に隠れる問題を修正しました。
候補パネルの重なり順を `z-20` から `z-30` に変更し、上部ナビゲーションの `z-40` は超えないようにしています。

### 見て欲しいポイント

- [ ] 技術候補パネルが固定会社見出しより前面に表示されること
- [ ] 候補選択と絞り込みが従来どおり動作すること
- [ ] 上部ナビゲーションとの重なり順を崩していないこと

### 見なくてもよいポイント

- [ ] 技術候補の分類や対象範囲（#314で別途PBI化）

### その他(あれば)

自己レビュー: 100/100。変更は表示レイヤーと回帰テストの2ファイルに限定しています。
ボットレビューは指摘なし。CodeRabbitはレビュー上限により通常レビューを実行できませんでした。

検証:
- `pnpm exec vitest run src/components/blocks/tech-filter.test.tsx src/components/blocks/project-section.test.tsx`
- `pnpm test`
- `pnpm run type-check`
- CIのlint、build、typecheck、test、e2eがすべて成功
- `git diff --check`

ローカル `pnpm run lint` はNode 26環境のBiome異常終了で完走しませんでした。CIのNode 22では成功しています。

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [x] 複数の変更が 1 つの PR に入り込んでいないか
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか
- [x] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（AdminやOwnerは例）

### レビュー観点

- [x] 想定通りに動作するか
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [x] その他（該当なし）
Evidence draft follows.
## Evidence
- HEAD: 7eb0bca73e16da666f6e0950fd2b0741d9d385a1
- Rebase base: 9418db18451fafe431d22dfb80511e662200cb1e (9418db1)
- Commands and exit codes:
- Focused Vitest regression tests: exit 0
type-check exit 0
full suite exit 0
Local evidence artifacts on Mac mini:
/Users/kouiso/worktrees/skillsheet-pr-315-rebase-20260906/artifacts/wi-315/vitest-tech-filter.log
/Users/kouiso/worktrees/skillsheet-pr-315-rebase-20260906/artifacts/wi-315/type-check.log
/Users/kouiso/worktrees/skillsheet-pr-315-rebase-20260906/artifacts/wi-315/exit-codes.txt
/Users/kouiso/worktrees/skillsheet-pr-315-rebase-20260906/artifacts/wi-315/ui-regression-note.txt
Artifacts are local to the Mac mini worktree and are not committed.
Artifact directory: /Users/kouiso/worktrees/skillsheet-pr-315-rebase-20260906/artifacts/wi-315/
