### PR TITLE
feat: Sentry/PostHog導入で障害と利用状況を可視化する

### DIFF
--- a/.env.enc
+++ b/.env.enc
@@ -1,18 +1,18 @@
-#ENC[AES256_GCM,data:vCTRGdnaj4RvSfvX0Bkj1+0Zi52Xcoen9R0ybHNr2Vr6pMSIkrb/uJsTcBaaG9y9in33,iv:XjfNuxR3ughBF//dSrpT6qybL7yeeogx8tcY1Y0/AhE=,tag:ycSYyfmTtlZXUHtk+3q4eg==,type:comment]
-#ENC[AES256_GCM,data:L+cI6WtfJy26KypzVkfV2K4/XZL2Lps4etnpgJeDfCTByrUJrX+jYL/tYt4=,iv:OR0CkRkdnQz2QZ+zXzLaVPlkg3+O70yh80Yg872owEs=,tag:LF+EqSepV7vIBeKbpqYVdA==,type:comment]
-DATABASE_URL=ENC[AES256_GCM,data:AQnJ6etn1IgjgVFmoF9Ch+6+0+Ahz5aUsleRBREhMgLVOPGeGHO4/n9rTOcZYuBUA1oho0yxn4xKV7V/sm3rpy6BqiSTyEkIaKVPxrXlkBNPASDDnb136qMK+mItWiuW5yRO4JaeATcHYBZlrd8q0qWKBJ+rEcPZo6n2EB6+gpsOZ/38Fot5CggDqSUR6HStCkhCBLcu,iv:Z4d4wA7rTv+Rwbmx0UNcWPs0kZ5YwY7lGozTlNLc5Xo=,tag:fOW4eRI0WpTARyrF1HniXQ==,type:str]
-SESSION_SECRET=ENC[AES256_GCM,data:sXqBixhr8c/MFCIW7EV8vx3NkT8+UUyHBECHcF6EyQv/GcvkOCTccJZXUA==,iv:eQBlF7dq1w6EAnFWhSfjPXQv8rVIecsJeRbYrGVolDU=,tag:cecaNySnNmQzVjsfZwHy6w==,type:str]
-VIEWER_CODE=ENC[AES256_GCM,data:1ZD9VcgNVg==,iv:VOYvfsAB33B7JkeUJ7wTkBS/y3DuNVcty4e4DBXvtRA=,tag:GO8fAW7/dhkeTthb8f6CXg==,type:str]
-BETTER_AUTH_SECRET=ENC[AES256_GCM,data:lkttzFyBaMapRStVVY7+RnHFbfeuRskxnrzZ59aKIGb1WUm9RK+gDSPhKw==,iv:w14wTjaExImejlXuUd2qnIqMsGoraiZ0d+BUVfRotUk=,tag:V7PmXQgjVeZXwD1twR+G2w==,type:str]
-SKILLSHEET_OWNER_ID=ENC[AES256_GCM,data:rfrPanuBzcB7bcfCNKKBSerI72PWTNUbFmBGI41u698=,iv:fDWOC85bzbEjkD9d22S35W5Ox4YJP9ewA4xESpaXmps=,tag:Yx7SOvbzcPyy5vHu9d4tbQ==,type:str]
-APP_ENV=ENC[AES256_GCM,data:WoPooeB6LBccXs4=,iv:8/wFQ/rbuL0pxs1ewxOh0pcQJFoEWNf9Ls6jFaExl3U=,tag:i3yKHie7wTzrSrIt1x3dag==,type:str]
-GITHUB_OWNER=ENC[AES256_GCM,data:EhSzlJuw,iv:HJA2r90cDQYutjyOeMvBUXOsD6eNTifpNJN4S79z7o4=,tag:xm8F+LseThj2wyJxAyExnw==,type:str]
-GITHUB_REPO=ENC[AES256_GCM,data:FdfwONyM9sCACx3JLDp5p70=,iv:ke+S6xcDzdGndYPT8NH5X8Y7NAlGI1aSA50LqvVhqaI=,tag:QTB7bM6JxJL6kRfz8mYOGg==,type:str]
-NEXT_PUBLIC_POSTHOG_KEY=ENC[AES256_GCM,data:iE4zsN1NHEddBSrNCHE41y2tDEjJgFBlUXYqVGTuPTy+hohq/yNH6doYABaFXsj9,iv:Ho+TmWgHhHk3JnjusYJEH0iFdEcqBHsg6PUp9/R23f8=,tag:CQjT8Q/PgH1cBWedrlypYQ==,type:str]
-NEXT_PUBLIC_POSTHOG_HOST=ENC[AES256_GCM,data:wMwQqpV546ZQvREEiFZ3wDIL98mKZFoy,iv:uSHSHpvppZuRM09rkJuQx7aS8Lfio8VVHgladJzZDdw=,tag:HjpUa6ByVn9KkYLsRQ2BDw==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEY09YamgyMCt2N0NsbTlB\nNFJCUitMV2N4cHJNRnBEaVdTR1ZlalpGUjBnCmltOUwrVmUrSWp6ek4rSGZFc0dR\nblgzbjVrMDBtWGVmTzlBb3ZWZml3SDQKLS0tIHh4TVdnWU5nTEhWcm5vWjNscEty\nMWN3VDYzUHBqM0JLZ3dBU0wySG1ZKzAKhxSIXWPJt4nqEjQfBTp+czRzh+U1N5yT\nxNwTYyVdftfwF6pW6tk6WtGRGa4YH1qGVnaJoRdZXAAiEcV908V3Hw==\n-----END AGE ENCRYPTED FILE-----\n
+#ENC[AES256_GCM,data:SUJKvTsorHu+cdqWRj1djneCwTHn52ZSw8OCvLuycpCXYAm1IdPEMJtn0wOXsCj8/7UG,iv:keToeqqGcChVdAF8/JpAMJ2NruiahdXj96IC2rMwCwE=,tag:Z/Ia6DUZDugiVsaci2wSQA==,type:comment]
+#ENC[AES256_GCM,data:O0jfYBdoS5IHWeQLomGenlnbRsNoFdQIVcYqwf7oxMJvKfj0k1fRX/gxlPA=,iv:xzloCVzZy4mEAk7zW4SFAg+czSBCOUGjZokt5Itf05o=,tag:0FP0P6vcgtLpU7J9hSRqww==,type:comment]
+DATABASE_URL=ENC[AES256_GCM,data:CzOYKwrkqQ4HgjyXmGDbZffIVv6Fe7P/EOXBFILnkCoUv6xse5mI7NUGAnWEcdzzWEyvWWeEcAv0rOPsF0YWssv98Woagt5GvznA7AtQXGkFt1uBOzqkjguAT5wgM3J5l3Lr0KtsgQEjXKqw2Z8UoTkos0xsysARwlYqpptHrgpIyJoOUx43TUbigTVc+uuxqjGGOoJz,iv:AptuaZU07nLZkbNzFEovkBpktAn+B/Z3wpsYCBuqxF8=,tag:NhDord18i0cFLBR6opzncw==,type:str]
+SESSION_SECRET=ENC[AES256_GCM,data:U/DaFev7Z7Z6PRbp5LrxKQmxF9wznwc0ZatevpkEcEWD49QwhPQ+pJBhJQ==,iv:IgTh9BUF+fP49oBNX99RpM6S1R3b3ZLJeDzaZZfaP3U=,tag:IXaEa5SPPSbB4en270869Q==,type:str]
+VIEWER_CODE=ENC[AES256_GCM,data:MsuRkXPfvA==,iv:gPFI5yISlt70wMlS25IPWwoOBLaJVzayFLQBQnlHq6Y=,tag:ALkNoYp7Cpc9+WQyuQQBfQ==,type:str]
+BETTER_AUTH_SECRET=ENC[AES256_GCM,data:+B/GfyZXUJbr+Ou/FGC5w057Oqv2p2zy5Kn0Vqbdssp1U1zBEe8gglC7cg==,iv:2x1WyxBfI0ad09rxuE4fAKLo+gtrzGdbXYuOmb3IJbI=,tag:TM/bGW5EHk8rY/++9YUK8g==,type:str]
+SKILLSHEET_OWNER_ID=ENC[AES256_GCM,data:8awq2Oyqh5d81chgTZbdhJ+uXajKSdFBQBPyzIp1jJU=,iv:XoQVUUMQ4xSKbrn7lEt4mMJrXgJWsrNsLqVukvSN2eI=,tag:fIqLni9SBVTGqWDP+wYNmA==,type:str]
+APP_ENV=ENC[AES256_GCM,data:OI4j3t4K7tA2lcA=,iv:S9yWHUWIAWM2jcJfFsiaFeVgK6ZDAGujtv0ha7HLJ1c=,tag:GmFdDGpX7FEF4L8PZyVSUA==,type:str]
+GITHUB_OWNER=ENC[AES256_GCM,data:w+7K1A2J,iv:XB5cqp4rvteMT3lfixpfGv7paXDH2ch5lH2dLbclOmg=,tag:XsVSDNNnSuU5Z9Tk1k6bcw==,type:str]
+GITHUB_REPO=ENC[AES256_GCM,data:8D8vt/rHhSbk2MX+kIEljTA=,iv:BSXac0hCTRQhP2jDZk4rK9VPJ0VBwm81K95WQv8OFig=,tag:eDP4LsLFJYoIVet2uYtD6g==,type:str]
+NEXT_PUBLIC_POSTHOG_KEY=ENC[AES256_GCM,data:5JEL2MJb8A6GMi1j1673FZ2jtEOtwCzfuFNBTkFW/NGmMe+l7Oeaj5YCI7POavfm,iv:/40gjIC3XzBOUkOOVQWz8iVEMwM86oJvWp3e/JUWNhw=,tag:nWgotKNO+enul0uN6DuvDQ==,type:str]
+NEXT_PUBLIC_POSTHOG_HOST=ENC[AES256_GCM,data:O51A61IwowMu2DNJZHXVjaOkPsDjkh/y,iv:CoQQAYLnifh8hX/xlvSF/KLuuiUxajanc6noZGv8jpk=,tag:Qc3SZIzIdi9fxAdEJCq+Gg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEYS84Q2RHMk8wWVZLNEkr\nOFl5VklwUjY0NzJ4bFQ5TDRtdFdxSThoM0Z3CjQxbkpza3JXN1d0V1MrQzA3Zk9m\nTGhaTVNVU2VtZzVXS00yTUc2eHpxaUkKLS0tIElyYlhOYTFrQVJ3bStqcUE2U2pN\nTTlOTTQrK1hLSmlFSEFMdXlqV0huNTQKDXX7N6QOyhlvO79vio6I0wyiLnRE12KI\nQv7rls9JUFQ3/AXc7k+I7H70PscVEFoV8q6UB2LxEcanUjc0L3hjWw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age189u2nwxqs9emdc0jhueu0873pes2qeqfgwujy07xyue5wdmrw9nqxw8zh6
-sops_lastmodified=2026-09-02T06:45:56Z
-sops_mac=ENC[AES256_GCM,data:rHCo1Zg/f+m4ztHUKs9sDSsnbsyuL9ynU3GbIj21OKRPrNFxAyE3mFMYvoqCpFbr3lle3XR3Uh1VxcCl2I1jjPo4fPQKLNQX9CJqdTTe3AB0kvxZh9RfNgf7Bb2tNwRlDRd2lnv3xaBDYXaQQqY+JqDnqC5ta7KuOvsF7h11LGk=,iv:rgHKY640c/W/Gn4MnLhEQrxfKzEkmPyxxcw23Zh4ciw=,tag:CGWGhH+ezkTCbpXYpBQ3hw==,type:str]
+sops_lastmodified=2026-09-02T07:06:30Z
+sops_mac=ENC[AES256_GCM,data:hCLvIcWnHcxvaGmK+v7OSs1/T5UcYmcThn/0JMgEqHseXcX99g7XjIw60q1p6IDtI/Maun89sm1qgHfV4AGLnE3va7yWE/YCtyURZpvjGhFb8DZDt1PjGd3y+zhcuz259+pLMFr19M6T3Xdu8ODnhKewFn0N1YtORuTw+lKu6fY=,iv:/XGERgxneFpPC3lhByKTveu8KF2tkBQNVLHTwQT2jZ4=,tag:9ht3Pl9KdoYGjO3W1H7isQ==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1

--- a/.env.enc
+++ b/.env.enc
@@ -1,0 +1,18 @@
+#ENC[AES256_GCM,data:vCTRGdnaj4RvSfvX0Bkj1+0Zi52Xcoen9R0ybHNr2Vr6pMSIkrb/uJsTcBaaG9y9in33,iv:XjfNuxR3ughBF//dSrpT6qybL7yeeogx8tcY1Y0/AhE=,tag:ycSYyfmTtlZXUHtk+3q4eg==,type:comment]
+#ENC[AES256_GCM,data:L+cI6WtfJy26KypzVkfV2K4/XZL2Lps4etnpgJeDfCTByrUJrX+jYL/tYt4=,iv:OR0CkRkdnQz2QZ+zXzLaVPlkg3+O70yh80Yg872owEs=,tag:LF+EqSepV7vIBeKbpqYVdA==,type:comment]
+DATABASE_URL=ENC[AES256_GCM,data:AQnJ6etn1IgjgVFmoF9Ch+6+0+Ahz5aUsleRBREhMgLVOPGeGHO4/n9rTOcZYuBUA1oho0yxn4xKV7V/sm3rpy6BqiSTyEkIaKVPxrXlkBNPASDDnb136qMK+mItWiuW5yRO4JaeATcHYBZlrd8q0qWKBJ+rEcPZo6n2EB6+gpsOZ/38Fot5CggDqSUR6HStCkhCBLcu,iv:Z4d4wA7rTv+Rwbmx0UNcWPs0kZ5YwY7lGozTlNLc5Xo=,tag:fOW4eRI0WpTARyrF1HniXQ==,type:str]
+SESSION_SECRET=ENC[AES256_GCM,data:sXqBixhr8c/MFCIW7EV8vx3NkT8+UUyHBECHcF6EyQv/GcvkOCTccJZXUA==,iv:eQBlF7dq1w6EAnFWhSfjPXQv8rVIecsJeRbYrGVolDU=,tag:cecaNySnNmQzVjsfZwHy6w==,type:str]
+VIEWER_CODE=ENC[AES256_GCM,data:1ZD9VcgNVg==,iv:VOYvfsAB33B7JkeUJ7wTkBS/y3DuNVcty4e4DBXvtRA=,tag:GO8fAW7/dhkeTthb8f6CXg==,type:str]
+BETTER_AUTH_SECRET=ENC[AES256_GCM,data:lkttzFyBaMapRStVVY7+RnHFbfeuRskxnrzZ59aKIGb1WUm9RK+gDSPhKw==,iv:w14wTjaExImejlXuUd2qnIqMsGoraiZ0d+BUVfRotUk=,tag:V7PmXQgjVeZXwD1twR+G2w==,type:str]
+SKILLSHEET_OWNER_ID=ENC[AES256_GCM,data:rfrPanuBzcB7bcfCNKKBSerI72PWTNUbFmBGI41u698=,iv:fDWOC85bzbEjkD9d22S35W5Ox4YJP9ewA4xESpaXmps=,tag:Yx7SOvbzcPyy5vHu9d4tbQ==,type:str]
+APP_ENV=ENC[AES256_GCM,data:WoPooeB6LBccXs4=,iv:8/wFQ/rbuL0pxs1ewxOh0pcQJFoEWNf9Ls6jFaExl3U=,tag:i3yKHie7wTzrSrIt1x3dag==,type:str]
+GITHUB_OWNER=ENC[AES256_GCM,data:EhSzlJuw,iv:HJA2r90cDQYutjyOeMvBUXOsD6eNTifpNJN4S79z7o4=,tag:xm8F+LseThj2wyJxAyExnw==,type:str]
+GITHUB_REPO=ENC[AES256_GCM,data:FdfwONyM9sCACx3JLDp5p70=,iv:ke+S6xcDzdGndYPT8NH5X8Y7NAlGI1aSA50LqvVhqaI=,tag:QTB7bM6JxJL6kRfz8mYOGg==,type:str]
+NEXT_PUBLIC_POSTHOG_KEY=ENC[AES256_GCM,data:iE4zsN1NHEddBSrNCHE41y2tDEjJgFBlUXYqVGTuPTy+hohq/yNH6doYABaFXsj9,iv:Ho+TmWgHhHk3JnjusYJEH0iFdEcqBHsg6PUp9/R23f8=,tag:CQjT8Q/PgH1cBWedrlypYQ==,type:str]
+NEXT_PUBLIC_POSTHOG_HOST=ENC[AES256_GCM,data:wMwQqpV546ZQvREEiFZ3wDIL98mKZFoy,iv:uSHSHpvppZuRM09rkJuQx7aS8Lfio8VVHgladJzZDdw=,tag:HjpUa6ByVn9KkYLsRQ2BDw==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEY09YamgyMCt2N0NsbTlB\nNFJCUitMV2N4cHJNRnBEaVdTR1ZlalpGUjBnCmltOUwrVmUrSWp6ek4rSGZFc0dR\nblgzbjVrMDBtWGVmTzlBb3ZWZml3SDQKLS0tIHh4TVdnWU5nTEhWcm5vWjNscEty\nMWN3VDYzUHBqM0JLZ3dBU0wySG1ZKzAKhxSIXWPJt4nqEjQfBTp+czRzh+U1N5yT\nxNwTYyVdftfwF6pW6tk6WtGRGa4YH1qGVnaJoRdZXAAiEcV908V3Hw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age189u2nwxqs9emdc0jhueu0873pes2qeqfgwujy07xyue5wdmrw9nqxw8zh6
+sops_lastmodified=2026-09-02T06:45:56Z
+sops_mac=ENC[AES256_GCM,data:rHCo1Zg/f+m4ztHUKs9sDSsnbsyuL9ynU3GbIj21OKRPrNFxAyE3mFMYvoqCpFbr3lle3XR3Uh1VxcCl2I1jjPo4fPQKLNQX9CJqdTTe3AB0kvxZh9RfNgf7Bb2tNwRlDRd2lnv3xaBDYXaQQqY+JqDnqC5ta7KuOvsF7h11LGk=,iv:rgHKY640c/W/Gn4MnLhEQrxfKzEkmPyxxcw23Zh4ciw=,tag:CGWGhH+ezkTCbpXYpBQ3hw==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.12.1

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # 環境変数のサンプル。`.env.local`（gitignore）にコピーして値を設定する。
 # サーバ専用の変数はブラウザに露出しない（NEXT_PUBLIC_ を付けないこと）。
+# 例外は Sentry/PostHog の DSN/キー（下記）のみ — ブラウザ SDK に埋め込む前提の値で、
+# VIEWER_CODE 等の秘匿値とは性質が違う。それ以外に NEXT_PUBLIC_ を付けたら事故。
 # 旧 Vite 名（VITE_*）も一部後方互換で読み取るが、新規は下記のサーバ専用名を推奨。
 
 # NeonDB 接続文字列（正本データ源・サーバ専用）。
@@ -33,3 +35,22 @@ APP_ENV=development
 
 # GitHub 読み経路の on-demand revalidate (/api/revalidate) 用シークレット。
 REVALIDATE_SECRET=your_revalidate_secret_here
+
+# --- Sentry / PostHog（監視・計測。どちらも任意。未設定なら自動で no-op） ---
+# 詳細は doc/observability.md 参照。
+
+# 上の注意書き「NEXT_PUBLIC_ を付けないこと」の例外はこの2つの DSN/キーのみ。
+# Sentry/PostHog のブラウザ側 SDK はクライアントバンドルに埋め込む前提の値であり、
+# 秘匿情報ではなく「送信先」の指定でしかない（VIEWER_CODE 等の秘匿値に付けたら事故）。
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+
+# ローカル検証用の非常口。'1' 以外は無視される。
+# 付けっぱなしにすると pnpm test:e2e が本番の Sentry/PostHog プロジェクトに書く。検証後は必ず消す。
+NEXT_PUBLIC_OBSERVABILITY_FORCE=
+
+# source map アップロード用（Vercel のビルド環境にのみ設定。GitHub Actions には入れない）。
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_AUTH_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # 環境変数のサンプル。`.env.local`（gitignore）にコピーして値を設定する。
 # サーバ専用の変数はブラウザに露出しない（NEXT_PUBLIC_ を付けないこと）。
-# 例外は Sentry/PostHog の DSN/キー（下記）のみ — ブラウザ SDK に埋め込む前提の値で、
-# VIEWER_CODE 等の秘匿値とは性質が違う。それ以外に NEXT_PUBLIC_ を付けたら事故。
+# 例外は Sentry/PostHog の DSN・キー・ホストと、ローカル検証用の非常口（下記4つ）のみ —
+# ブラウザ SDK に埋め込む前提の値で、VIEWER_CODE 等の秘匿値とは性質が違う。
+# それ以外に NEXT_PUBLIC_ を付けたら事故。
 # 旧 Vite 名（VITE_*）も一部後方互換で読み取るが、新規は下記のサーバ専用名を推奨。
 
 # NeonDB 接続文字列（正本データ源・サーバ専用）。
@@ -39,9 +40,10 @@ REVALIDATE_SECRET=your_revalidate_secret_here
 # --- Sentry / PostHog（監視・計測。どちらも任意。未設定なら自動で no-op） ---
 # 詳細は doc/observability.md 参照。
 
-# 上の注意書き「NEXT_PUBLIC_ を付けないこと」の例外はこの2つの DSN/キーのみ。
-# Sentry/PostHog のブラウザ側 SDK はクライアントバンドルに埋め込む前提の値であり、
-# 秘匿情報ではなく「送信先」の指定でしかない（VIEWER_CODE 等の秘匿値に付けたら事故）。
+# 上の注意書き「NEXT_PUBLIC_ を付けないこと」の例外はこの3つ（DSN・キー・ホスト）と、
+# 下のローカル検証用スイッチのみ。Sentry/PostHog のブラウザ側 SDK はクライアントバンドルに
+# 埋め込む前提の値であり、秘匿情報ではなく「送信先」の指定でしかない
+# （VIEWER_CODE 等の秘匿値に付けたら事故）。
 NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ next-env.d.ts
 
 *.env*
 !.env.example
+!.env.enc
 secret
 *.local
 

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - path_regex: \.env\.enc$
+    age: age189u2nwxqs9emdc0jhueu0873pes2qeqfgwujy07xyue5wdmrw9nqxw8zh6

--- a/SETUP.md
+++ b/SETUP.md
@@ -67,9 +67,15 @@ cp .env.example .env
 umask 077
 mkdir -p ~/.config/sops/age
 key_tmp="$(mktemp ~/.config/sops/age/skillsheet-viewer.XXXXXX)"
-op item get "skillsheet-viewer SOPS age key" --vault RITMO --fields notesPlain --format json \
-  | jq -r '.value' | grep -v '^#' > "$key_tmp"
-mv "$key_tmp" ~/.config/sops/age/skillsheet-viewer.txt
+# op / jq のどちらかが失敗しても mv しない（既存の鍵ファイルを空ファイルで潰さない）。
+# 対話シェルに貼る前提なので `set -e` は使わず、中身が age 秘密鍵であることを確認してから置き換える。
+if op item get "skillsheet-viewer SOPS age key" --vault RITMO --fields notesPlain --format json \
+  | jq -r '.value' | grep -v '^#' > "$key_tmp" \
+  && grep -q '^AGE-SECRET-KEY-' "$key_tmp"; then
+  mv "$key_tmp" ~/.config/sops/age/skillsheet-viewer.txt
+else
+  rm -f "$key_tmp"; echo "鍵の取得に失敗。既存ファイルは変更していない" >&2
+fi
 
 export SOPS_AGE_KEY_FILE=~/.config/sops/age/skillsheet-viewer.txt
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -47,6 +47,7 @@ pnpm install
 ### 2. 環境変数の設定
 
 `.env.example` をコピーして `.env`（コミット禁止）に値を設定します。**すべてサーバー専用**で、ブラウザには公開しません（`NEXT_PUBLIC_` を付けないこと）。
+例外は Sentry/PostHog の DSN/キー（後述）のみ — ブラウザ SDK に埋め込む前提の値で秘匿情報ではない。
 
 ```bash
 cp .env.example .env
@@ -73,6 +74,16 @@ cp .env.example .env
 | `REVALIDATE_SECRET` | tRPC の `maintenance.revalidate` でキャッシュを手動失効させるためのシークレット |
 
 > DB 接続文字列は、実行時はプール用（`-pooler` ホスト）、マイグレーションは非プール文字列を使うと安定します。
+
+#### 監視・計測（Sentry / PostHog。すべて任意。未設定なら自動で no-op。詳細は [doc/observability.md](doc/observability.md)）
+
+| 変数 | 用途 |
+|------|------|
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry の送信先。未設定なら `Sentry.init` を呼ばない |
+| `NEXT_PUBLIC_POSTHOG_KEY` | PostHog のプロジェクトキー。未設定なら `posthog.init` を呼ばない |
+| `NEXT_PUBLIC_POSTHOG_HOST` | PostHog のホスト（既定 `https://us.i.posthog.com`） |
+| `NEXT_PUBLIC_OBSERVABILITY_FORCE` | ローカル検証用の非常口（`'1'` のみ有効）。**検証後は必ず消す** — 付けっぱなしだと e2e が本番プロジェクトに書く |
+| `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` | source map アップロード用。**Vercel のビルド環境にのみ**設定し、GitHub Actions には入れない |
 
 ### 3. DB マイグレーションの適用
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -53,6 +53,25 @@ pnpm install
 cp .env.example .env
 ```
 
+#### 実際の値の共有（SOPS + age）
+
+このリポジトリでは、開発用の実値を入れた `.env` を [SOPS](https://github.com/getsops/sops) で暗号化した `.env.enc` としてリポジトリにコミットしています（平文の `.env` 自体はコミットしません）。復号鍵（age 秘密鍵）は 1Password の `RITMO` vault に `skillsheet-viewer SOPS age key` として保存済みです。
+
+```bash
+# 初回のみ：1Password から秘密鍵を取り出してローカルに保存
+mkdir -p ~/.config/sops/age
+op item get "skillsheet-viewer SOPS age key" --vault RITMO --fields notesPlain --format json \
+  | jq -r '.value' | grep -v '^#' > ~/.config/sops/age/skillsheet-viewer.txt
+
+export SOPS_AGE_KEY_FILE=~/.config/sops/age/skillsheet-viewer.txt
+
+# 復号して .env を作る
+pnpm env:decrypt
+
+# .env を編集したら、暗号化し直してコミットする
+pnpm env:encrypt
+```
+
 #### 必須（欠けると起動時に fail-fast で throw / `src/lib/env.ts`）
 
 | 変数 | 用途 |

--- a/SETUP.md
+++ b/SETUP.md
@@ -59,9 +59,12 @@ cp .env.example .env
 
 ```bash
 # 初回のみ：1Password から秘密鍵を取り出してローカルに保存
+umask 077
 mkdir -p ~/.config/sops/age
+key_tmp="$(mktemp ~/.config/sops/age/skillsheet-viewer.XXXXXX)"
 op item get "skillsheet-viewer SOPS age key" --vault RITMO --fields notesPlain --format json \
-  | jq -r '.value' | grep -v '^#' > ~/.config/sops/age/skillsheet-viewer.txt
+  | jq -r '.value' | grep -v '^#' > "$key_tmp"
+mv "$key_tmp" ~/.config/sops/age/skillsheet-viewer.txt
 
 export SOPS_AGE_KEY_FILE=~/.config/sops/age/skillsheet-viewer.txt
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -47,7 +47,7 @@ pnpm install
 ### 2. 環境変数の設定
 
 `.env.example` をコピーして `.env`（コミット禁止）に値を設定します。**すべてサーバー専用**で、ブラウザには公開しません（`NEXT_PUBLIC_` を付けないこと）。
-例外は Sentry/PostHog の DSN/キー（後述）のみ — ブラウザ SDK に埋め込む前提の値で秘匿情報ではない。
+例外は Sentry/PostHog の DSN・キー・ホストと、ローカル検証用の非常口（後述）のみ — ブラウザ SDK に埋め込む前提の値で秘匿情報ではない。
 
 ```bash
 cp .env.example .env

--- a/SETUP.md
+++ b/SETUP.md
@@ -65,10 +65,12 @@ cp .env.example .env
 ```bash
 # 初回のみ：1Password から秘密鍵を取り出してローカルに保存
 umask 077
+# op / jq の失敗をパイプラインの終了ステータスに反映させる（`-e` は付けない: 対話シェルが落ちる）。
+set -o pipefail
 mkdir -p ~/.config/sops/age
 key_tmp="$(mktemp ~/.config/sops/age/skillsheet-viewer.XXXXXX)"
 # op / jq のどちらかが失敗しても mv しない（既存の鍵ファイルを空ファイルで潰さない）。
-# 対話シェルに貼る前提なので `set -e` は使わず、中身が age 秘密鍵であることを確認してから置き換える。
+# 念のため中身が age 秘密鍵であることも確認してから置き換える。
 if op item get "skillsheet-viewer SOPS age key" --vault RITMO --fields notesPlain --format json \
   | jq -r '.value' | grep -v '^#' > "$key_tmp" \
   && grep -q '^AGE-SECRET-KEY-' "$key_tmp"; then

--- a/SETUP.md
+++ b/SETUP.md
@@ -57,6 +57,11 @@ cp .env.example .env
 
 このリポジトリでは、開発用の実値を入れた `.env` を [SOPS](https://github.com/getsops/sops) で暗号化した `.env.enc` としてリポジトリにコミットしています（平文の `.env` 自体はコミットしません）。復号鍵（age 秘密鍵）は 1Password の `RITMO` vault に `skillsheet-viewer SOPS age key` として保存済みです。
 
+**入れてよい値・漏れたときの手順**（このリポジトリは公開で、`.env.enc` は git 履歴に恒久的に残る）:
+
+- `.env.enc` に入れるのは**ローカル開発用の値だけ**。本番（Vercel）の `DATABASE_URL` / `SESSION_SECRET` / `VIEWER_CODE` / `BETTER_AUTH_SECRET` は入れない（本番値は Vercel の環境変数だけに置く）。
+- age 秘密鍵が漏れた（漏れたかもしれない）ときは、`.env.enc` を消しても履歴から復号できるので、**中の全値をローテーションする**のが唯一の対処。鍵の再生成と `.sops.yaml` の recipient 更新はその後。
+
 ```bash
 # 初回のみ：1Password から秘密鍵を取り出してローカルに保存
 umask 077

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -1,11 +1,11 @@
 import { TRPCError } from '@trpc/server';
 import { type NextRequest, NextResponse } from 'next/server';
-
+import { VIEWER_AUTH_NOT_CONFIGURED_MESSAGE } from '@/server/known-config-error';
 import { createTRPCContext } from '@/server/trpc/context';
 import { createCallerFactory } from '@/server/trpc/init';
 import { trpcErrorToResponse } from '@/server/trpc/route-error';
 import { appRouter } from '@/server/trpc/router';
-import { isSameOriginRequest, VIEWER_AUTH_NOT_CONFIGURED_MESSAGE } from '@/server/trpc/router/auth';
+import { isSameOriginRequest } from '@/server/trpc/router/auth';
 
 const createCaller = createCallerFactory(appRouter);
 

--- a/app/api/trpc/[trpc]/route.ts
+++ b/app/api/trpc/[trpc]/route.ts
@@ -1,5 +1,6 @@
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 
+import { reportTRPCError } from '@/server/report-error';
 import { createTRPCContext } from '@/server/trpc/context';
 import { shouldLogTRPCError } from '@/server/trpc/log-error';
 import { appRouter } from '@/server/trpc/router';
@@ -18,8 +19,8 @@ function handler(req: Request) {
     // onError 未設定だとエラーが HTTP レスポンス（TRPCError の code/message）にしか残らず、
     // サーバー側ログには一切出ない。
     onError({ error, path }) {
-      if (!shouldLogTRPCError(error.code)) return;
-      console.error(`tRPC error on ${path ?? '<unknown>'}:`, error);
+      const label = `trpc:${path ?? '<unknown>'}`;
+      reportTRPCError({ error, scope: label, logArgs: [`tRPC error on ${path ?? '<unknown>'}:`, error] });
     },
   });
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { captureError } from '@/lib/observability/capture';
 
 // 動的ルート（/view/[path] 等）のサーバー側システムエラーを受け取るセグメント境界。
 // ファイル不在は notFound() で、設定不備（GitHub/DB未設定等）は isConfigError() で別扱い、
@@ -11,6 +12,11 @@ import { Button } from '@/components/ui/button';
 export default function Error({ error: err, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     console.error('Route error boundary:', err);
+    // digest がある＝サーバーが投げたエラーで、onRequestError（instrumentation.ts）が
+    // 既にスタック付きで報告済み。ここで重ねて送ると同じ障害が2件の Issue に分かれる。
+    if (!err.digest) {
+      captureError(err, { scope: 'route-error-boundary' });
+    }
   }, [err]);
 
   return (

--- a/app/global-error.test.tsx
+++ b/app/global-error.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import GlobalError from './global-error';
+
+const { captureWarningMock, captureErrorMock } = vi.hoisted(() => ({
+  captureWarningMock: vi.fn(),
+  captureErrorMock: vi.fn(),
+}));
+vi.mock('@/lib/observability/capture', () => ({
+  captureWarning: captureWarningMock,
+  captureError: captureErrorMock,
+}));
+
+describe('GlobalError', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    captureWarningMock.mockClear();
+    captureErrorMock.mockClear();
+    window.localStorage.clear();
+  });
+
+  it('digest 付き（Server Component 起源 = 設定不備）は captureWarning を固定 fingerprint で呼ぶ', () => {
+    const error = Object.assign(new Error('opaque server error'), { digest: 'abc123' });
+    render(<GlobalError error={error} />);
+    expect(captureWarningMock).toHaveBeenCalledWith(error, {
+      scope: 'config-error-boundary',
+      fingerprint: ['config-error-boundary'],
+    });
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('digest 無し（Providers 等 Client Component 起源の本物のバグ）は captureError を呼ぶ', () => {
+    const error = new Error('real bug in Providers') as Error & { digest?: string };
+    render(<GlobalError error={error} />);
+    expect(captureErrorMock).toHaveBeenCalledWith(error, { scope: 'config-error-boundary-client' });
+    expect(captureWarningMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -8,6 +8,25 @@ import { THEME_INIT_SCRIPT } from '@/lib/theme-init-script';
 
 import './globals.css';
 
+// 固定 fingerprint は Sentry 上で1つの Issue にまとめるだけで、送信自体（無料枠の消費）は
+// 都度発生する。同じ設定不備は直るまで直らないので、同一ブラウザからは一定時間に1回だけ送る
+// （レビュー指摘: 「1回だけ知らせる」は実態と違い、毎ページロードで送信され続けていた）。
+const CONFIG_ERROR_REPORT_COOLDOWN_MS = 60 * 60 * 1000;
+const CONFIG_ERROR_REPORT_STORAGE_KEY = 'skillsheet:config-error-last-reported-at';
+
+function shouldReportConfigError(): boolean {
+  try {
+    const last = window.localStorage.getItem(CONFIG_ERROR_REPORT_STORAGE_KEY);
+    if (last && Date.now() - Number(last) < CONFIG_ERROR_REPORT_COOLDOWN_MS) return false;
+    window.localStorage.setItem(CONFIG_ERROR_REPORT_STORAGE_KEY, String(Date.now()));
+    return true;
+  } catch {
+    // プライベートモード等で localStorage が使えない環境では制御を諦めて送る
+    // （抑制を優先すると、その環境では設定不備に永久に気づけなくなる）。
+    return true;
+  }
+}
+
 /**
  * ルートレイアウト（layout.tsx）自体が投げるエラーを受け取る最後の境界。
  *
@@ -30,7 +49,9 @@ export default function GlobalError({ error: err }: { error: Error & { digest?: 
     // ここに来る時点で常に設定不備（このファイル冒頭のコメント参照）。バグ報告ではなく
     // 「デプロイが壊れとる」信号として warning レベルで送る。固定 fingerprint で
     // 同じ Issue に集約する（欠落変数が違っても、案内すべき対処は同じ）。
-    captureWarning(err, { scope: 'config-error-boundary', fingerprint: ['config-error-boundary'] });
+    if (shouldReportConfigError()) {
+      captureWarning(err, { scope: 'config-error-boundary', fingerprint: ['config-error-boundary'] });
+    }
   }, [err]);
 
   return (

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 
 import { ConfigErrorNotice } from '@/components/config-error-notice';
+import { captureWarning } from '@/lib/observability/capture';
 import { THEME_INIT_SCRIPT } from '@/lib/theme-init-script';
 
 import './globals.css';
@@ -26,6 +27,10 @@ import './globals.css';
 export default function GlobalError({ error: err }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     console.error('Root layout error boundary:', err);
+    // ここに来る時点で常に設定不備（このファイル冒頭のコメント参照）。バグ報告ではなく
+    // 「デプロイが壊れとる」信号として warning レベルで送る。固定 fingerprint で
+    // 同じ Issue に集約する（欠落変数が違っても、案内すべき対処は同じ）。
+    captureWarning(err, { scope: 'config-error-boundary', fingerprint: ['config-error-boundary'] });
   }, [err]);
 
   return (

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from 'react';
 
 import { ConfigErrorNotice } from '@/components/config-error-notice';
-import { captureWarning } from '@/lib/observability/capture';
+import { captureError, captureWarning } from '@/lib/observability/capture';
 import { THEME_INIT_SCRIPT } from '@/lib/theme-init-script';
 
 import './globals.css';
@@ -33,10 +33,16 @@ function shouldReportConfigError(): boolean {
  * `error.tsx` はレイアウトの子（page.tsx 等）が投げたエラーしか捕まえず、
  * レイアウト自身が投げるエラーは対象外（Next.js の仕様。ルートレイアウトを
  * 上書きできる境界は global-error.tsx のみ）。このアプリで layout.tsx が
- * 同期的に throw しうるのは `assertServerEnv()`（必須環境変数の欠落）だけなので
+ * 同期的に throw しうるのは `assertServerEnv()`（必須環境変数の欠落）だけだが
  * （レビュー指摘: このファイルが無いと、DATABASE_URL 等の未設定時に
  * `/view` 系の isConfigError() 分岐にすら到達せず、素の Next.js デフォルト
- * エラー画面になっていた）、ここに来た場合は常に設定不備として案内する。
+ * エラー画面になっていた）、`<Providers>`（app/providers.tsx、Client Component）が
+ * ハイドレーション中に本物のバグで throw した場合もこの境界が拾う。両者の区別は
+ * `err.digest` の有無で行う: Server Component 側の throw は Next.js が本番ビルドで
+ * message を伏せて digest だけを付与するため（メッセージ文字列比較はここでは使えない
+ * — is-config-error.ts のコメント参照）、digest の有無がサーバー起源かどうかの
+ * 唯一の信頼できるシグナルになる（レビュー指摘: 全件を無条件で設定不備の warning
+ * 固定 fingerprint 扱いにすると、Providers 側の本物のバグが埋もれる）。
  *
  * global-error.tsx はルートレイアウト全体を置き換えるため、html/body タグを
  * 自前で持つ必要がある（Providers は意図的に省略: ここに来る時点で layout.tsx 自体が動いていない）。
@@ -46,11 +52,17 @@ function shouldReportConfigError(): boolean {
 export default function GlobalError({ error: err }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     console.error('Root layout error boundary:', err);
-    // ここに来る時点で常に設定不備（このファイル冒頭のコメント参照）。バグ報告ではなく
-    // 「デプロイが壊れとる」信号として warning レベルで送る。固定 fingerprint で
-    // 同じ Issue に集約する（欠落変数が違っても、案内すべき対処は同じ）。
-    if (shouldReportConfigError()) {
-      captureWarning(err, { scope: 'config-error-boundary', fingerprint: ['config-error-boundary'] });
+    // digest 付き = Server Component（layout.tsx の assertServerEnv()）起源 → 設定不備。
+    // 「デプロイが壊れとる」信号として warning レベル・固定 fingerprint で1つの Issue に
+    // 集約する（欠落変数が違っても、案内すべき対処は同じ）。
+    // digest 無し = Providers（Client Component）が本物のバグで throw → 通常の error として送る
+    // （固定 fingerprint を使うと個々のバグが1つの Issue に埋もれてしまう）。
+    if (typeof err.digest === 'string') {
+      if (shouldReportConfigError()) {
+        captureWarning(err, { scope: 'config-error-boundary', fingerprint: ['config-error-boundary'] });
+      }
+    } else {
+      captureError(err, { scope: 'config-error-boundary-client' });
     }
   }, [err]);
 

--- a/app/view/[path]/deferred-edit-sheet-view.test.tsx
+++ b/app/view/[path]/deferred-edit-sheet-view.test.tsx
@@ -35,7 +35,7 @@ describe('DeferredEditSheetView', () => {
 
   it('編集者判定の待機中でも本文を表示し、編集導線は出さない', () => {
     useAuthStatusQuery.mockReturnValue({ data: undefined });
-    render(<DeferredEditSheetView title="T" content="本文" />);
+    render(<DeferredEditSheetView title="T" content="本文" source="db" />);
     expect(screen.getByRole('heading', { name: 'T' })).toBeInTheDocument();
     expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-can-edit', 'false');
     expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-reserve-edit-slot', 'true');
@@ -43,13 +43,13 @@ describe('DeferredEditSheetView', () => {
 
   it('編集者判定の失敗時も本文を表示し、編集導線は出さない', () => {
     useAuthStatusQuery.mockReturnValue({ data: undefined, error: new Error('db down') });
-    render(<DeferredEditSheetView title="T" content="本文" />);
+    render(<DeferredEditSheetView title="T" content="本文" source="db" />);
     expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-can-edit', 'false');
   });
 
   it('編集者判定の成功後は編集導線を有効にする', () => {
     useAuthStatusQuery.mockReturnValue({ data: { canEdit: true, canView: true } });
-    render(<DeferredEditSheetView title="T" content="本文" />);
+    render(<DeferredEditSheetView title="T" content="本文" source="db" />);
     expect(screen.getByText('本文').closest('article')).toHaveAttribute('data-can-edit', 'true');
   });
 });

--- a/app/view/[path]/page.tsx
+++ b/app/view/[path]/page.tsx
@@ -59,10 +59,12 @@ export default async function SheetViewPage({ params }: PageProps) {
     // 「未設定」の文面で案内しており、トークン拒否のときに調査を誤誘導していた）。
     // console.error は出さない（一時的な障害ではないため）（#157）。
     // 設定不備は 200 ＋ 原因と対処、一時的なシステムエラーは error.tsx / 監視へ委ねる。
-    return configErrorNoticeOrRethrow(err, `Failed to load sheet: ${path}`);
+    // ログ文字列にシート識別子（path）を埋め込まない — 監視基盤の
+    // 送信側 breadcrumb・console キャプチャに乗る余地を発生源で断つ。
+    return configErrorNoticeOrRethrow(err, 'Failed to load sheet');
   }
 
   // key={path}: 別シートへ遷移してもコンポーネントを再マウントし、ビュー
   // ON/OFF トグルの state（初回マウント時に決まる）を新しいシートへ持ち越さない。
-  return <DeferredEditSheetView key={path} title={sheet.title} content={sheet.content} />;
+  return <DeferredEditSheetView key={path} title={sheet.title} content={sheet.content} source="github" />;
 }

--- a/app/view/[path]/sheet-view-client.test.tsx
+++ b/app/view/[path]/sheet-view-client.test.tsx
@@ -63,7 +63,7 @@ const projectBlock: Block = { id: 'p1', type: 'project', order: 0, data: { compa
 const markdownBlock: Block = { id: 'm1', type: 'markdown', order: 0, data: { markdown: '# 目印' } };
 
 const renderClient = (props: Partial<React.ComponentProps<typeof SheetViewClient>> = {}) =>
-  render(<SheetViewClient title="テストシート" content="# 見出し" {...props} />);
+  render(<SheetViewClient title="テストシート" content="# 見出し" source="db" {...props} />);
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/app/view/[path]/sheet-view-client.tsx
+++ b/app/view/[path]/sheet-view-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import Header from '@/components/header';
 import SkillSheetViewer from '@/components/skill-sheet-viewer';
@@ -8,7 +8,7 @@ import { ALL_VIEW_KEYS, ViewerTopbar, type ViewKey } from '@/components/viewer-t
 import type { Block } from '@/db/blocks';
 import { useReadDepth } from '@/hooks/use-read-depth';
 import { captureError, track } from '@/lib/observability/capture';
-import type { SheetSource } from '@/lib/observability/event';
+import { type PdfFailureReason, type SheetSource, toSecondsBucket } from '@/lib/observability/event';
 
 interface SheetViewClientProps {
   title: string;
@@ -29,23 +29,15 @@ interface SheetViewClientProps {
   referenceMonth?: number;
 }
 
-const PDF_DURATION_BUCKETS = [
-  { max: 5_000, label: '0-5' },
-  { max: 15_000, label: '5-15' },
-  { max: 30_000, label: '15-30' },
-  { max: 60_000, label: '30-60' },
-] as const;
+// ブラウザの fetch はネットワーク失敗を `TypeError` で投げ、message はブラウザごとに違う
+// （Chrome "Failed to fetch" / Firefox "NetworkError when attempting to fetch resource." /
+// Safari "Load failed"）。`FetchError` という name は node-fetch 系のもので、ブラウザでは出ない。
+// message はここで分類にだけ使い、イベントには enum しか乗せない（URL 等が混ざっても送らない）。
+const BROWSER_FETCH_FAILURE_MESSAGE = /fetch|network|load failed/iu;
 
-function durationBucket(ms: number): (typeof PDF_DURATION_BUCKETS)[number]['label'] | '60+' {
-  const found = PDF_DURATION_BUCKETS.find((b) => ms < b.max);
-  return found?.label ?? '60+';
-}
-
-function pdfFailureReason(err: unknown): 'TypeError' | 'RangeError' | 'FetchError' | 'Error' | 'unknown' {
-  if (err instanceof TypeError) return 'TypeError';
+function pdfFailureReason(err: unknown): PdfFailureReason {
+  if (err instanceof TypeError) return BROWSER_FETCH_FAILURE_MESSAGE.test(err.message) ? 'FetchError' : 'TypeError';
   if (err instanceof RangeError) return 'RangeError';
-  // ブラウザの fetch 失敗（オフライン等）は環境依存の名前になりがちなので name で判定する
-  // （err.message はフォント URL 等を含みうるので使わない）。
   if (err instanceof Error && err.name === 'FetchError') return 'FetchError';
   if (err instanceof Error) return 'Error';
   return 'unknown';
@@ -79,17 +71,19 @@ const SheetViewClient = ({
 
   // 親が key={path}/key={id} でシートごとに再マウントする設計（トグル state を
   // 次のシートへ持ち越さないため）なので、このコンポーネントの mount は
-  // 「1シートを開いた」に一致する。ここが初の useEffect になるので依存配列を
-  // 貼り付けず個別に検討した — isDashboard/source/blockCount は再マウントでしか変わらない。
-  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント1回だけで送る（下のコメント参照）。
+  // 「1シートを開いた」に一致する。依存配列は正直に書き、「1マウント1回」は ref で保証する
+  // （編集後の router.refresh() で blocks が差し替わっても sheet_viewed を二重送信しない）。
+  const sheetViewedSentRef = useRef(false);
   useEffect(() => {
+    if (sheetViewedSentRef.current) return;
+    sheetViewedSentRef.current = true;
     track({
       name: 'sheet_viewed',
       layout: isDashboard ? 'dashboard' : 'markdown',
       source,
       blockCount,
     });
-  }, []);
+  }, [isDashboard, source, blockCount]);
 
   useReadDepth();
 
@@ -134,14 +128,18 @@ const SheetViewClient = ({
       }, REVOKE_OBJECT_URL_DELAY_MS);
 
       toast.success('PDFをダウンロードしました', { id: toastId });
-      track({ name: 'pdf_exported', result: 'success', durationBucket: durationBucket(performance.now() - startedAt) });
+      track({
+        name: 'pdf_exported',
+        result: 'success',
+        durationBucket: toSecondsBucket(performance.now() - startedAt),
+      });
     } catch (err) {
       console.error('Error generating PDF:', err);
       toast.error('PDFの生成に失敗しました', { id: toastId });
       track({
         name: 'pdf_exported',
         result: 'failure',
-        durationBucket: durationBucket(performance.now() - startedAt),
+        durationBucket: toSecondsBucket(performance.now() - startedAt),
         reason: pdfFailureReason(err),
       });
       captureError(err, { feature: 'pdf-export' });

--- a/app/view/[path]/sheet-view-client.tsx
+++ b/app/view/[path]/sheet-view-client.tsx
@@ -1,16 +1,20 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import Header from '@/components/header';
 import SkillSheetViewer from '@/components/skill-sheet-viewer';
 import { ALL_VIEW_KEYS, ViewerTopbar, type ViewKey } from '@/components/viewer-topbar';
 import type { Block } from '@/db/blocks';
+import { captureError, track } from '@/lib/observability/capture';
+import type { SheetSource } from '@/lib/observability/event';
 
 interface SheetViewClientProps {
   title: string;
   content: string;
   blocks?: Block[];
+  /** シートの取得元。計測イベントの source プロパティにそのまま乗る。 */
+  source: SheetSource;
   /** 編集者ログイン済みか。false（閲覧コードのみ等）のときは編集導線を出さない。 */
   canEdit?: boolean;
   /** 編集者判定の前後で編集ボタン分の幅を固定し、レイアウトずれを防ぐ。 */
@@ -24,12 +28,35 @@ interface SheetViewClientProps {
   referenceMonth?: number;
 }
 
+const PDF_DURATION_BUCKETS = [
+  { max: 5_000, label: '0-5' },
+  { max: 15_000, label: '5-15' },
+  { max: 30_000, label: '15-30' },
+  { max: 60_000, label: '30-60' },
+] as const;
+
+function durationBucket(ms: number): (typeof PDF_DURATION_BUCKETS)[number]['label'] | '60+' {
+  const found = PDF_DURATION_BUCKETS.find((b) => ms < b.max);
+  return found?.label ?? '60+';
+}
+
+function pdfFailureReason(err: unknown): 'TypeError' | 'RangeError' | 'FetchError' | 'Error' | 'unknown' {
+  if (err instanceof TypeError) return 'TypeError';
+  if (err instanceof RangeError) return 'RangeError';
+  // ブラウザの fetch 失敗（オフライン等）は環境依存の名前になりがちなので name で判定する
+  // （err.message はフォント URL 等を含みうるので使わない）。
+  if (err instanceof Error && err.name === 'FetchError') return 'FetchError';
+  if (err instanceof Error) return 'Error';
+  return 'unknown';
+}
+
 const REVOKE_OBJECT_URL_DELAY_MS = 100;
 
 const SheetViewClient = ({
   title,
   content,
   blocks,
+  source,
   canEdit = false,
   reserveEditSlot = false,
   stale = false,
@@ -47,13 +74,33 @@ const SheetViewClient = ({
     () => (blocks ?? []).find((b): b is Extract<Block, { type: 'profile' }> => b.type === 'profile'),
     [blocks],
   );
+  const blockCount = blocks?.length ?? 0;
+
+  // 親が key={path}/key={id} でシートごとに再マウントする設計（トグル state を
+  // 次のシートへ持ち越さないため）なので、このコンポーネントの mount は
+  // 「1シートを開いた」に一致する。ここが初の useEffect になるので依存配列を
+  // 貼り付けず個別に検討した — isDashboard/source/blockCount は再マウントでしか変わらない。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント1回だけで送る（下のコメント参照）。
+  useEffect(() => {
+    track({
+      name: 'sheet_viewed',
+      layout: isDashboard ? 'dashboard' : 'markdown',
+      source,
+      blockCount,
+    });
+  }, []);
 
   const toggleView = (view: ViewKey) => {
-    setViews((prev) => (prev.includes(view) ? prev.filter((v) => v !== view) : [...prev, view]));
+    // setState の updater 内で副作用（track）を呼ばない — StrictMode 下では updater が
+    // 2回呼ばれうるため、外側で現在値から次の状態を決めてから1回だけ送る。
+    const enabled = !views.includes(view);
+    track({ name: 'sheet_view_toggled', view, enabled });
+    setViews((prev) => (enabled ? [...prev, view] : prev.filter((v) => v !== view)));
   };
 
   const handleDownloadPdf = async () => {
     const toastId = toast.loading('PDFを生成中…');
+    const startedAt = performance.now();
     // 生成に失敗したときの後始末。import が済んだ時点で掴んでおく — catch の中で
     // 改めて動的 import すると、その await の分だけ finally が遅れてボタンが busy のまま残る。
     let resetFontsOnFailure: (() => void) | undefined;
@@ -84,9 +131,17 @@ const SheetViewClient = ({
       }, REVOKE_OBJECT_URL_DELAY_MS);
 
       toast.success('PDFをダウンロードしました', { id: toastId });
+      track({ name: 'pdf_exported', result: 'success', durationBucket: durationBucket(performance.now() - startedAt) });
     } catch (err) {
       console.error('Error generating PDF:', err);
       toast.error('PDFの生成に失敗しました', { id: toastId });
+      track({
+        name: 'pdf_exported',
+        result: 'failure',
+        durationBucket: durationBucket(performance.now() - startedAt),
+        reason: pdfFailureReason(err),
+      });
+      captureError(err, { feature: 'pdf-export' });
       // フォント取得の失敗（オフライン・5xx 等）は @react-pdf/font 内で reject 済みの
       // Promise として永久にキャッシュされ、次のクリックも即座に同じ失敗を再現する
       // （リロードしないと直らない「詰み」状態になる）。失敗のたびに登録をリセットし、

--- a/app/view/[path]/sheet-view-client.tsx
+++ b/app/view/[path]/sheet-view-client.tsx
@@ -6,6 +6,7 @@ import Header from '@/components/header';
 import SkillSheetViewer from '@/components/skill-sheet-viewer';
 import { ALL_VIEW_KEYS, ViewerTopbar, type ViewKey } from '@/components/viewer-topbar';
 import type { Block } from '@/db/blocks';
+import { useReadDepth } from '@/hooks/use-read-depth';
 import { captureError, track } from '@/lib/observability/capture';
 import type { SheetSource } from '@/lib/observability/event';
 
@@ -89,6 +90,8 @@ const SheetViewClient = ({
       blockCount,
     });
   }, []);
+
+  useReadDepth();
 
   const toggleView = (view: ViewKey) => {
     // setState の updater 内で副作用（track）を呼ばない — StrictMode 下では updater が

--- a/app/view/db/[id]/page.tsx
+++ b/app/view/db/[id]/page.tsx
@@ -49,6 +49,7 @@ export default async function DbSheetByIdPage({ params }: Props) {
         title={sheet.title}
         content={sheet.content}
         blocks={sheet.blocks}
+        source="db"
         canEdit={canEdit}
         stale={sheet.stale}
         referenceMonth={currentMonthKey()}
@@ -64,6 +65,8 @@ export default async function DbSheetByIdPage({ params }: Props) {
     // 直前まで形式検証が無く、DB 側の型エラーがそのまま 500 として抜けていた）。
     notFoundOnTrpcCodes(err, ['NOT_FOUND', 'BAD_REQUEST']);
     // #157: 待っても直らない設定不備は 200 ＋ 原因と対処を返し、一時的な障害は再スローする。
-    return configErrorNoticeOrRethrow(err, `Failed to load sheet: ${id}`);
+    // ログ文字列にシート識別子（id）を埋め込まない — 監視基盤の
+    // 送信側 breadcrumb・console キャプチャに乗る余地を発生源で断つ。
+    return configErrorNoticeOrRethrow(err, 'Failed to load sheet');
   }
 }

--- a/app/view/db/page.tsx
+++ b/app/view/db/page.tsx
@@ -37,6 +37,7 @@ export default async function DbSheetPage() {
         title={sheet.title}
         content={sheet.content}
         blocks={sheet.blocks}
+        source="db"
         canEdit={canEdit}
         stale={sheet.stale}
         referenceMonth={currentMonthKey()}

--- a/app/viewer-auth/page.tsx
+++ b/app/viewer-auth/page.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { track } from '@/lib/observability/capture';
 import { trpc } from '@/lib/trpc-client';
 import { resolveNextPath } from '@/util/resolve-next-path';
 
@@ -24,6 +25,7 @@ const ViewerAuthPage = () => {
 
     try {
       await loginMutation.mutateAsync({ code });
+      track({ name: 'viewer_auth_submitted', outcome: 'success' });
       // 認証後の遷移先。?next= が内部パスのときのみ許可（オープンリダイレクト防止）。
       const next = new URLSearchParams(window.location.search).get('next');
       const dest = resolveNextPath(next, '/view', window.location.origin);
@@ -31,8 +33,13 @@ const ViewerAuthPage = () => {
     } catch (err) {
       if (err instanceof TRPCClientError && err.data?.code === 'UNAUTHORIZED') {
         setError('認証コードが正しくありません');
+        track({ name: 'viewer_auth_submitted', outcome: 'invalid_code' });
+      } else if (err instanceof TRPCClientError && err.data?.code === 'TOO_MANY_REQUESTS') {
+        setError('認証に失敗しました。もう一度お試しください。');
+        track({ name: 'viewer_auth_submitted', outcome: 'rate_limited' });
       } else {
         setError('認証に失敗しました。もう一度お試しください。');
+        track({ name: 'viewer_auth_submitted', outcome: 'error' });
       }
     }
   };

--- a/doc/05-toc-and-deploy.md
+++ b/doc/05-toc-and-deploy.md
@@ -74,6 +74,8 @@ const observer = new IntersectionObserver(
 
 Vercel のプロジェクト設定に、`SETUP.md` に列挙した変数を登録する。必須は `DATABASE_URL` / `SESSION_SECRET` / `VIEWER_CODE` / `BETTER_AUTH_SECRET` / `SKILLSHEET_OWNER_ID`（`assertServerEnv()` が起動時に検証）。GitHub シード副系統を使う場合のみ `GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` などを追加する。
 
+Sentry/PostHog（監視・計測。任意）は `NEXT_PUBLIC_SENTRY_DSN` / `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` を Production・Preview に、`SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN`（source map アップロード用）は **ビルド環境にのみ**登録する。「Enable access to System Environment Variables」を ON にしないと、キルスイッチが読む `NEXT_PUBLIC_VERCEL_ENV` が空になり無効化されたままになる。詳細は [doc/observability.md](observability.md)。
+
 ### ランタイム DB 依存の動的化
 
 `DATABASE_URL` はランタイム専用で、ビルド時には注入されない。DB を読むページは先頭で `connection()`（`next/server`）を呼び、`next build` の静的評価を避けてそのコンポーネント単位で動的レンダリングする（[01](01-setup-and-routing.md) 参照）。`env.ts` の `assertServerEnv()` もビルドフェーズ（`NEXT_PHASE === 'phase-production-build'`）では検証を no-op にして、secrets 未注入のビルドを壊さない。

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -97,6 +97,17 @@
 - Tailwind CSS v4 + shadcn/ui（Radix UI）を使用
 - 共通 UI 部品は `src/components/ui` に集約
 
+## 監視・計測（Sentry / PostHog）
+
+詳細は [doc/observability.md](observability.md)。規約だけここに書く。
+
+- `@sentry/*` / `posthog-js` をアプリコードから直接 import しない。必ず
+  `src/lib/observability/capture.ts`（`captureError` / `captureWarning` / `track`）を経由する
+  （`pnpm lint` が `scripts/check-telemetry-imports.mjs` で機械的に強制する）。
+- 送信するイベントのプロパティに自由記述の `string` を書かない。enum・数値・真偽値のみ
+  （`src/lib/observability/event.ts` の閉じた判別共用体を参照。シート名・ファイル名が
+  「書けてしまう」余地を型から消すための制約）。
+
 ## Markdown レンダリング
 
 ### react-markdown

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -84,7 +84,7 @@ enum 以外の `string` プロパティを置かない（シート名等が書�
 
 | イベント | いつ | 主なプロパティ |
 |---|---|---|
-| `$pageview` | 自動（`capture_pageview: 'history_change'`） | ルート enum |
+| `$pageview` | 自動（`capture_pageview: 'history_change'`） | なし（`$current_url`/`$pathname` は denylist で落としており、ルート enum への置き換えもしていない。ページ単位でルートを見たい場合は `sheet_viewed` 等の手動イベントの enum プロパティを使う） |
 | `sheet_viewed` | シート表示コンポーネントの mount | `layout`, `source`, `blockCount` |
 | `sheet_read_depth` | スクロールで 25/50/75/100% 到達 | `depthPercent`, `secondsBucket` |
 | `sheet_view_toggled` | ダッシュボードのビュー切替 | `view`, `enabled` |

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -19,7 +19,7 @@
 | `app/api/auth`・`app/api/logout`・`app/api/revalidate`（`route-error.ts`） | 同上（互換 REST アダプタ側） | 同上 |
 | `instrumentation.ts` の `onRequestError` | サーバーで捕捉されなかった例外（Next.js が最後に拾う） | 届く。ただし**設定不備は届かない**（次項） |
 | `app/error.tsx` | ルートセグメントの予期せぬエラー | 届く。ただし `err.digest` があるサーバー起源のエラーは `onRequestError` が既に報告済みなので二重送信しない |
-| `app/global-error.tsx` | `layout.tsx` 自体が同期 throw（＝必須環境変数の欠落） | **warning レベルで届く**。固定 fingerprint（`config-error-boundary`）で1つの Issue に集約される |
+| `app/global-error.tsx` | `layout.tsx` 自体が同期 throw（＝必須環境変数の欠落） | **warning レベルで届く**。固定 fingerprint で1つの Issue に集約し、同一ブラウザからは1時間に1回だけ送信する（次項） |
 | `sheet-view-client.tsx` の PDF 生成失敗 | フォント取得失敗・レンダリング例外 | 届く（`feature: 'pdf-export'` タグ付き） |
 | `auth-gate.ts` / `viewer-rate-limit.ts` | Better Auth セッション確認失敗・DB 経路の総当たり防御が fail open | **warning レベルで届く**（セキュリティの劣化信号。バグ報告ではない） |
 
@@ -36,8 +36,11 @@
   （未設定・トークン拒否・テーブル未マイグレーション・接続文字列の書式エラー）
 
 これらは「待っても直らない」原因であり、対処は環境変数の設定であって障害対応ではない。
-`app/global-error.tsx` だけが例外で、**warning レベル・固定 fingerprint** で1回だけ知らせる
+`app/global-error.tsx` だけが例外で、**warning レベル・固定 fingerprint** で送る
 （「デプロイが壊れている」という信号であって、個々のリクエストのエラーではないため）。
+固定 fingerprint は Sentry 上で1つの Issue にまとめるだけで送信自体は都度発生するため、
+同一ブラウザからの再送は `localStorage` で1時間に1回へ絞っている
+（直りもしない状態で毎ページロード送ると無料枠を溶かす）。
 
 ## PII が乗らないこと
 
@@ -63,8 +66,11 @@
 
 - **IP マスキング**: Sentry 側のプロジェクト設定（Data Scrubbing）で行う。コード側は
   `dataCollection` オプションを一切書かない設計にしている（書くと逆に緩くなる罠がある）。
-- **PostHog の cookie 同意**: 匿名 id を持つ first-party cookie を1つ置く。個人情報ではないが、
-  同意なしに置く cookie ではあるため、必要なら `persistence: 'memory'` に切り替える
+- **PostHog の cookie 同意**: 匿名 id を持つ first-party cookie を1つ置く。cookie ID は
+  UK/EU GDPR 上「個人データ」になりうる識別子であり、同意なしに置いてよいと断定はしない。
+  EU/UK 圏の閲覧者にも見せる前提なら、同意取得前に `posthog.init`/`posthog.capture` が
+  走らない同意ゲートが要る（**未実装。対象地域を絞るか同意ゲートを作るかは未決定**）。
+  cookie 自体を避けたいだけなら `persistence: 'memory'` に切り替えられる
   （`instrumentation-client.ts` の `posthog.init` オプション、1行）。
 - **本番スタックトレースの関数名可読性**: Next.js 16 + Turbopack 環境で Sentry の関数名が
   難読化されたままになる既知の不具合（sentry-javascript #18248、Vercel 側の対応待ち）。

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -64,18 +64,30 @@
 
 ## コードでは保証できないもの（ベンダー側の設定）
 
-- **IP マスキング**: Sentry 側のプロジェクト設定（Data Scrubbing）で行う。コード側は
+- **IP マスキング（Sentry）**: Sentry 側のプロジェクト設定（Data Scrubbing）で行う。コード側は
   `dataCollection` オプションを一切書かない設計にしている（書くと逆に緩くなる罠がある）。
+- **IP の破棄（PostHog）**: PostHog は既定で受信時の IP を `$ip` としてサーバー側に保存する。
+  コードからは止められないので、プロジェクト設定の「Discard client IP data」を ON にする。
 - **PostHog の cookie 同意**: 匿名 id を持つ first-party cookie を1つ置く。cookie ID は
   UK/EU GDPR 上「個人データ」になりうる識別子であり、同意なしに置いてよいと断定はしない。
-  EU/UK 圏の閲覧者にも見せる前提なら、同意取得前に `posthog.init`/`posthog.capture` が
-  走らない同意ゲートが要る（**未実装。対象地域を絞るか同意ゲートを作るかは未決定**）。
+  **対象は国内（日本）の閲覧者に限る前提**で運用する — 閲覧経路は `VIEWER_CODE` で守られ、
+  コードを渡した相手だけが読める。EU/UK 圏へ共有する必要が出たら、共有する前に
+  同意取得後だけ `posthog.init`/`posthog.capture` が走る同意ゲートを入れる（未実装）。
   cookie 自体を避けたいだけなら `persistence: 'memory'` に切り替えられる
   （`instrumentation-client.ts` の `posthog.init` オプション、1行）。
 - **本番スタックトレースの関数名可読性**: Next.js 16 + Turbopack 環境で Sentry の関数名が
   難読化されたままになる既知の不具合（sentry-javascript #18248、Vercel 側の対応待ち）。
   現状はコードで閉じられない。実際に起きたエラーで確認し、読めなければ Issue の説明欄で
   「入っているが役に立たない」ことを明示する運用でしのぐ。
+
+## 欠測（広告ブロッカー）
+
+`us.i.posthog.com` と Sentry の ingest ドメインは主要なブロックリストに載っている。読者が
+エンジニア中心なら、`sheet_viewed` / `pdf_exported` は相当な割合が届かない前提で数字を読む
+（「0 件」は「誰も読んでいない」ではなく「ブロックされた」かもしれない）。
+本気で数えたくなったら、Sentry は `withSentryConfig` の `tunnelRoute`、PostHog は Next の
+`rewrites` で `/ingest/*` を逆プロキシする（どちらも自ドメイン経由にするだけで、送る内容は変わらない）。
+未実装。まず届く数を見てから決める。
 
 ## 6つのイベント（PostHog）
 

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -73,7 +73,9 @@
   **対象は国内（日本）の閲覧者に限る前提**で運用する — 閲覧経路は `VIEWER_CODE` で守られ、
   コードを渡した相手だけが読める。EU/UK 圏へ共有する必要が出たら、共有する前に
   同意取得後だけ `posthog.init`/`posthog.capture` が走る同意ゲートを入れる（未実装）。
-  cookie 自体を避けたいだけなら `persistence: 'memory'` に切り替えられる
+  共有先の法域はコードでは判定できないので、共有する前に人が確認する。
+  `persistence: 'memory'` は識別子の保存場所を cookie からメモリに変えるだけの設定で、
+  送信そのものは止まらない。同意ゲートの代替にはならない
   （`instrumentation-client.ts` の `posthog.init` オプション、1行）。
 - **本番スタックトレースの関数名可読性**: Next.js 16 + Turbopack 環境で Sentry の関数名が
   難読化されたままになる既知の不具合（sentry-javascript #18248、Vercel 側の対応待ち）。

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -1,0 +1,89 @@
+# Observability（Sentry / PostHog）
+
+午前2時に障害対応するための手順書。設計判断の背景は PR の説明を参照し、
+ここには「どこに何が出るか」「何が出ないか」「止め方」だけを書く。
+
+## 何のために入れたか
+
+- **Sentry**: 本番で起きたエラーに気づく（今までは `console.error` だけで、誰も見ていなかった）。
+- **PostHog**: 誰がシートを開いて、最後まで読んで、PDF を落としたかが分かる。
+
+両方とも **無料枠の範囲内**で運用する前提。キーが1つも設定されていなければ、
+ビルド・テスト・アプリの動作は一切変わらない（自動で no-op）。
+
+## どのエラーがどこに出るか
+
+| 場所 | 何が起きたとき | Sentry に届くか |
+|---|---|---|
+| `app/api/trpc/[trpc]/route.ts` の `onError` | tRPC procedure の想定外エラー | 届く（`shouldLogTRPCError` が true のコードのみ。UNAUTHORIZED/NOT_FOUND/CONFLICT は届かない） |
+| `app/api/auth`・`app/api/logout`・`app/api/revalidate`（`route-error.ts`） | 同上（互換 REST アダプタ側） | 同上 |
+| `instrumentation.ts` の `onRequestError` | サーバーで捕捉されなかった例外（Next.js が最後に拾う） | 届く。ただし**設定不備は届かない**（次項） |
+| `app/error.tsx` | ルートセグメントの予期せぬエラー | 届く。ただし `err.digest` があるサーバー起源のエラーは `onRequestError` が既に報告済みなので二重送信しない |
+| `app/global-error.tsx` | `layout.tsx` 自体が同期 throw（＝必須環境変数の欠落） | **warning レベルで届く**。固定 fingerprint（`config-error-boundary`）で1つの Issue に集約される |
+| `sheet-view-client.tsx` の PDF 生成失敗 | フォント取得失敗・レンダリング例外 | 届く（`feature: 'pdf-export'` タグ付き） |
+| `auth-gate.ts` / `viewer-rate-limit.ts` | Better Auth セッション確認失敗・DB 経路の総当たり防御が fail open | **warning レベルで届く**（セキュリティの劣化信号。バグ報告ではない） |
+
+## あえて報告しないもの（#157 の設定不備契約）
+
+環境変数が1つ欠けた状態で本番にクローラが来ると、`assertServerEnv()` は
+**成功するまで毎リクエスト throw し続ける**（一度成功したら以降は no-op という設計だが、
+失敗はメモ化されない）。ここを無条件で Sentry に送ると、5,000 件/月の無料枠を1日で溶かす。
+
+そのため以下は **error レベルでは送らない**:
+
+- `src/lib/env.ts` の `assertServerEnv()` が投げる「必須のサーバー環境変数が設定されていません」
+- `src/util/is-config-error.ts` の `classifyConfigError()` が判定する GitHub/DB の設定不備
+  （未設定・トークン拒否・テーブル未マイグレーション・接続文字列の書式エラー）
+
+これらは「待っても直らない」原因であり、対処は環境変数の設定であって障害対応ではない。
+`app/global-error.tsx` だけが例外で、**warning レベル・固定 fingerprint** で1回だけ知らせる
+（「デプロイが壊れている」という信号であって、個々のリクエストのエラーではないため）。
+
+## PII が乗らないこと
+
+- Cookie・HTTP header・query string は `beforeSend` で丸ごと落とす。
+- URL・パスは実際の値ではなく `route: view-sheet` のようなルート名 enum に丸める
+  （`src/lib/observability/scrub.ts` の `toRouteName`）。
+- サーバー側の `console.error` は Sentry のブレッドクラムに乗らない
+  （`consoleIntegration` を明示的に無効化している。ブラウザ専用の `breadcrumbsIntegration` とは別物）。
+- GitHub API への送信 URL（ファイル名を含む）はサーバー側 breadcrumb を無効化して防いでいる。
+- PostHog は `autocapture: false`（クリックした要素のテキスト＝経歴書の本文が送られるのを防ぐ、
+  最重要設定）、セッションリプレイ OFF、`person_profiles: 'identified_only'`。
+
+## 止め方（60秒でできること）
+
+| やりたいこと | 手順 |
+|---|---|
+| Sentry だけ止める | Vercel の `NEXT_PUBLIC_SENTRY_DSN` を空にして再デプロイ |
+| PostHog だけ止める | Vercel の `NEXT_PUBLIC_POSTHOG_KEY` を空にして再デプロイ |
+| 両方一時停止 | Sentry / PostHog 側のプロジェクト設定で ingestion を止める（コード変更不要） |
+| ローカルで確認だけしたい | `.env.local` に `NEXT_PUBLIC_OBSERVABILITY_FORCE=1` を追加。**検証後は必ず消す**（消し忘れると `pnpm test:e2e` が本番プロジェクトに書く） |
+
+## コードでは保証できないもの（ベンダー側の設定）
+
+- **IP マスキング**: Sentry 側のプロジェクト設定（Data Scrubbing）で行う。コード側は
+  `dataCollection` オプションを一切書かない設計にしている（書くと逆に緩くなる罠がある）。
+- **PostHog の cookie 同意**: 匿名 id を持つ first-party cookie を1つ置く。個人情報ではないが、
+  同意なしに置く cookie ではあるため、必要なら `persistence: 'memory'` に切り替える
+  （`instrumentation-client.ts` の `posthog.init` オプション、1行）。
+- **本番スタックトレースの関数名可読性**: Next.js 16 + Turbopack 環境で Sentry の関数名が
+  難読化されたままになる既知の不具合（sentry-javascript #18248、Vercel 側の対応待ち）。
+  現状はコードで閉じられない。実際に起きたエラーで確認し、読めなければ Issue の説明欄で
+  「入っているが役に立たない」ことを明示する運用でしのぐ。
+
+## 6つのイベント（PostHog）
+
+`src/lib/observability/event.ts` の閉じた判別共用体がすべて。新しいイベントを足すときは
+enum 以外の `string` プロパティを置かない（シート名等が書けてしまう余地を型で塞ぐ）。
+
+| イベント | いつ | 主なプロパティ |
+|---|---|---|
+| `$pageview` | 自動（`capture_pageview: 'history_change'`） | ルート enum |
+| `sheet_viewed` | シート表示コンポーネントの mount | `layout`, `source`, `blockCount` |
+| `sheet_read_depth` | スクロールで 25/50/75/100% 到達 | `depthPercent`, `secondsBucket` |
+| `sheet_view_toggled` | ダッシュボードのビュー切替 | `view`, `enabled` |
+| `pdf_exported` | PDF ダウンロードの成功・失敗 | `result`, `durationBucket`, `reason?` |
+| `viewer_auth_submitted` | `/viewer-auth` のログイン試行 | `outcome`（入力コードそのものは送らない） |
+
+ビルダー（`/builder`）にはイベントを入れていない。利用者が1人で、その1人が
+ダッシュボードを見る人だから。

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,61 @@
+import * as Sentry from '@sentry/nextjs';
+import posthog from 'posthog-js';
+import { registerObservabilityHandle } from '@/lib/observability/capture';
+import {
+  getPostHogHost,
+  getPostHogKey,
+  getSentryDsn,
+  isPostHogEnabled,
+  isSentryEnabled,
+} from '@/lib/observability/config';
+import { SHARED_SENTRY_OPTIONS } from '@/lib/observability/sentry-options';
+import { buildClientIntegrations } from '@/lib/observability/sentry-options.client';
+
+// Next はクライアント計測の初期化ファイルを1本しか許さない（`instrumentation-client.ts`）ため、
+// Sentry と PostHog の両方をここで初期化する。fetch/XHR を素で掴ませたいので Sentry を先に。
+if (isSentryEnabled()) {
+  Sentry.init({
+    dsn: getSentryDsn(),
+    integrations: (defaults) => buildClientIntegrations(defaults),
+    ...SHARED_SENTRY_OPTIONS,
+  });
+}
+
+if (isPostHogEnabled()) {
+  posthog.init(getPostHogKey() as string, {
+    api_host: getPostHogHost(),
+    defaults: '2026-05-30',
+    capture_pageview: 'history_change',
+    // 職務経歴書ページでは「クリックした要素のテキスト」が取引先名そのもの。最重要の1行。
+    autocapture: false,
+    disable_session_recording: true,
+    capture_dead_clicks: false,
+    enable_heatmaps: false,
+    // 副作用で ON にされうる（例: プロジェクト側設定）ので明示的に false を書く。
+    capture_exceptions: false,
+    person_profiles: 'identified_only',
+    // remote-config 経由のスクリプト注入による hydration mismatch を避ける。
+    // 代償はサーベイ/ツールバー機能が使えなくなること（使う予定なし）。
+    disable_external_dependency_loading: true,
+    property_denylist: ['$title', '$referrer', '$initial_current_url', '$initial_referrer', '$initial_pathname'],
+  });
+}
+
+registerObservabilityHandle({
+  capture(error, level, context) {
+    if (isSentryEnabled()) {
+      Sentry.captureException(error, {
+        level,
+        tags: { scope: context.scope, feature: context.feature },
+        fingerprint: context.fingerprint,
+      });
+    }
+  },
+  track(event) {
+    if (!isPostHogEnabled()) return;
+    const { name, ...properties } = event;
+    posthog.capture(name, properties);
+  },
+});
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -23,8 +23,15 @@ import type { ObservabilityEvent } from '@/lib/observability/event';
 // 「初期化完了後に registerObservabilityHandle する」実装にすると、ハイドレーション中の
 // ごく初期の例外（例: app/providers.tsx の同期 throw）を取りこぼす窓ができてしまうため、
 // ハンドル自体は同期的に登録し、送信先が無ければキューへ積む方式にした。
+//
+// 動的 import が失敗した場合（デプロイ直後に古い HTML が消えた chunk を参照する等）は
+// その SDK を諦めてキューを捨てる。キュー自体にも上限を置く — 失敗を検知できるまでの間に
+// 例外が連発すると、送り先の無いキューがページの寿命いっぱい伸び続けるため（レビュー指摘）。
 let sentryClient: typeof import('@sentry/nextjs') | undefined;
 let posthogClient: typeof import('posthog-js')['default'] | undefined;
+let sentryUnavailable = false;
+let posthogUnavailable = false;
+const MAX_PENDING_ITEMS = 20;
 const pendingCaptures: Array<{ error: unknown; level: 'error' | 'warning'; context: CaptureContext }> = [];
 const pendingTracks: ObservabilityEvent[] = [];
 
@@ -36,7 +43,7 @@ registerObservabilityHandle({
         tags: { scope: context.scope, feature: context.feature },
         fingerprint: context.fingerprint,
       });
-    } else if (isSentryEnabled()) {
+    } else if (!sentryUnavailable && isSentryEnabled() && pendingCaptures.length < MAX_PENDING_ITEMS) {
       pendingCaptures.push({ error, level, context });
     }
   },
@@ -44,7 +51,7 @@ registerObservabilityHandle({
     if (posthogClient) {
       const { name, ...properties } = event;
       posthogClient.capture(name, properties);
-    } else if (isPostHogEnabled()) {
+    } else if (!posthogUnavailable && isPostHogEnabled() && pendingTracks.length < MAX_PENDING_ITEMS) {
       pendingTracks.push(event);
     }
   },
@@ -112,8 +119,14 @@ async function initPostHog(): Promise<void> {
   }
 }
 
-void initSentry();
-void initPostHog();
+initSentry().catch(() => {
+  sentryUnavailable = true;
+  pendingCaptures.length = 0;
+});
+initPostHog().catch(() => {
+  posthogUnavailable = true;
+  pendingTracks.length = 0;
+});
 
 export function onRouterTransitionStart(url: string, navigationType: 'push' | 'replace' | 'traverse'): void {
   sentryClient?.captureRouterTransitionStart(url, navigationType);

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,5 +1,4 @@
-import * as Sentry from '@sentry/nextjs';
-import posthog from 'posthog-js';
+import type { CaptureContext } from '@/lib/observability/capture';
 import { registerObservabilityHandle } from '@/lib/observability/capture';
 import {
   getPostHogHost,
@@ -8,20 +7,76 @@ import {
   isPostHogEnabled,
   isSentryEnabled,
 } from '@/lib/observability/config';
-import { SHARED_SENTRY_OPTIONS } from '@/lib/observability/sentry-options';
-import { buildClientIntegrations } from '@/lib/observability/sentry-options.client';
+import type { ObservabilityEvent } from '@/lib/observability/event';
 
 // Next はクライアント計測の初期化ファイルを1本しか許さない（`instrumentation-client.ts`）ため、
-// Sentry と PostHog の両方をここで初期化する。fetch/XHR を素で掴ませたいので Sentry を先に。
-if (isSentryEnabled()) {
+// Sentry と PostHog の両方をここで初期化する。
+//
+// SDK 本体は動的 import にする。トップレベルで静的 import すると、両方無効な環境
+// （キー未設定のデプロイ・DSN を意図的に外したプレビュー環境等）でも、このファイルは
+// 全ルートで必ずロードされる性質上、実行時の `if` 分岐に関わらず2つの SDK が
+// クライアントバンドルにダウンロード・評価される（レビュー指摘: no-op のはずが
+// バンドルサイズ・起動コストだけは常に払っていた）。
+//
+// 初期化が終わるまでの短い間（ダイナミック import が解決するまでの数msから数十ms）に
+// 発生した capture/track はキューに積み、初期化完了後にまとめて送る。ここで単純に
+// 「初期化完了後に registerObservabilityHandle する」実装にすると、ハイドレーション中の
+// ごく初期の例外（例: app/providers.tsx の同期 throw）を取りこぼす窓ができてしまうため、
+// ハンドル自体は同期的に登録し、送信先が無ければキューへ積む方式にした。
+let sentryClient: typeof import('@sentry/nextjs') | undefined;
+let posthogClient: typeof import('posthog-js')['default'] | undefined;
+const pendingCaptures: Array<{ error: unknown; level: 'error' | 'warning'; context: CaptureContext }> = [];
+const pendingTracks: ObservabilityEvent[] = [];
+
+registerObservabilityHandle({
+  capture(error, level, context) {
+    if (sentryClient) {
+      sentryClient.captureException(error, {
+        level,
+        tags: { scope: context.scope, feature: context.feature },
+        fingerprint: context.fingerprint,
+      });
+    } else if (isSentryEnabled()) {
+      pendingCaptures.push({ error, level, context });
+    }
+  },
+  track(event) {
+    if (posthogClient) {
+      const { name, ...properties } = event;
+      posthogClient.capture(name, properties);
+    } else if (isPostHogEnabled()) {
+      pendingTracks.push(event);
+    }
+  },
+});
+
+async function initSentry(): Promise<void> {
+  if (!isSentryEnabled()) return;
+  // integrations の組み立て（sentry-options.client.ts）も Sentry 型に依存するため、
+  // SDK 本体と合わせて動的 import する。
+  const [Sentry, { SHARED_SENTRY_OPTIONS }, { buildClientIntegrations }] = await Promise.all([
+    import('@sentry/nextjs'),
+    import('@/lib/observability/sentry-options'),
+    import('@/lib/observability/sentry-options.client'),
+  ]);
   Sentry.init({
     dsn: getSentryDsn(),
     integrations: (defaults) => buildClientIntegrations(defaults),
     ...SHARED_SENTRY_OPTIONS,
   });
+  sentryClient = Sentry;
+  for (const pending of pendingCaptures.splice(0)) {
+    Sentry.captureException(pending.error, {
+      level: pending.level,
+      tags: { scope: pending.context.scope, feature: pending.context.feature },
+      fingerprint: pending.context.fingerprint,
+    });
+  }
 }
 
-if (isPostHogEnabled()) {
+async function initPostHog(): Promise<void> {
+  if (!isPostHogEnabled()) return;
+  const { default: posthog } = await import('posthog-js');
   posthog.init(getPostHogKey() as string, {
     api_host: getPostHogHost(),
     defaults: '2026-05-30',
@@ -50,23 +105,16 @@ if (isPostHogEnabled()) {
       '$initial_pathname',
     ],
   });
-}
-
-registerObservabilityHandle({
-  capture(error, level, context) {
-    if (isSentryEnabled()) {
-      Sentry.captureException(error, {
-        level,
-        tags: { scope: context.scope, feature: context.feature },
-        fingerprint: context.fingerprint,
-      });
-    }
-  },
-  track(event) {
-    if (!isPostHogEnabled()) return;
+  posthogClient = posthog;
+  for (const event of pendingTracks.splice(0)) {
     const { name, ...properties } = event;
     posthog.capture(name, properties);
-  },
-});
+  }
+}
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+void initSentry();
+void initPostHog();
+
+export function onRouterTransitionStart(url: string, navigationType: 'push' | 'replace' | 'traverse'): void {
+  sentryClient?.captureRouterTransitionStart(url, navigationType);
+}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -37,7 +37,18 @@ if (isPostHogEnabled()) {
     // remote-config 経由のスクリプト注入による hydration mismatch を避ける。
     // 代償はサーベイ/ツールバー機能が使えなくなること（使う予定なし）。
     disable_external_dependency_loading: true,
-    property_denylist: ['$title', '$referrer', '$initial_current_url', '$initial_referrer', '$initial_pathname'],
+    // $current_url/$pathname は enum 置換ではなく全イベントから denylist で落とす方針にした
+    // （$pageview は enum 化の窓口を経由しない自動送信のため。ルート情報が要る場合は
+    // sheet_viewed 等の手動イベントの enum プロパティを見る）。
+    property_denylist: [
+      '$title',
+      '$referrer',
+      '$current_url',
+      '$pathname',
+      '$initial_current_url',
+      '$initial_referrer',
+      '$initial_pathname',
+    ],
   });
 }
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,33 @@
+import type { Instrumentation } from 'next';
+
+import { MISSING_SERVER_ENV_PREFIX } from '@/lib/env';
+import { isSentryEnabled } from '@/lib/observability/config';
+import { classifyConfigError } from '@/util/is-config-error';
+
+/**
+ * nodejs runtime かつキルスイッチが通っているときだけ `sentry.server.config` を読み込む。
+ * edge runtime（proxy.ts）はここでは対象外（`sentry.edge.config.ts` は意図的に作っていない — 5行の
+ * ヘッダーコピーだけの edge コードのために追加の設定ファイルを持つ価値が薄いため）。
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === 'nodejs' && isSentryEnabled()) {
+    await import('./sentry.server.config');
+  }
+}
+
+/**
+ * `assertServerEnv()` の欠落判定と `classifyConfigError()` は別文言なので両方見る。
+ * どちらかに該当するエラーは「設定不備」＝待っても直らない原因なので、ここでは報告しない
+ * （全リクエストで throw し続けて Sentry の無料枠を食い尽くす事故を防ぐ）。
+ * 設定不備自体は `app/global-error.tsx` が warning レベルで別途1回だけ拾う。
+ */
+function isKnownConfigError(error: unknown): boolean {
+  if (classifyConfigError(error) !== null) return true;
+  return error instanceof Error && error.message.startsWith(MISSING_SERVER_ENV_PREFIX);
+}
+
+export const onRequestError: Instrumentation.onRequestError = async (error, request, context) => {
+  if (!isSentryEnabled() || isKnownConfigError(error)) return;
+  const Sentry = await import('@sentry/nextjs');
+  await Sentry.captureRequestError(error, request, context);
+};

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,8 +1,7 @@
 import type { Instrumentation } from 'next';
 
-import { MISSING_SERVER_ENV_PREFIX } from '@/lib/env';
 import { isSentryEnabled } from '@/lib/observability/config';
-import { classifyConfigError } from '@/util/is-config-error';
+import { isKnownConfigError } from '@/server/known-config-error';
 
 /**
  * nodejs runtime かつキルスイッチが通っているときだけ `sentry.server.config` を読み込む。
@@ -15,17 +14,9 @@ export async function register(): Promise<void> {
   }
 }
 
-/**
- * `assertServerEnv()` の欠落判定と `classifyConfigError()` は別文言なので両方見る。
- * どちらかに該当するエラーは「設定不備」＝待っても直らない原因なので、ここでは報告しない
- * （全リクエストで throw し続けて Sentry の無料枠を食い尽くす事故を防ぐ）。
- * 設定不備自体は `app/global-error.tsx` が warning レベルで別途1回だけ拾う。
- */
-function isKnownConfigError(error: unknown): boolean {
-  if (classifyConfigError(error) !== null) return true;
-  return error instanceof Error && error.message.startsWith(MISSING_SERVER_ENV_PREFIX);
-}
-
+// 設定不備（待っても直らない原因）は報告しない。判定は `src/server/known-config-error.ts` に
+// 集約してあり、`report-error.ts` と同じ関数を使う（2か所に分けると文言の追加が片方に漏れる）。
+// 設定不備自体は `app/global-error.tsx` が warning レベルで別途1回だけ拾う。
 export const onRequestError: Instrumentation.onRequestError = async (error, request, context) => {
   if (!isSentryEnabled() || isKnownConfigError(error)) return;
   const Sentry = await import('@sentry/nextjs');

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import bundleAnalyzer from '@next/bundle-analyzer';
+import { withSentryConfig } from '@sentry/nextjs/config';
 import type { NextConfig } from 'next';
 
 const withBundleAnalyzer = bundleAnalyzer({
@@ -18,4 +19,14 @@ const nextConfig: NextConfig = {
   allowedDevOrigins: ['127.0.0.1', 'localhost'],
 };
 
-export default withBundleAnalyzer(nextConfig);
+// Sentry が最外。最終的に解決された Turbopack 設定にパッチを当てるため、
+// withBundleAnalyzer より内側だと Sentry から見える設定が古いままになる。
+export default withSentryConfig(withBundleAnalyzer(nextConfig), {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  // トークンが無いビルド（ローカル・CI・トークン未設定のプレビュー）では
+  // source map 関連の処理そのものを止める。ビルドは落とさない。
+  sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
+  silent: true,
+});

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
       "brace-expansion@>=3": "^5.0.9",
       "test-exclude": "^8.0.0",
       "fast-uri@3": "^3.1.5",
-      "nanoid": "^3.3.17"
+      "nanoid": "^3.3.17",
+      "browserslist": "^4.28.7"
     },
     "patchedDependencies": {
       "@react-pdf/textkit@6.3.0": "patches/@react-pdf__textkit@6.3.0.patch"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "env:decrypt": "sops -d --input-type dotenv --output-type dotenv .env.enc > .env",
+    "env:encrypt": "sops -e --input-type dotenv --output-type dotenv --filename-override .env.enc .env > .env.enc"
   },
   "dependencies": {
     "@better-auth/core": "^1.6.25",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "biome check . --error-on-warnings && node scripts/check-jsdom-pdf-assertions.mjs && ./scripts/check-naming.sh",
+    "lint": "biome check . --error-on-warnings && node scripts/check-jsdom-pdf-assertions.mjs && node scripts/check-telemetry-imports.mjs && ./scripts/check-naming.sh",
     "format": "biome format --write .",
     "type-check": "tsc --noEmit",
     "test": "vitest run && vitest run --config vitest.config.node.ts && vitest run --config vitest.config.pdf.ts",
@@ -43,6 +43,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-pdf/renderer": "^4.3.1",
     "@react-pdf/textkit": "6.3.0",
+    "@sentry/nextjs": "^10.73.0",
     "@tanstack/react-query": "^5.101.4",
     "@trpc/client": "^11.18.0",
     "@trpc/react-query": "^11.18.0",
@@ -55,6 +56,7 @@
     "framer-motion": "^11.15.0",
     "lucide-react": "^1.17.0",
     "next": "^16.2.11",
+    "posthog-js": "^1.424.1",
     "react": "^19.2.0",
     "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.0",
@@ -106,6 +108,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@sentry/cli",
       "esbuild",
       "sharp",
       "unrs-resolver"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "build-storybook": "storybook build",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "env:decrypt": "sops -d --input-type dotenv --output-type dotenv .env.enc > .env",
-    "env:encrypt": "sops -e --input-type dotenv --output-type dotenv --filename-override .env.enc .env > .env.enc"
+    "env:decrypt": "tmp=$(mktemp .env.tmp.XXXXXX) && sops -d --input-type dotenv --output-type dotenv .env.enc > \"$tmp\" && mv \"$tmp\" .env",
+    "env:encrypt": "tmp=$(mktemp .env.enc.tmp.XXXXXX) && sops -e --input-type dotenv --output-type dotenv --filename-override .env.enc .env > \"$tmp\" && mv \"$tmp\" .env.enc"
   },
   "dependencies": {
     "@better-auth/core": "^1.6.25",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
       "sharp": "^0.35.3",
       "brace-expansion@>=3": "^5.0.9",
       "test-exclude": "^8.0.0",
-      "fast-uri@3": "^3.1.5",
+      "fast-uri@3": "^3.1.7",
       "nanoid": "^3.3.17",
       "browserslist": "^4.28.7"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   test-exclude: ^8.0.0
   fast-uri@3: ^3.1.5
   nanoid: ^3.3.17
+  browserslist: ^4.28.7
 
 patchedDependencies:
   '@react-pdf/textkit@6.3.0':
@@ -3377,6 +3378,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   better-auth@1.6.25:
     resolution: {integrity: sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==}
     peerDependencies:
@@ -3460,8 +3466,8 @@ packages:
   browserify-zlib@0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3478,6 +3484,9 @@ packages:
 
   caniuse-lite@1.0.30001797:
     resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3754,8 +3763,8 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
-  electron-to-chromium@1.5.368:
-    resolution: {integrity: sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -3782,9 +3791,6 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
@@ -4561,8 +4567,8 @@ packages:
       encoding:
         optional: true
 
-  node-releases@2.0.47:
-    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
   normalize-svg-path@1.1.0:
@@ -5215,11 +5221,11 @@ packages:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ^4.28.7
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -5566,7 +5572,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -7997,6 +8003,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.34: {}
 
+  baseline-browser-mapping@2.11.20: {}
+
   better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)):
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
@@ -8082,13 +8090,13 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
-  browserslist@4.28.2:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.34
-      caniuse-lite: 1.0.30001797
-      electron-to-chromium: 1.5.368
-      node-releases: 2.0.47
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   buffer-from@1.1.2: {}
 
@@ -8099,6 +8107,8 @@ snapshots:
   cac@6.7.14: {}
 
   caniuse-lite@1.0.30001797: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -8254,7 +8264,7 @@ snapshots:
 
   duplexer@0.1.2: {}
 
-  electron-to-chromium@1.5.368: {}
+  electron-to-chromium@1.5.420: {}
 
   emoji-regex-xs@1.0.0: {}
 
@@ -8272,8 +8282,6 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
-
-  es-module-lexer@2.1.0: {}
 
   es-module-lexer@2.3.2: {}
 
@@ -9354,7 +9362,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-releases@2.0.47: {}
+  node-releases@2.0.54: {}
 
   normalize-svg-path@1.1.0:
     dependencies:
@@ -10105,9 +10113,9 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -10322,10 +10330,10 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.23.0
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.2
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   sharp: ^0.35.3
   brace-expansion@>=3: ^5.0.9
   test-exclude: ^8.0.0
-  fast-uri@3: ^3.1.5
+  fast-uri@3: ^3.1.7
   nanoid: ^3.3.17
   browserslist: ^4.28.7
 
@@ -3875,8 +3875,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
@@ -7963,7 +7963,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8436,7 +8436,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fault@1.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
     dependencies:
       '@better-auth/core':
         specifier: ^1.6.25
-        version: 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+        version: 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -55,6 +55,9 @@ importers:
       '@react-pdf/textkit':
         specifier: 6.3.0
         version: 6.3.0(patch_hash=cf9d1b07e319496586e063cac807f88a809f71fe6aabad688480364b93a7df15)
+      '@sentry/nextjs':
+        specifier: ^10.73.0
+        version: 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.7)
@@ -69,7 +72,7 @@ importers:
         version: 11.18.0(typescript@5.9.3)
       better-auth:
         specifier: ^1.6.22
-        version: 1.6.25(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2))(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))
+        version: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -81,7 +84,7 @@ importers:
         version: 4.4.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2)
+        version: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2)
       framer-motion:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -90,7 +93,10 @@ importers:
         version: 1.17.0(react@19.2.7)
       next:
         specifier: ^16.2.11
-        version: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      posthog-js:
+        specifier: ^1.424.1
+        version: 1.424.1(@types/react@19.2.17)(react@19.2.7)
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -169,7 +175,7 @@ importers:
         version: 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
       '@storybook/nextjs-vite':
         specifier: ^10.5.4
-        version: 10.5.5(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
+        version: 10.5.5(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -1793,6 +1799,44 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.11.0':
+    resolution: {integrity: sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.11.0':
+    resolution: {integrity: sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.11.0':
+    resolution: {integrity: sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.11.0':
+    resolution: {integrity: sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
@@ -2037,6 +2081,15 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posthog/browser-common@0.7.1':
+    resolution: {integrity: sha512-JO/5dIVx3NTrbg0W2VciDDmmizsvwaYYHE5cnJE1Gra+UqBnEuVGH9DTE/kBFgVMp+08z5uj/aAprsYD2WG/QQ==}
+
+  '@posthog/core@1.50.2':
+    resolution: {integrity: sha512-El7y/ipZ45OFBRTN/+ixat9Nw21bW+pKKnX0G+rG4rWxBtDA47Ub/ZUnHvZNhAufNInQr4AYCUeWQsuJsTcoKg==}
+
+  '@posthog/types@1.407.2':
+    resolution: {integrity: sha512-F/x/qlZSGiianCEZlZ9XRYHUYffH07Zv+1oOllxAw15ifObagxSZzc2IneZE01eFqPl2OmoNuY86ER5Uyvy8Zw==}
 
   '@radix-ui/primitive@1.1.4':
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
@@ -2453,6 +2506,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
+  '@rollup/plugin-commonjs@28.0.1':
+    resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/pluginutils@5.4.0':
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
     engines: {node: '>=14.0.0'}
@@ -2599,6 +2661,165 @@ packages:
     resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
     cpu: [x64]
     os: [win32]
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser-utils@10.73.0':
+    resolution: {integrity: sha512-qQygxJZ+RV779+iL1+lrJ4f4sZLgbgW0/JWPNp0YlcEAE62yCsdKbqoTEjB/EugdS4mSjBMX0chZC6rblu2Ycw==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.73.0':
+    resolution: {integrity: sha512-HqTe1S5RrWLufhX2LaFP3yNoMxfNDroh120bq1zdGHZfFDBMJQ0CDXxHO+L4UJfQ5dWdCCzWbXIAiZuWGa/DFQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/bundler-plugins@10.73.0':
+    resolution: {integrity: sha512-4X5m2hoqgKO6SxHR7MF9QnvxPNk0hwTJFixDJ/pzQGVM+C34j/rSabouBqd0M+ZdxFeAt/9kA5X0TyeceNo9YQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.73.0':
+    resolution: {integrity: sha512-FLO1UgH19RyasVpofu612WCOgb2nEH0dZy+R72d7p65XU9i0wxlMKm3+sgfwKmiSJp1Qhilaaxs4Jg6BbiM5HA==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.73.0':
+    resolution: {integrity: sha512-D6nSngX+e46Mae2/oh2bxBvxNK1z2NERbuMAhB5sx9x4xMBWIyGnYYTECehvEqV9+AqGAgxxhOZoYIG3AmRwww==}
+    engines: {node: '>=18'}
+
+  '@sentry/nextjs@10.73.0':
+    resolution: {integrity: sha512-lZFlQkafIHnYKTo0QCY+VqFC7rEt/SRAVrTCKyM+r1yIAw+iIfU1qM2QT7xn71+t0U520I0xBJ2O+YzqLYXJIQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
+
+  '@sentry/node-core@10.73.0':
+    resolution: {integrity: sha512-GHAGUmZPmm6FKfxfv2maVVJ/A99YAmd7oFOuKMDmITI6O/Msl6JB3vPTEpopVAHLW0LYJQBOjddL9C7o+Jt44g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.73.0':
+    resolution: {integrity: sha512-jiMJ6GgXDw6UMGzJY+o0c8OoeA9OfHqZ/xEpHfDqy75hn+9CEkRkbNGCIdMvsc7wW/Se1Os394hHfTpU+YEskg==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.73.0':
+    resolution: {integrity: sha512-fQouPQKsH0CQrw6oAn1k0Z2I+tgyochCovifr5qNS69i0OzjknLa03WJyiZ/IuzXc4AVa5jAKfOeE9slABz8Qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/react@10.73.0':
+    resolution: {integrity: sha512-wJrzS98ddPvhGS/MKNHZyE8X7ecd4KwKdz7fHino2qkqBBrF4cxWr+q/uLTIk5PYWMkeJ4oKMjHAjOqmzGR4tg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.73.0':
+    resolution: {integrity: sha512-sxa2lKkHPfF/j5xFpW7gocthWXRqyoHz8KCPy6yGc8plT477nl57iGSKhQDYsx1Ny10TLjs7YkIuPP1GY/Ax2Q==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.73.0':
+    resolution: {integrity: sha512-nN2wjN/Y0J5BOJV5hqRHUEBfxwUsipp1PKjcDHh6Fpxnrtfldu3Y99E8cQInseo5heFdzEvrOHBBrqWZXOHVKQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/server-utils@10.73.0':
+    resolution: {integrity: sha512-QskripdKFbM/+gipC6mpa2crLwL7+VbkX84IpHg2z9UlYQ1kNKd3aMT+Qk9NLRSw/zu1rSIAvlbWfx4D3rgNAA==}
+    engines: {node: '>=18'}
+
+  '@sentry/vercel-edge@10.73.0':
+    resolution: {integrity: sha512-DJLqVzd3ng4IwR+ux/vK1Wth/CSwUrsiwIbNsyneHw79cyhfjYuovFTw1xrjn9zTJoVSE8KkdajLSLwmLbnoTw==}
+    engines: {node: '>=18'}
+
+  '@sentry/webpack-plugin@5.4.0':
+    resolution: {integrity: sha512-J3a0BvUZ75Qxy+v/Ap3Hx4ZEcSjlPHZ/jDtxdRhXQCyNeEb8xq0uUBTI9VLtGk2eNeNucOxOEJ5ngqdNjnEH/A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      webpack: '>=5.0.0'
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2940,6 +3161,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -3079,6 +3303,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3278,6 +3506,9 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -3310,12 +3541,18 @@ packages:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
 
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
+
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -3406,6 +3643,17 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -3538,6 +3786,9 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -3633,8 +3884,15 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
+
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
 
   fontkit@2.0.4:
     resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
@@ -3772,6 +4030,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -3783,6 +4045,10 @@ packages:
     resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  import-in-the-middle@3.4.0:
+    resolution: {integrity: sha512-Xfjwfarhe+LGmoaof+sexeNo3sGRysb5x56WrZLwHtmqT0OilSKtVWkv0lrCcMgSKyKP9oBogBAisHZvtJH0aw==}
+    engines: {node: '>=18'}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -3831,6 +4097,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
@@ -3841,6 +4110,9 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3993,6 +4265,10 @@ packages:
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -4227,6 +4503,9 @@ packages:
   module-alias@2.3.4:
     resolution: {integrity: sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   motion-dom@11.18.1:
     resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
 
@@ -4273,6 +4552,15 @@ packages:
       sass:
         optional: true
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
@@ -4299,6 +4587,14 @@ packages:
   oxc-resolver@11.20.0:
     resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
@@ -4316,6 +4612,10 @@ packages:
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -4366,6 +4666,25 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.424.1:
+    resolution: {integrity: sha512-5jJ3PWPDbJ255gcIgANRGt83npqb6hNwgmDt67PmaNMW3ZRTo+arlooEJaSC+poAAJHgsAU4VL0NJ9i/rvmd5g==}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4374,15 +4693,25 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -4516,6 +4845,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -4609,6 +4942,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -4795,6 +5132,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -4834,6 +5174,10 @@ packages:
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -5017,6 +5361,12 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-vitals@6.2.1:
+    resolution: {integrity: sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -5054,6 +5404,14 @@ packages:
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -5123,6 +5481,10 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
@@ -5280,6 +5642,20 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -5292,12 +5668,26 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
+  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2))':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2)
+
   '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2))':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2)
+
+  '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.2
 
   '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
@@ -5306,9 +5696,19 @@ snapshots:
     optionalDependencies:
       kysely: 0.29.2
 
+  '@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+
   '@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
@@ -5316,10 +5716,21 @@ snapshots:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
+  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+
   '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
+
+  '@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
 
   '@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
@@ -5919,7 +6330,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -6040,6 +6450,47 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.2.0': {}
+
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.4.0
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
@@ -6175,6 +6626,17 @@ snapshots:
       playwright: 1.62.0
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@posthog/browser-common@0.7.1':
+    dependencies:
+      '@posthog/core': 1.50.2
+      '@posthog/types': 1.407.2
+
+  '@posthog/core@1.50.2':
+    dependencies:
+      '@posthog/types': 1.407.2
+
+  '@posthog/types@1.407.2': {}
 
   '@radix-ui/primitive@1.1.4': {}
 
@@ -6613,6 +7075,18 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
+  '@rollup/plugin-commonjs@28.0.1(rollup@4.61.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.61.1
+
   '@rollup/pluginutils@5.4.0(rollup@4.61.1)':
     dependencies:
       '@types/estree': 1.0.9
@@ -6696,6 +7170,203 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser-utils@10.73.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+
+  '@sentry/browser@10.73.0':
+    dependencies:
+      '@sentry/browser-utils': 10.73.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/feedback': 10.73.0
+      '@sentry/replay': 10.73.0
+      '@sentry/replay-canvas': 10.73.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/bundler-plugins@10.73.0(rollup@4.61.1)(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.73.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.61.1
+      webpack: 5.107.2(esbuild@0.28.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.73.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/feedback@10.73.0':
+    dependencies:
+      '@sentry/core': 10.73.0
+
+  '@sentry/nextjs@10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.61.1)
+      '@sentry/browser-utils': 10.73.0
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/node': 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/react': 10.73.0(react@19.2.7)
+      '@sentry/server-utils': 10.73.0
+      '@sentry/vercel-edge': 10.73.0
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.61.1)(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rollup: 4.61.1
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
+  '@sentry/node-core@10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/opentelemetry': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.4.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/node-core': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.73.0
+      import-in-the-middle: 3.4.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+
+  '@sentry/react@10.73.0(react@19.2.7)':
+    dependencies:
+      '@sentry/browser': 10.73.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      react: 19.2.7
+
+  '@sentry/replay-canvas@10.73.0':
+    dependencies:
+      '@sentry/core': 10.73.0
+      '@sentry/replay': 10.73.0
+
+  '@sentry/replay@10.73.0':
+    dependencies:
+      '@sentry/browser-utils': 10.73.0
+      '@sentry/core': 10.73.0
+
+  '@sentry/server-utils@10.73.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+
+  '@sentry/vercel-edge@10.73.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.73.0
+
+  '@sentry/webpack-plugin@5.4.0(rollup@4.61.1)(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@sentry/bundler-plugins': 10.73.0(rollup@4.61.1)(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
+      webpack: 5.107.2(esbuild@0.28.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@standard-schema/spec@1.1.0': {}
 
   '@storybook/addon-docs@10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))':
@@ -6744,6 +7415,30 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@storybook/nextjs-vite@10.5.5(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@storybook/builder-vite': 10.5.5(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
+      '@storybook/react': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+      '@storybook/react-vite': 10.5.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)
+      vite-plugin-storybook-nextjs: 3.3.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+      - esbuild
+      - rollup
+      - supports-color
+      - webpack
 
   '@storybook/nextjs-vite@10.5.5(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))(webpack@5.107.2(esbuild@0.28.0)(lightningcss@1.32.0))':
     dependencies:
@@ -7010,8 +7705,7 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/json-schema@7.0.15':
-    optional: true
+  '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -7040,6 +7734,9 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -7150,26 +7847,20 @@ snapshots:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
       '@webassemblyjs/helper-wasm-bytecode': 1.13.2
-    optional: true
 
-  '@webassemblyjs/floating-point-hex-parser@1.13.2':
-    optional: true
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
 
-  '@webassemblyjs/helper-api-error@1.13.2':
-    optional: true
+  '@webassemblyjs/helper-api-error@1.13.2': {}
 
-  '@webassemblyjs/helper-buffer@1.14.1':
-    optional: true
+  '@webassemblyjs/helper-buffer@1.14.1': {}
 
   '@webassemblyjs/helper-numbers@1.13.2':
     dependencies:
       '@webassemblyjs/floating-point-hex-parser': 1.13.2
       '@webassemblyjs/helper-api-error': 1.13.2
       '@xtuc/long': 4.2.2
-    optional: true
 
-  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
-    optional: true
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
 
   '@webassemblyjs/helper-wasm-section@1.14.1':
     dependencies:
@@ -7177,20 +7868,16 @@ snapshots:
       '@webassemblyjs/helper-buffer': 1.14.1
       '@webassemblyjs/helper-wasm-bytecode': 1.13.2
       '@webassemblyjs/wasm-gen': 1.14.1
-    optional: true
 
   '@webassemblyjs/ieee754@1.13.2':
     dependencies:
       '@xtuc/ieee754': 1.2.0
-    optional: true
 
   '@webassemblyjs/leb128@1.13.2':
     dependencies:
       '@xtuc/long': 4.2.2
-    optional: true
 
-  '@webassemblyjs/utf8@1.13.2':
-    optional: true
+  '@webassemblyjs/utf8@1.13.2': {}
 
   '@webassemblyjs/wasm-edit@1.14.1':
     dependencies:
@@ -7202,7 +7889,6 @@ snapshots:
       '@webassemblyjs/wasm-opt': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       '@webassemblyjs/wast-printer': 1.14.1
-    optional: true
 
   '@webassemblyjs/wasm-gen@1.14.1':
     dependencies:
@@ -7211,7 +7897,6 @@ snapshots:
       '@webassemblyjs/ieee754': 1.13.2
       '@webassemblyjs/leb128': 1.13.2
       '@webassemblyjs/utf8': 1.13.2
-    optional: true
 
   '@webassemblyjs/wasm-opt@1.14.1':
     dependencies:
@@ -7219,7 +7904,6 @@ snapshots:
       '@webassemblyjs/helper-buffer': 1.14.1
       '@webassemblyjs/wasm-gen': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-    optional: true
 
   '@webassemblyjs/wasm-parser@1.14.1':
     dependencies:
@@ -7229,28 +7913,23 @@ snapshots:
       '@webassemblyjs/ieee754': 1.13.2
       '@webassemblyjs/leb128': 1.13.2
       '@webassemblyjs/utf8': 1.13.2
-    optional: true
 
   '@webassemblyjs/wast-printer@1.14.1':
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
-    optional: true
 
   '@webcontainer/env@1.1.1': {}
 
-  '@xtuc/ieee754@1.2.0':
-    optional: true
+  '@xtuc/ieee754@1.2.0': {}
 
-  '@xtuc/long@4.2.2':
-    optional: true
+  '@xtuc/long@4.2.2': {}
 
   abs-svg-path@0.1.1: {}
 
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
-    optional: true
 
   acorn-walk@8.3.5:
     dependencies:
@@ -7258,18 +7937,22 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
-    optional: true
 
   ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
       ajv: 8.20.0
       fast-deep-equal: 3.1.3
-    optional: true
 
   ajv@8.20.0:
     dependencies:
@@ -7277,7 +7960,6 @@ snapshots:
       fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    optional: true
 
   ansi-regex@5.0.1: {}
 
@@ -7315,15 +7997,15 @@ snapshots:
 
   baseline-browser-mapping@2.10.34: {}
 
-  better-auth@1.6.25(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2))(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)):
+  better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)):
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2))
-      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2))
+      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
@@ -7336,8 +8018,8 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2)
-      next: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      drizzle-orm: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2)
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       vitest: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)
@@ -7438,8 +8120,9 @@ snapshots:
 
   check-error@2.1.3: {}
 
-  chrome-trace-event@1.0.4:
-    optional: true
+  chrome-trace-event@1.0.4: {}
+
+  cjs-module-lexer@2.2.1: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -7459,16 +8142,19 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
-  commander@2.20.3:
-    optional: true
+  commander@2.20.3: {}
 
   commander@7.2.0: {}
+
+  commondir@1.0.1: {}
 
   convert-source-map@2.0.0: {}
 
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
+  core-js@3.50.0: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -7540,12 +8226,26 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dompurify@3.4.14:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
+
   drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.12
       tsx: 4.23.9
+
+  drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.29.2):
+    optionalDependencies:
+      '@neondatabase/serverless': 1.1.0
+      '@opentelemetry/api': 1.9.1
+      kysely: 0.29.2
 
   drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(kysely@0.29.2):
     optionalDependencies:
@@ -7573,8 +8273,9 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  es-module-lexer@2.1.0:
-    optional: true
+  es-module-lexer@2.1.0: {}
+
+  es-module-lexer@2.3.2: {}
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -7698,20 +8399,16 @@ snapshots:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
-    optional: true
 
   esprima@4.0.1: {}
 
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
-    optional: true
 
-  estraverse@4.3.0:
-    optional: true
+  estraverse@4.3.0: {}
 
-  estraverse@5.3.0:
-    optional: true
+  estraverse@5.3.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
 
@@ -7731,8 +8428,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5:
-    optional: true
+  fast-uri@3.1.5: {}
 
   fault@1.0.4:
     dependencies:
@@ -7742,7 +8438,14 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.4.9: {}
+
   fflate@0.8.3: {}
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
 
   fontkit@2.0.4:
     dependencies:
@@ -7787,8 +8490,7 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  glob-to-regexp@0.4.1:
-    optional: true
+  glob-to-regexp@0.4.1: {}
 
   glob@13.0.6:
     dependencies:
@@ -7926,6 +8628,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -7936,6 +8645,12 @@ snapshots:
   hyphen@1.14.1: {}
 
   image-size@2.0.2: {}
+
+  import-in-the-middle@3.4.0:
+    dependencies:
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 2.3.2
+      module-details-from-path: 1.0.4
 
   indent-string@4.0.0: {}
 
@@ -7970,6 +8685,10 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.9
+
   is-url@1.2.4: {}
 
   is-what@5.5.0: {}
@@ -7977,6 +8696,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -8008,7 +8729,6 @@ snapshots:
       '@types/node': 24.13.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    optional: true
 
   jiti@2.7.0: {}
 
@@ -8052,8 +8772,7 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-schema-traverse@1.0.0:
-    optional: true
+  json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
 
@@ -8115,8 +8834,11 @@ snapshots:
       base64-js: 0.0.8
       unicode-trie: 2.0.0
 
-  loader-runner@4.3.2:
-    optional: true
+  loader-runner@4.3.2: {}
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   longest-streak@3.1.0: {}
 
@@ -8331,8 +9053,7 @@ snapshots:
 
   media-engine@1.0.3: {}
 
-  merge-stream@2.0.0:
-    optional: true
+  merge-stream@2.0.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8544,8 +9265,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mime-db@1.54.0:
-    optional: true
+  mime-db@1.54.0: {}
 
   min-indent@1.0.1: {}
 
@@ -8558,6 +9278,8 @@ snapshots:
   minipass@7.1.3: {}
 
   module-alias@2.3.4: {}
+
+  module-details-from-path@1.0.4: {}
 
   motion-dom@11.18.1:
     dependencies:
@@ -8573,8 +9295,34 @@ snapshots:
 
   nanostores@1.3.0: {}
 
-  neo-async@2.6.2:
-    optional: true
+  neo-async@2.6.2: {}
+
+  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@next/env': 16.2.11
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
+      postcss: 8.5.25
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.62.0
+      sharp: 0.35.3(@types/node@24.13.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
 
   next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -8601,6 +9349,10 @@ snapshots:
       - '@babel/core'
       - '@types/node'
       - babel-plugin-macros
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.47: {}
 
@@ -8666,6 +9418,14 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   pako@0.2.9: {}
 
   pako@1.0.11: {}
@@ -8689,6 +9449,8 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+
+  path-exists@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -8734,6 +9496,26 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.424.1(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@posthog/browser-common': 0.7.1
+      '@posthog/core': 1.50.2
+      '@posthog/types': 1.407.2
+      core-js: 3.50.0
+      dompurify: 3.4.14
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 6.2.1
+      web-vitals-soft-navs: web-vitals@6.2.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  preact@10.29.8: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8741,6 +9523,8 @@ snapshots:
       react-is: 17.0.2
 
   prismjs@1.30.0: {}
+
+  progress@2.0.3: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -8750,7 +9534,11 @@ snapshots:
 
   property-information@7.2.0: {}
 
+  proxy-from-env@1.1.0: {}
+
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue@6.0.2:
     dependencies:
@@ -8943,6 +9731,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
@@ -9005,7 +9800,6 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
-    optional: true
 
   semver@6.3.1: {}
 
@@ -9074,6 +9868,10 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
+
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
 
   std-env@3.10.0: {}
 
@@ -9151,7 +9949,6 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
-    optional: true
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -9175,7 +9972,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.0
       lightningcss: 1.32.0
-    optional: true
 
   terser@5.48.0:
     dependencies:
@@ -9183,7 +9979,6 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    optional: true
 
   test-exclude@8.0.0:
     dependencies:
@@ -9222,6 +10017,8 @@ snapshots:
     dependencies:
       tldts: 7.4.2
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -9251,6 +10048,8 @@ snapshots:
       fsevents: 2.3.3
 
   tw-animate-css@1.4.0: {}
+
+  type-fest@0.7.1: {}
 
   typescript@5.9.3: {}
 
@@ -9375,6 +10174,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-storybook-nextjs@3.3.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)):
+    dependencies:
+      '@next/env': 16.0.0
+      image-size: 2.0.2
+      magic-string: 0.30.21
+      module-alias: 2.3.4
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      ts-dedent: 2.3.0
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)
+      vite-tsconfig-paths: 5.1.4(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite-plugin-storybook-nextjs@3.3.1(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.0)(@types/node@24.13.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.9)):
     dependencies:
       '@next/env': 16.0.0
@@ -9467,9 +10281,12 @@ snapshots:
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
-    optional: true
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@6.2.1: {}
+
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -9492,8 +10309,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-sources@3.5.0:
-    optional: true
+  webpack-sources@3.5.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -9535,7 +10351,6 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
-    optional: true
 
   whatwg-mimetype@4.0.0: {}
 
@@ -9545,6 +10360,15 @@ snapshots:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.1
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -9574,6 +10398,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  yocto-queue@0.1.0: {}
 
   yoga-layout@3.2.1: {}
 

--- a/scripts/check-telemetry-imports.mjs
+++ b/scripts/check-telemetry-imports.mjs
@@ -82,12 +82,14 @@ for (const target of TARGET_DIRS) {
       const allowedDirectImport = ALLOWED_DIRECT_IMPORT_FILES.has(filePath);
 
       if (!allowedDirectImport) {
-        // import 文は複数行にまたがりうるため、ファイル全文に対して 's' フラグ付きで検査する
-        // （1行ずつの走査だと `from '...'` が別行にある複数行 import を見逃す）。
+        // コメント行の文字列に "import" が含まれると、貪欲な全文パターンがそこから
+        // マッチを開始し、後続の本物の import 文まで食い潰して見逃す
+        // （レビュー指摘: `// import の代わりに窓口を使う` のようなコメント直後の
+        // 本物の import が検出されなくなる）。行頭が `//` の行は空行に潰してから検査する。
+        const sanitizedContent = lines.map((line) => (line.trim().startsWith('//') ? '' : line)).join('\n');
         const importPattern = new RegExp(IMPORT_PATTERN.source, `${IMPORT_PATTERN.flags}g`);
-        for (const match of content.matchAll(importPattern)) {
-          const line = content.slice(0, match.index).split('\n').length;
-          if (lines[line - 1]?.trim().startsWith('//')) continue;
+        for (const match of sanitizedContent.matchAll(importPattern)) {
+          const line = sanitizedContent.slice(0, match.index).split('\n').length;
           violations.push({
             file: relative(ROOT, filePath),
             line,

--- a/scripts/check-telemetry-imports.mjs
+++ b/scripts/check-telemetry-imports.mjs
@@ -40,7 +40,9 @@ const ALLOWED_DIRECT_IMPORT_FILES = new Set(
 
 // `import type` は実行時コードを生成しない（Sentry.setUser 等を呼びようがない）ので許可する。
 // sentry-options.ts が型だけを共有ファイルから参照するために使っている。
-const IMPORT_PATTERN = /^\s*import\s+(?!type\s)[^;]*from\s+['"](@sentry\/[^'"]+|posthog-js)['"]/;
+// `import(...)` の動的呼び出し（report-error.ts が isSentryEnabled() 判定後にのみ読み込むために使う）も拾う。
+const IMPORT_PATTERN =
+  /^\s*import\s+(?!type\s)[^;]*from\s+['"](@sentry\/[^'"]+|posthog-js)['"]|import\(\s*['"](@sentry\/[^'"]+|posthog-js)['"]\s*\)/;
 const SET_USER_PATTERN = /Sentry\.setUser\s*\(/;
 const IDENTIFY_PATTERN = /posthog\.identify\s*\(/;
 

--- a/scripts/check-telemetry-imports.mjs
+++ b/scripts/check-telemetry-imports.mjs
@@ -21,6 +21,7 @@ const TARGET_DIRS = [
   'instrumentation.ts',
   'instrumentation-client.ts',
   'sentry.server.config.ts',
+  'proxy.ts',
 ];
 const SKIP_DIR_NAMES = new Set(['node_modules', '.next', '.git']);
 
@@ -78,15 +79,20 @@ for (const target of TARGET_DIRS) {
   try {
     for await (const filePath of walk(fullPath)) {
       const content = await readFile(filePath, 'utf-8');
-      const lines = content.split('\n');
       const allowedDirectImport = ALLOWED_DIRECT_IMPORT_FILES.has(filePath);
 
+      // ブロックコメント（/* ... */）と行コメント（// ...）の中身を空白に潰してから検査する。
+      // 改行だけは残し、後続の行番号計算がズレないようにする
+      // （レビュー指摘: `/* import ... from '@sentry/nextjs' */` のようなブロックコメントで
+      // コメントアウトしただけの記述が IMPORT_PATTERN に一致し、lint が誤って失敗していた）。
+      const withoutBlockComments = content.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+      const sanitizedContent = withoutBlockComments
+        .split('\n')
+        .map((line) => (line.trim().startsWith('//') ? '' : line))
+        .join('\n');
+      const sanitizedLines = sanitizedContent.split('\n');
+
       if (!allowedDirectImport) {
-        // コメント行の文字列に "import" が含まれると、貪欲な全文パターンがそこから
-        // マッチを開始し、後続の本物の import 文まで食い潰して見逃す
-        // （レビュー指摘: `// import の代わりに窓口を使う` のようなコメント直後の
-        // 本物の import が検出されなくなる）。行頭が `//` の行は空行に潰してから検査する。
-        const sanitizedContent = lines.map((line) => (line.trim().startsWith('//') ? '' : line)).join('\n');
         const importPattern = new RegExp(IMPORT_PATTERN.source, `${IMPORT_PATTERN.flags}g`);
         for (const match of sanitizedContent.matchAll(importPattern)) {
           const line = sanitizedContent.slice(0, match.index).split('\n').length;
@@ -99,9 +105,8 @@ for (const target of TARGET_DIRS) {
         }
       }
 
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        if (line.trim().startsWith('//')) continue;
+      for (let i = 0; i < sanitizedLines.length; i++) {
+        const line = sanitizedLines[i];
 
         if (SET_USER_PATTERN.test(line)) {
           violations.push({ file: relative(ROOT, filePath), line: i + 1, reason: 'Sentry.setUser() は全面禁止' });

--- a/scripts/check-telemetry-imports.mjs
+++ b/scripts/check-telemetry-imports.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * `@sentry/*` / `posthog-js` への直接依存を、窓口（src/lib/observability/*）と
+ * SDK 初期化に必要な数ファイルだけに閉じ込める。
+ *
+ * 「送らんものを型と lint で表現する」設計の要。アプリコードが直接 SDK を呼べる状態だと、
+ * 次の1行で `scrubSentryEvent`/`captureError` の窓口を素通りできてしまう。
+ *
+ * `Sentry.setUser(` / `posthog.identify(` は許可リストの中でも全面禁止
+ * （ユーザー識別を送らない設計そのものを、機械的に固定する）。
+ */
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { cwd } from 'node:process';
+
+const ROOT = cwd();
+const TARGET_DIRS = [
+  'app',
+  'src',
+  'next.config.ts',
+  'instrumentation.ts',
+  'instrumentation-client.ts',
+  'sentry.server.config.ts',
+];
+const SKIP_DIR_NAMES = new Set(['node_modules', '.next', '.git']);
+
+// SDK を直接 import してよい唯一の場所。ここを増やすときは、なぜ窓口を経由できないかを
+// コメントで説明すること（バンドラ層をまたぐ・初期化そのものである等）。
+const ALLOWED_DIRECT_IMPORT_FILES = new Set(
+  [
+    'next.config.ts',
+    'instrumentation.ts',
+    'instrumentation-client.ts',
+    'sentry.server.config.ts',
+    'src/lib/observability/sentry-options.server.ts',
+    'src/lib/observability/sentry-options.client.ts',
+    'src/server/report-error.ts',
+  ].map((p) => join(ROOT, p)),
+);
+
+// `import type` は実行時コードを生成しない（Sentry.setUser 等を呼びようがない）ので許可する。
+// sentry-options.ts が型だけを共有ファイルから参照するために使っている。
+const IMPORT_PATTERN = /^\s*import\s+(?!type\s)[^;]*from\s+['"](@sentry\/[^'"]+|posthog-js)['"]/;
+const SET_USER_PATTERN = /Sentry\.setUser\s*\(/;
+const IDENTIFY_PATTERN = /posthog\.identify\s*\(/;
+
+function isTargetSourceFile(fileName) {
+  return /\.(ts|tsx)$/.test(fileName) && !fileName.endsWith('.d.ts');
+}
+
+async function* walk(path) {
+  const s = await stat(path);
+  if (s.isDirectory()) {
+    const entries = await readdir(path);
+    for (const entry of entries) {
+      if (SKIP_DIR_NAMES.has(entry)) continue;
+      yield* walk(join(path, entry));
+    }
+  } else if (s.isFile() && isTargetSourceFile(path)) {
+    yield path;
+  }
+}
+
+let exitCode = 0;
+const violations = [];
+
+for (const target of TARGET_DIRS) {
+  const fullPath = join(ROOT, target);
+  try {
+    for await (const filePath of walk(fullPath)) {
+      const content = await readFile(filePath, 'utf-8');
+      const lines = content.split('\n');
+      const allowedDirectImport = ALLOWED_DIRECT_IMPORT_FILES.has(filePath);
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.trim().startsWith('//')) continue;
+
+        if (!allowedDirectImport && IMPORT_PATTERN.test(line)) {
+          violations.push({
+            file: relative(ROOT, filePath),
+            line: i + 1,
+            reason: '@sentry/* / posthog-js を直接 import している（src/lib/observability/capture.ts 経由にすること）',
+          });
+          exitCode = 1;
+        }
+        if (SET_USER_PATTERN.test(line)) {
+          violations.push({ file: relative(ROOT, filePath), line: i + 1, reason: 'Sentry.setUser() は全面禁止' });
+          exitCode = 1;
+        }
+        if (IDENTIFY_PATTERN.test(line)) {
+          violations.push({ file: relative(ROOT, filePath), line: i + 1, reason: 'posthog.identify() は全面禁止' });
+          exitCode = 1;
+        }
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+if (violations.length > 0) {
+  console.error('telemetry import ゲートに違反しています:');
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line} ${v.reason}`);
+  }
+} else {
+  console.log('telemetry import ゲート: 違反なし。');
+}
+
+process.exit(exitCode);

--- a/scripts/check-telemetry-imports.mjs
+++ b/scripts/check-telemetry-imports.mjs
@@ -41,10 +41,17 @@ const ALLOWED_DIRECT_IMPORT_FILES = new Set(
 // `import type` は実行時コードを生成しない（Sentry.setUser 等を呼びようがない）ので許可する。
 // sentry-options.ts が型だけを共有ファイルから参照するために使っている。
 // `import(...)` の動的呼び出し（report-error.ts が isSentryEnabled() 判定後にのみ読み込むために使う）も拾う。
+// `[^;]` は改行も含むため、`import {\n ... \n} from '...'` のような複数行 import も
+// 1つの import 文の途中で `;` を跨がない限り検出できる
+// （レビュー指摘: 旧実装は1行ずつ判定していたため、from が別行にある複数行 import を見逃していた）。
 const IMPORT_PATTERN =
-  /^\s*import\s+(?!type\s)[^;]*from\s+['"](@sentry\/[^'"]+|posthog-js)['"]|import\(\s*['"](@sentry\/[^'"]+|posthog-js)['"]\s*\)/;
-const SET_USER_PATTERN = /Sentry\.setUser\s*\(/;
-const IDENTIFY_PATTERN = /posthog\.identify\s*\(/;
+  /import\s+(?!type\s)[^;]*from\s+['"](@sentry\/[^'"]+|posthog-js)['"]|import\(\s*['"](@sentry\/[^'"]+|posthog-js)['"]\s*\)/su;
+// `?.` によるオプショナルチェーン経由の呼び出し（`Sentry?.setUser(...)`）も対象にする。
+// エイリアス経由の間接呼び出し（`const f = posthog.identify; f(...)`）は静的な行走査では
+// 原理的に検出できず、AST 解析が要る。本スクリプトは「うっかり直接呼んでしまう」ことへの
+// 防波堤（本来の防御は capture.ts の窓口一本化）なので、意図的な回避までは対象外とする。
+const SET_USER_PATTERN = /Sentry\??\.setUser\s*\(/;
+const IDENTIFY_PATTERN = /posthog\??\.identify\s*\(/;
 
 function isTargetSourceFile(fileName) {
   return /\.(ts|tsx)$/.test(fileName) && !fileName.endsWith('.d.ts');
@@ -74,18 +81,26 @@ for (const target of TARGET_DIRS) {
       const lines = content.split('\n');
       const allowedDirectImport = ALLOWED_DIRECT_IMPORT_FILES.has(filePath);
 
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        if (line.trim().startsWith('//')) continue;
-
-        if (!allowedDirectImport && IMPORT_PATTERN.test(line)) {
+      if (!allowedDirectImport) {
+        // import 文は複数行にまたがりうるため、ファイル全文に対して 's' フラグ付きで検査する
+        // （1行ずつの走査だと `from '...'` が別行にある複数行 import を見逃す）。
+        const importPattern = new RegExp(IMPORT_PATTERN.source, `${IMPORT_PATTERN.flags}g`);
+        for (const match of content.matchAll(importPattern)) {
+          const line = content.slice(0, match.index).split('\n').length;
+          if (lines[line - 1]?.trim().startsWith('//')) continue;
           violations.push({
             file: relative(ROOT, filePath),
-            line: i + 1,
+            line,
             reason: '@sentry/* / posthog-js を直接 import している（src/lib/observability/capture.ts 経由にすること）',
           });
           exitCode = 1;
         }
+      }
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.trim().startsWith('//')) continue;
+
         if (SET_USER_PATTERN.test(line)) {
           violations.push({ file: relative(ROOT, filePath), line: i + 1, reason: 'Sentry.setUser() は全面禁止' });
           exitCode = 1;

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { getSentryDsn } from '@/lib/observability/config';
+import { SHARED_SENTRY_OPTIONS } from '@/lib/observability/sentry-options';
+import { buildServerIntegrations } from '@/lib/observability/sentry-options.server';
+
+// `instrumentation.ts` の register() が DSN ゲートを通過した nodejs runtime でのみこのファイルを
+// import するので、ここでは無条件に init してよい。
+Sentry.init({
+  dsn: getSentryDsn(),
+  integrations: (defaults) => buildServerIntegrations(defaults),
+  ...SHARED_SENTRY_OPTIONS,
+});

--- a/src/hooks/use-read-depth.test.ts
+++ b/src/hooks/use-read-depth.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ObservabilityHandle, registerObservabilityHandle } from '@/lib/observability/capture';
+
+import { useReadDepth } from './use-read-depth';
+
+function setScroll(scrollY: number, scrollHeight: number, clientHeight: number) {
+  Object.defineProperty(window, 'scrollY', { value: scrollY, configurable: true });
+  Object.defineProperty(document.documentElement, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(document.documentElement, 'clientHeight', { value: clientHeight, configurable: true });
+}
+
+describe('useReadDepth', () => {
+  let handle: ObservabilityHandle;
+
+  beforeEach(() => {
+    handle = { capture: vi.fn(), track: vi.fn() };
+    registerObservabilityHandle(handle);
+    // rAF を setTimeout(0) に差し替える。同期実行にすると、フック内の
+    // `rafRef.current = requestAnimationFrame(checkDepth)` の代入が checkDepth 内の
+    // `rafRef.current = null` より後に走ってしまい（cb がコールバック内で先に呼ばれるため）、
+    // 2回目以降の scroll がずっと無視される事故になる（テストでのみ起きる順序問題）。
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number,
+    );
+    setScroll(0, 2000, 1000);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('マウント直後に現在位置の到達度を判定する（スクロール不要な短いページで100%を送る）', () => {
+    setScroll(0, 500, 1000); // scrollHeight <= clientHeight → 常に100%
+    renderHook(() => useReadDepth());
+    expect(handle.track).toHaveBeenCalledWith(expect.objectContaining({ name: 'sheet_read_depth', depthPercent: 100 }));
+  });
+
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it('25/50/75/100% をそれぞれ1回ずつ送る（重複しない）', async () => {
+    renderHook(() => useReadDepth());
+
+    setScroll(250, 2000, 1000); // (250+1000)/2000 = 62.5% → 25・50 が発火
+    window.dispatchEvent(new Event('scroll'));
+    await tick();
+    setScroll(250, 2000, 1000);
+    window.dispatchEvent(new Event('scroll')); // 同じ位置での再発火は増えない
+    await tick();
+
+    setScroll(1000, 2000, 1000); // 100%
+    window.dispatchEvent(new Event('scroll'));
+    await tick();
+
+    const depths = (handle.track as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0].depthPercent);
+    expect(depths).toEqual([25, 50, 75, 100]);
+  });
+
+  it('enabled=false なら一切送らない', () => {
+    renderHook(() => useReadDepth(false));
+    window.dispatchEvent(new Event('scroll'));
+    expect(handle.track).not.toHaveBeenCalled();
+  });
+
+  it('アンマウント後は scroll listener が残らない', () => {
+    const { unmount } = renderHook(() => useReadDepth());
+    unmount();
+    (handle.track as ReturnType<typeof vi.fn>).mockClear();
+    setScroll(1000, 2000, 1000);
+    window.dispatchEvent(new Event('scroll'));
+    expect(handle.track).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-read-depth.test.ts
+++ b/src/hooks/use-read-depth.test.ts
@@ -65,12 +65,13 @@ describe('useReadDepth', () => {
     expect(handle.track).not.toHaveBeenCalled();
   });
 
-  it('アンマウント後は scroll listener が残らない', () => {
+  it('アンマウント後は scroll listener が残らない', async () => {
     const { unmount } = renderHook(() => useReadDepth());
     unmount();
     (handle.track as ReturnType<typeof vi.fn>).mockClear();
     setScroll(1000, 2000, 1000);
     window.dispatchEvent(new Event('scroll'));
+    await tick();
     expect(handle.track).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-read-depth.test.ts
+++ b/src/hooks/use-read-depth.test.ts
@@ -74,4 +74,45 @@ describe('useReadDepth', () => {
     await tick();
     expect(handle.track).not.toHaveBeenCalled();
   });
+
+  function stubResizeObserver(): { fire: () => void } {
+    let callback: (() => void) | undefined;
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(cb: () => void) {
+          callback = cb;
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+    return { fire: () => callback?.() };
+  }
+
+  it('load 完了前の ResizeObserver 通知は無視する（未読込画像による早期到達を防ぐ）', () => {
+    const { fire } = stubResizeObserver();
+    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+    setScroll(1000, 2000, 1000); // 100% 相当（scrollable かつ最下部）
+    renderHook(() => useReadDepth());
+
+    fire(); // load 前の通知は無視されるべき
+    expect(handle.track).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event('load'));
+    expect(handle.track).toHaveBeenCalledWith(expect.objectContaining({ depthPercent: 100 }));
+
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+  });
+
+  it('document の収縮だけを伴う resize 通知は既読度を進めない（セクション OFF 対策）', () => {
+    const { fire } = stubResizeObserver();
+    setScroll(0, 2000, 1000); // マウント時に 25・50% が発火
+    renderHook(() => useReadDepth());
+    (handle.track as ReturnType<typeof vi.fn>).mockClear();
+
+    setScroll(0, 1000, 1000); // scrollHeight が縮む → 見かけ上は 100% だが実際は読んでいない
+    fire();
+    expect(handle.track).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/use-read-depth.test.ts
+++ b/src/hooks/use-read-depth.test.ts
@@ -25,6 +25,10 @@ describe('useReadDepth', () => {
       'requestAnimationFrame',
       (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number,
     );
+    // rAF を setTimeout に差し替えたので、キャンセル側も対応する clearTimeout にする
+    // （jsdom 本来の cancelAnimationFrame は setTimeout の ID を知らず、保留中の
+    // コールバックが cleanup 後も走ってしまい、rafRef の後始末漏れを検出できない）。
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id));
     setScroll(0, 2000, 1000);
   });
 
@@ -63,6 +67,23 @@ describe('useReadDepth', () => {
     renderHook(() => useReadDepth(false));
     window.dispatchEvent(new Event('scroll'));
     expect(handle.track).not.toHaveBeenCalled();
+  });
+
+  it('enabled を false→true に戻したあとも scroll で読了度が進む', async () => {
+    const { rerender } = renderHook(({ enabled }: { enabled: boolean }) => useReadDepth(enabled), {
+      initialProps: { enabled: true },
+    });
+    // 25/50% が mount 時に発火済み。scroll で rAF を予約したまま無効化 → cleanup がキャンセルする。
+    window.dispatchEvent(new Event('scroll'));
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    (handle.track as ReturnType<typeof vi.fn>).mockClear();
+
+    setScroll(1000, 2000, 1000); // 100%
+    window.dispatchEvent(new Event('scroll'));
+    await tick();
+    const depths = (handle.track as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0].depthPercent);
+    expect(depths).toEqual([75, 100]);
   });
 
   it('アンマウント後は scroll listener が残らない', async () => {

--- a/src/hooks/use-read-depth.ts
+++ b/src/hooks/use-read-depth.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+
+import { track } from '@/lib/observability/capture';
+import type { SecondsBucket } from '@/lib/observability/event';
+
+const THRESHOLDS = [25, 50, 75, 100] as const;
+
+const SECONDS_BUCKETS: ReadonlyArray<{ maxMs: number; label: SecondsBucket }> = [
+  { maxMs: 5_000, label: '0-5' },
+  { maxMs: 15_000, label: '5-15' },
+  { maxMs: 30_000, label: '15-30' },
+  { maxMs: 60_000, label: '30-60' },
+];
+
+function secondsBucket(elapsedMs: number): SecondsBucket {
+  const found = SECONDS_BUCKETS.find((b) => elapsedMs < b.maxMs);
+  return found?.label ?? '60+';
+}
+
+function currentScrollPercent(): number {
+  const doc = document.documentElement;
+  const scrollable = doc.scrollHeight - doc.clientHeight;
+  if (scrollable <= 0) return 100;
+  return Math.min(100, Math.round(((window.scrollY + doc.clientHeight) / doc.scrollHeight) * 100));
+}
+
+/**
+ * ページの読了度を 25/50/75/100% の到達時にそれぞれ1回だけ送る（1ページ最大4イベント）。
+ * scroll イベントは高頻度で発火するため rAF で間引く。
+ */
+export function useReadDepth(enabled = true): void {
+  const firedRef = useRef<Set<(typeof THRESHOLDS)[number]>>(new Set());
+  const startedAtRef = useRef(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // スクロール不要なほど短いページなら、マウント直後の1回分の判定で 100% がそのまま送れる。
+    startedAtRef.current = performance.now();
+
+    const checkDepth = () => {
+      rafRef.current = null;
+      const percent = currentScrollPercent();
+      for (const threshold of THRESHOLDS) {
+        if (percent >= threshold && !firedRef.current.has(threshold)) {
+          firedRef.current.add(threshold);
+          track({
+            name: 'sheet_read_depth',
+            depthPercent: threshold,
+            secondsBucket: secondsBucket(performance.now() - startedAtRef.current),
+          });
+        }
+      }
+    };
+
+    const onScroll = () => {
+      if (rafRef.current !== null) return;
+      rafRef.current = requestAnimationFrame(checkDepth);
+    };
+
+    checkDepth();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [enabled]);
+}

--- a/src/hooks/use-read-depth.ts
+++ b/src/hooks/use-read-depth.ts
@@ -53,16 +53,26 @@ export function useReadDepth(enabled = true): void {
       }
     };
 
+    // 未読込の画像は初期レイアウトの高さがほぼ0で、直後に判定すると「スクロール不要な
+    // 短いページ」と誤認して 100% を早期発火してしまう（一度発火した閾値は撤回できない）。
+    // load 完了までは scroll / resize どちらの通知も判定に使わない
+    // （レビュー指摘: ResizeObserver は window の 'load' より前にも初回通知を発火しうる。
+    // load 前提のこの初回判定ガードは scroll にしかかかっていなかった）。
+    let readyForMeasurement = document.readyState === 'complete';
+    let lastScrollHeight = document.documentElement.scrollHeight;
+
     const onScroll = () => {
+      if (!readyForMeasurement) return;
       if (rafRef.current !== null) return;
       rafRef.current = requestAnimationFrame(checkDepth);
     };
 
-    // 未読込の画像は初期レイアウトの高さがほぼ0で、直後に判定すると「スクロール不要な
-    // 短いページ」と誤認して 100% を早期発火してしまう（一度発火した閾値は撤回できない）。
-    // 初回判定だけは読み込み完了まで待つ（読み込み済みなら即座に判定する）。
-    let runInitialCheck = () => checkDepth();
-    if (document.readyState === 'complete') {
+    let runInitialCheck = () => {
+      readyForMeasurement = true;
+      lastScrollHeight = document.documentElement.scrollHeight;
+      checkDepth();
+    };
+    if (readyForMeasurement) {
       checkDepth();
       runInitialCheck = () => {};
     } else {
@@ -70,8 +80,17 @@ export function useReadDepth(enabled = true): void {
     }
 
     // 遅延ロード画像やフォント差し替えなど、load 後もレイアウトが変わりうるケースを拾う
-    // ための継続的な再判定（スクロールしなくても到達度が変わりうる）。
-    const resizeObserver = new ResizeObserver(() => checkDepth());
+    // ための継続的な再判定（スクロールしなくても到達度が変わりうる）。ただし document の
+    // 「成長」だけを再判定のトリガーにする。ダッシュボードでセクションを OFF にする操作は
+    // scrollHeight を縮めるが、これは実際に読んだ量とは無関係で、縮んだ分だけ既読率が
+    // 跳ね上がり不可逆の閾値を誤発火させてしまう（レビュー指摘）。
+    const resizeObserver = new ResizeObserver(() => {
+      if (!readyForMeasurement) return;
+      const { scrollHeight } = document.documentElement;
+      if (scrollHeight <= lastScrollHeight) return;
+      lastScrollHeight = scrollHeight;
+      checkDepth();
+    });
     resizeObserver.observe(document.documentElement);
 
     window.addEventListener('scroll', onScroll, { passive: true });

--- a/src/hooks/use-read-depth.ts
+++ b/src/hooks/use-read-depth.ts
@@ -35,7 +35,7 @@ export function useReadDepth(enabled = true): void {
 
   useEffect(() => {
     if (!enabled) return;
-    // スクロール不要なほど短いページなら、マウント直後の1回分の判定で 100% がそのまま送れる。
+    // スクロール不要なほど短いページなら、初回判定で 100% がそのまま送れる。
     startedAtRef.current = performance.now();
 
     const checkDepth = () => {
@@ -58,10 +58,27 @@ export function useReadDepth(enabled = true): void {
       rafRef.current = requestAnimationFrame(checkDepth);
     };
 
-    checkDepth();
+    // 未読込の画像は初期レイアウトの高さがほぼ0で、直後に判定すると「スクロール不要な
+    // 短いページ」と誤認して 100% を早期発火してしまう（一度発火した閾値は撤回できない）。
+    // 初回判定だけは読み込み完了まで待つ（読み込み済みなら即座に判定する）。
+    let runInitialCheck = () => checkDepth();
+    if (document.readyState === 'complete') {
+      checkDepth();
+      runInitialCheck = () => {};
+    } else {
+      window.addEventListener('load', runInitialCheck, { once: true });
+    }
+
+    // 遅延ロード画像やフォント差し替えなど、load 後もレイアウトが変わりうるケースを拾う
+    // ための継続的な再判定（スクロールしなくても到達度が変わりうる）。
+    const resizeObserver = new ResizeObserver(() => checkDepth());
+    resizeObserver.observe(document.documentElement);
+
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => {
       window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('load', runInitialCheck);
+      resizeObserver.disconnect();
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     };
   }, [enabled]);

--- a/src/hooks/use-read-depth.ts
+++ b/src/hooks/use-read-depth.ts
@@ -86,7 +86,13 @@ export function useReadDepth(enabled = true): void {
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('load', runInitialCheck);
       resizeObserver.disconnect();
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        // 保留中の rAF をキャンセルしたら ID も消し、「rafRef が非 null なら予約中」の不変条件を
+        // cleanup 側でも保つ。実害は無い（enabled を戻した直後の checkDepth() が先頭で null に
+        // するため詰まらない）が、不変条件を1か所の副作用に頼らないための後始末（レビュー指摘）。
+        rafRef.current = null;
+      }
     };
   }, [enabled]);
 }

--- a/src/hooks/use-read-depth.ts
+++ b/src/hooks/use-read-depth.ts
@@ -1,21 +1,9 @@
 import { useEffect, useRef } from 'react';
 
 import { track } from '@/lib/observability/capture';
-import type { SecondsBucket } from '@/lib/observability/event';
+import { toSecondsBucket } from '@/lib/observability/event';
 
 const THRESHOLDS = [25, 50, 75, 100] as const;
-
-const SECONDS_BUCKETS: ReadonlyArray<{ maxMs: number; label: SecondsBucket }> = [
-  { maxMs: 5_000, label: '0-5' },
-  { maxMs: 15_000, label: '5-15' },
-  { maxMs: 30_000, label: '15-30' },
-  { maxMs: 60_000, label: '30-60' },
-];
-
-function secondsBucket(elapsedMs: number): SecondsBucket {
-  const found = SECONDS_BUCKETS.find((b) => elapsedMs < b.maxMs);
-  return found?.label ?? '60+';
-}
 
 function currentScrollPercent(): number {
   const doc = document.documentElement;
@@ -47,7 +35,7 @@ export function useReadDepth(enabled = true): void {
           track({
             name: 'sheet_read_depth',
             depthPercent: threshold,
-            secondsBucket: secondsBucket(performance.now() - startedAtRef.current),
+            secondsBucket: toSecondsBucket(performance.now() - startedAtRef.current),
           });
         }
       }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -25,6 +25,10 @@ const REQUIRED_SERVER_ENV = [
 // GitHub 読み取りは副系統。揃っていなくても致命的ではないので warn 止まり。
 const OPTIONAL_GITHUB_ENV = ['GITHUB_TOKEN', 'GITHUB_OWNER', 'GITHUB_REPO'] as const;
 
+// 設定不備由来のエラーを classifyConfigError() とは別経路で判定するための文言プレフィックス。
+// assertServerEnv() の throw 文言と一字一句一致させること（observability 側の設定不備フィルタが依存する）。
+export const MISSING_SERVER_ENV_PREFIX = '必須のサーバー環境変数が設定されていません';
+
 // `next build` の静的解析フェーズでは secrets が無いのが正常なので検証しない。
 // （Vercel ビルド等で secrets 未注入のまま import されても落とさない）
 function isBuildPhase(): boolean {

--- a/src/lib/observability/capture.test.ts
+++ b/src/lib/observability/capture.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { captureError, captureWarning, type ObservabilityHandle, registerObservabilityHandle, track } from './capture';
+
+const REGISTRY_KEY = Symbol.for('skillsheet.observability');
+
+function clearRegistry(): void {
+  delete (globalThis as Record<symbol, unknown>)[REGISTRY_KEY];
+}
+
+describe('observability capture facade', () => {
+  afterEach(() => {
+    clearRegistry();
+  });
+
+  it('未登録なら captureError は例外を投げず何もしない', () => {
+    expect(() => captureError(new Error('boom'))).not.toThrow();
+  });
+
+  it('未登録なら captureWarning は例外を投げず何もしない', () => {
+    expect(() => captureWarning('degraded')).not.toThrow();
+  });
+
+  it('未登録なら track は例外を投げず何もしない', () => {
+    expect(() => track({ name: 'viewer_auth_submitted', outcome: 'success' })).not.toThrow();
+  });
+
+  it('登録済みなら captureError が level: error で委譲される', () => {
+    const handle: ObservabilityHandle = { capture: vi.fn(), track: vi.fn() };
+    registerObservabilityHandle(handle);
+    const err = new Error('boom');
+    captureError(err, { scope: 'test' });
+    expect(handle.capture).toHaveBeenCalledWith(err, 'error', { scope: 'test' });
+  });
+
+  it('登録済みなら captureWarning が level: warning で委譲される', () => {
+    const handle: ObservabilityHandle = { capture: vi.fn(), track: vi.fn() };
+    registerObservabilityHandle(handle);
+    captureWarning('degraded', { feature: 'auth' });
+    expect(handle.capture).toHaveBeenCalledWith('degraded', 'warning', { feature: 'auth' });
+  });
+
+  it('登録済みなら track がそのまま委譲される', () => {
+    const handle: ObservabilityHandle = { capture: vi.fn(), track: vi.fn() };
+    registerObservabilityHandle(handle);
+    track({ name: 'sheet_view_toggled', view: 'timeline', enabled: true });
+    expect(handle.track).toHaveBeenCalledWith({ name: 'sheet_view_toggled', view: 'timeline', enabled: true });
+  });
+
+  it('この窓口自体は setUser/identify に相当するメソッドを一切持たない', () => {
+    // ObservabilityHandle インターフェースは capture/track の2つしか持たない。
+    // つまりこの窓口経由では、そもそもユーザー識別情報を送る手段が構造的に無い。
+    const handle: ObservabilityHandle = { capture: vi.fn(), track: vi.fn() };
+    expect(Object.keys(handle).sort()).toEqual(['capture', 'track']);
+  });
+});

--- a/src/lib/observability/capture.ts
+++ b/src/lib/observability/capture.ts
@@ -1,0 +1,52 @@
+import type { ObservabilityEvent } from './event';
+
+/**
+ * アプリコードから直接 `@sentry/*` / `posthog-js` を呼ばせないための唯一の窓口。
+ * `scripts/check-telemetry-imports.mjs` がこのファイル以外からの直接 import を lint で禁止する。
+ *
+ * SDK ハンドルはモジュールスコープの変数ではなく `globalThis` に置く。Next はクライアント
+ * バンドルを複数レイヤ（RSC / route handler / client）に分けて処理するため、モジュール
+ * スコープの変数はレイヤをまたいで共有される保証がない。`instrumentation-client.ts` が
+ * Sentry / PostHog を初期化した直後に `registerObservabilityHandle()` でここへ登録する。
+ *
+ * 未登録なら黙って no-op（throw しない）。`useThemeMode()` のような「無いと壊れる」機能とは
+ * 違い、計測が届かないことはアプリの不具合ではない。
+ */
+
+export interface CaptureContext {
+  /** どの境界/処理から呼ばれたか（例: 'route-error-boundary', 'config-error-boundary'）。 */
+  scope?: string;
+  /** 機能単位のタグ（例: 'pdf-export'）。 */
+  feature?: string;
+  /** 同じ原因のエラーをダッシュボード上で1つにまとめるための固定キー。 */
+  fingerprint?: string[];
+}
+
+export interface ObservabilityHandle {
+  capture(error: unknown, level: 'error' | 'warning', context: CaptureContext): void;
+  track(event: ObservabilityEvent): void;
+}
+
+const REGISTRY_KEY = Symbol.for('skillsheet.observability');
+
+type GlobalWithRegistry = typeof globalThis & { [REGISTRY_KEY]?: ObservabilityHandle };
+
+export function registerObservabilityHandle(handle: ObservabilityHandle): void {
+  (globalThis as GlobalWithRegistry)[REGISTRY_KEY] = handle;
+}
+
+function getHandle(): ObservabilityHandle | undefined {
+  return (globalThis as GlobalWithRegistry)[REGISTRY_KEY];
+}
+
+export function captureError(error: unknown, context: CaptureContext = {}): void {
+  getHandle()?.capture(error, 'error', context);
+}
+
+export function captureWarning(error: unknown, context: CaptureContext = {}): void {
+  getHandle()?.capture(error, 'warning', context);
+}
+
+export function track(event: ObservabilityEvent): void {
+  getHandle()?.track(event);
+}

--- a/src/lib/observability/config.test.ts
+++ b/src/lib/observability/config.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getPostHogHost, isPostHogEnabled, isSentryEnabled } from './config';
+
+/**
+ * config.ts は `process.env.NEXT_PUBLIC_*` を関数の中で毎回リテラル参照している
+ * （トップレベル定数にキャッシュしていない）ので、テストごとに `vi.stubEnv` で書き換えれば
+ * モジュールの再 import なしに検証できる。`NODE_ENV` は `@types/node` 上 readonly なので
+ * 直接代入できず、`vi.stubEnv` を使う必要がある。
+ *
+ * vitest は既定で `NODE_ENV=test` を注入する。デプロイ環境ゲート単体を検証するテストは
+ * `NODE_ENV` を明示的に 'production' 相当へ上書きして、test-env ゲートと deploy-env ゲートの
+ * 2つが混ざらないようにする（NODE_ENV=test ゲート自体は専用テストで確認する）。
+ *
+ * `process.env.NEXT_PUBLIC_*` はビルド時に文字列インライン化される（Next の仕様）ため、
+ * ここでの真理値表は「ロジックが正しいか」の保証であって、本番ビルドでの実際の無効化を
+ * 保証しない。本番相当の保証は動作確認手順（DevTools 目視）で行う。
+ */
+describe('observability config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('DSN があっても NEXT_PUBLIC_VERCEL_ENV が無ければ無効', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://example.invalid/1');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', '');
+    vi.stubEnv('NEXT_PUBLIC_OBSERVABILITY_FORCE', '');
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('production かつ DSN ありなら有効', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://example.invalid/1');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+    expect(isSentryEnabled()).toBe(true);
+  });
+
+  it('preview かつ DSN ありなら有効', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://example.invalid/1');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
+    expect(isSentryEnabled()).toBe(true);
+  });
+
+  it('development では FORCE=1 が無い限り無効', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://example.invalid/1');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'development');
+    vi.stubEnv('NEXT_PUBLIC_OBSERVABILITY_FORCE', '');
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('FORCE=1 なら deploy env ゲートを迂回する（ローカル検証用）', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://example.invalid/1');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', '');
+    vi.stubEnv('NEXT_PUBLIC_OBSERVABILITY_FORCE', '1');
+    expect(isSentryEnabled()).toBe(true);
+  });
+
+  it('DSN が空文字なら production でも無効', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', '');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('PostHog も同じゲートを共有する', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+    expect(isPostHogEnabled()).toBe(true);
+  });
+
+  it('NODE_ENV=test では FORCE=1 かつ production 相当でも常に無効', () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://example.invalid/1');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_OBSERVABILITY_FORCE', '1');
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('getPostHogHost は未設定時に既定ホストを返す', () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', '');
+    expect(getPostHogHost()).toBe('https://us.i.posthog.com');
+  });
+});

--- a/src/lib/observability/config.ts
+++ b/src/lib/observability/config.ts
@@ -1,0 +1,52 @@
+/**
+ * Sentry / PostHog のキルスイッチ。
+ *
+ * `process.env.NEXT_PUBLIC_*` は各関数の中で必ずリテラルのプロパティアクセスとして書くこと。
+ * 変数越し（`process.env[key]`）にすると Next のビルド時インライン化が効かず、
+ * クライアントバンドルに `process.env` オブジェクトそのものを持ち込もうとして壊れる。
+ *
+ * このモジュールは絶対にログを出さない。キルスイッチ自身が診断のノイズ源になってはいけない。
+ */
+
+function isTestEnv(): boolean {
+  return process.env.NODE_ENV === 'test';
+}
+
+function isWebdriver(): boolean {
+  return typeof navigator !== 'undefined' && navigator.webdriver === true;
+}
+
+/**
+ * `NEXT_PUBLIC_VERCEL_ENV` は Vercel のビルド時にのみ注入される（ローカル・CI では undefined）。
+ * これ自体が「ローカル/CI では無効」というキルスイッチとして機能する
+ * （ローカル e2e が本番 Neon に書いた事故と同じ機構を、ここで構造的に塞ぐ）。
+ */
+function isDeployEnvAllowed(): boolean {
+  if (process.env.NEXT_PUBLIC_OBSERVABILITY_FORCE === '1') return true;
+  const env = process.env.NEXT_PUBLIC_VERCEL_ENV;
+  return env === 'production' || env === 'preview';
+}
+
+export function isSentryEnabled(): boolean {
+  if (isTestEnv() || isWebdriver()) return false;
+  if (!isDeployEnvAllowed()) return false;
+  return typeof process.env.NEXT_PUBLIC_SENTRY_DSN === 'string' && process.env.NEXT_PUBLIC_SENTRY_DSN.length > 0;
+}
+
+export function isPostHogEnabled(): boolean {
+  if (isTestEnv() || isWebdriver()) return false;
+  if (!isDeployEnvAllowed()) return false;
+  return typeof process.env.NEXT_PUBLIC_POSTHOG_KEY === 'string' && process.env.NEXT_PUBLIC_POSTHOG_KEY.length > 0;
+}
+
+export function getSentryDsn(): string | undefined {
+  return process.env.NEXT_PUBLIC_SENTRY_DSN;
+}
+
+export function getPostHogKey(): string | undefined {
+  return process.env.NEXT_PUBLIC_POSTHOG_KEY;
+}
+
+export function getPostHogHost(): string {
+  return process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
+}

--- a/src/lib/observability/event.test.ts
+++ b/src/lib/observability/event.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type { ViewKey } from '@/components/viewer-topbar';
+
+import { toSecondsBucket, type ViewToggleKey } from './event';
+
+describe('ViewToggleKey', () => {
+  it('viewer-topbar.tsx の ViewKey と値の集合が一致する（依存方向を守るため複製している）', () => {
+    // 型レベルの検査。片方だけに値を足すと tsc（pnpm type-check）がここで落ちる。
+    expectTypeOf<ViewKey>().toEqualTypeOf<ViewToggleKey>();
+  });
+});
+
+describe('toSecondsBucket', () => {
+  it.each([
+    [0, '0-5'],
+    [4_999, '0-5'],
+    [5_000, '5-15'],
+    [14_999, '5-15'],
+    [15_000, '15-30'],
+    [29_999, '15-30'],
+    [30_000, '30-60'],
+    [59_999, '30-60'],
+    [60_000, '60+'],
+    [3_600_000, '60+'],
+  ] as const)('%d ms → %s', (ms, expected) => {
+    expect(toSecondsBucket(ms)).toBe(expected);
+  });
+});

--- a/src/lib/observability/event.ts
+++ b/src/lib/observability/event.ts
@@ -7,7 +7,10 @@
  */
 export type ViewKind = 'markdown' | 'dashboard';
 export type SheetSource = 'db' | 'github';
-export type ViewToggleKey = 'timeline' | 'summary' | 'detail';
+// src/components/viewer-topbar.tsx の ViewKey と同じ値。型を直接 import すると
+// components → lib/observability の依存方向が逆転するので、値の集合だけを複製する
+// （viewer-topbar.tsx 側を変えたらここも変えること。テストで揃っているかを検査する）。
+export type ViewToggleKey = 'skills' | 'process' | 'projects' | 'timeline';
 export type PdfResult = 'success' | 'failure';
 export type PdfFailureReason = 'TypeError' | 'RangeError' | 'FetchError' | 'Error' | 'unknown';
 export type SecondsBucket = '0-5' | '5-15' | '15-30' | '30-60' | '60+';

--- a/src/lib/observability/event.ts
+++ b/src/lib/observability/event.ts
@@ -9,12 +9,26 @@ export type ViewKind = 'markdown' | 'dashboard';
 export type SheetSource = 'db' | 'github';
 // src/components/viewer-topbar.tsx の ViewKey と同じ値。型を直接 import すると
 // components → lib/observability の依存方向が逆転するので、値の集合だけを複製する
-// （viewer-topbar.tsx 側を変えたらここも変えること。テストで揃っているかを検査する）。
+// （viewer-topbar.tsx 側を変えたらここも変えること。両者が一致するかは event.test.ts の
+// 型テストが検査する）。
 export type ViewToggleKey = 'skills' | 'process' | 'projects' | 'timeline';
 export type PdfResult = 'success' | 'failure';
 export type PdfFailureReason = 'TypeError' | 'RangeError' | 'FetchError' | 'Error' | 'unknown';
 export type SecondsBucket = '0-5' | '5-15' | '15-30' | '30-60' | '60+';
 export type ViewerAuthOutcome = 'success' | 'invalid_code' | 'rate_limited' | 'error';
+
+const SECONDS_BUCKETS: ReadonlyArray<{ maxMs: number; label: SecondsBucket }> = [
+  { maxMs: 5_000, label: '0-5' },
+  { maxMs: 15_000, label: '5-15' },
+  { maxMs: 30_000, label: '15-30' },
+  { maxMs: 60_000, label: '30-60' },
+];
+
+/** 経過ミリ秒を SecondsBucket に丸める。読了時間（use-read-depth）と PDF 生成時間で同じ区切りを使う。 */
+export function toSecondsBucket(elapsedMs: number): SecondsBucket {
+  const found = SECONDS_BUCKETS.find((b) => elapsedMs < b.maxMs);
+  return found?.label ?? '60+';
+}
 
 export type ObservabilityEvent =
   | { name: 'sheet_viewed'; layout: ViewKind; source: SheetSource; blockCount: number }

--- a/src/lib/observability/event.ts
+++ b/src/lib/observability/event.ts
@@ -1,0 +1,21 @@
+/**
+ * 手動 capture するイベントの閉じた判別共用体。
+ *
+ * enum 以外に `string` を置かない。シート名・ファイル名・エラーメッセージ本文のような
+ * 「書けてしまう」自由文字列を型から締め出す。新しいイベントを足すときも、
+ * プロパティ型に `string` を書きたくなったら enum に変換できないか先に考えること。
+ */
+export type ViewKind = 'markdown' | 'dashboard';
+export type SheetSource = 'db' | 'github';
+export type ViewToggleKey = 'timeline' | 'summary' | 'detail';
+export type PdfResult = 'success' | 'failure';
+export type PdfFailureReason = 'TypeError' | 'RangeError' | 'FetchError' | 'Error' | 'unknown';
+export type SecondsBucket = '0-5' | '5-15' | '15-30' | '30-60' | '60+';
+export type ViewerAuthOutcome = 'success' | 'invalid_code' | 'rate_limited' | 'error';
+
+export type ObservabilityEvent =
+  | { name: 'sheet_viewed'; layout: ViewKind; source: SheetSource; blockCount: number }
+  | { name: 'sheet_read_depth'; depthPercent: 25 | 50 | 75 | 100; secondsBucket: SecondsBucket }
+  | { name: 'sheet_view_toggled'; view: ViewToggleKey; enabled: boolean }
+  | { name: 'pdf_exported'; result: PdfResult; durationBucket: SecondsBucket; reason?: PdfFailureReason }
+  | { name: 'viewer_auth_submitted'; outcome: ViewerAuthOutcome };

--- a/src/lib/observability/scrub.test.ts
+++ b/src/lib/observability/scrub.test.ts
@@ -81,6 +81,15 @@ describe('redactFreeText', () => {
   it('既知ルートに一致しない "/" は無関係な文字列として壊さない', () => {
     expect(redactFreeText('3/4 done, review and/or approve')).toBe('3/4 done, review and/or approve');
   });
+
+  it('/viewer-auth のクエリも落とす（/view が接頭辞一致して残る回帰の防止）', () => {
+    expect(redactFreeText('fetch failed: /viewer-auth?code=1234')).toBe('fetch failed: /[route:viewer-auth]');
+    expect(redactFreeText('redirect: /viewer-auth?next=/view/機密.md')).toBe('redirect: /[route:viewer-auth]');
+  });
+
+  it('既知ルート名を接頭辞に持つだけの別パスは丸めない', () => {
+    expect(redactFreeText('see /views/x and /viewer-authx')).toBe('see /views/x and /viewer-authx');
+  });
 });
 
 describe('scrubBreadcrumb', () => {
@@ -143,6 +152,19 @@ describe('scrubSentryEvent', () => {
       exception: { values: [{ value: 'Failed to load sheet: 技術スキルシート.md' }] },
     });
     expect(result.exception?.values?.[0].value).toBe('Failed to load sheet: [redacted.md]');
+  });
+
+  it('transaction をルート名に丸める（サーバーはメソッド付き・クライアントはパスのみ）', () => {
+    expect(scrubSentryEvent({ transaction: 'GET /view/技術スキルシート.md' }).transaction).toBe(
+      'GET /[route:view-sheet]',
+    );
+    expect(scrubSentryEvent({ transaction: '/view/db/550e8400-e29b-41d4-a716-446655440000' }).transaction).toBe(
+      '/[route:view-db-sheet]',
+    );
+  });
+
+  it('parameterize 済みの transaction も同じルート名に落ちる', () => {
+    expect(scrubSentryEvent({ transaction: 'GET /view/[path]' }).transaction).toBe('GET /[route:view-sheet]');
   });
 
   it('user は常に落とす（setUser を呼んでいなくても防御）', () => {

--- a/src/lib/observability/scrub.test.ts
+++ b/src/lib/observability/scrub.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactFreeText, scrubBreadcrumb, scrubSentryEvent, toRouteName } from './scrub';
+
+describe('toRouteName', () => {
+  it.each([
+    ['/', 'home'],
+    ['/view', 'view-index'],
+    ['/view/', 'view-index'],
+    ['/view/技術スキルシート.md', 'view-sheet'],
+    ['/view/db', 'view-db-index'],
+    ['/view/db/abcd1234', 'view-db-sheet'],
+    ['/viewer-auth', 'viewer-auth'],
+    ['/login', 'login'],
+    ['/builder', 'builder'],
+    ['/builder/preview', 'builder-preview'],
+    ['/api/auth/callback/google', 'api-auth'],
+    ['/api/logout', 'api-logout'],
+    ['/api/revalidate', 'api-revalidate'],
+    ['/api/trpc/auth.login', 'api-trpc'],
+    ['/some/unknown/path', 'other'],
+    ['not a url at all ///', 'other'],
+  ] as const)('%s → %s', (input, expected) => {
+    expect(toRouteName(input)).toBe(expected);
+  });
+
+  it('絶対 URL でも pathname を見て判定する', () => {
+    expect(toRouteName('https://example.com/view/機密案件.md?x=1')).toBe('view-sheet');
+  });
+});
+
+describe('redactFreeText', () => {
+  it('.md ファイル名を潰す', () => {
+    expect(redactFreeText('Failed to load sheet: 技術スキルシート.md')).toBe('Failed to load sheet: [redacted.md]');
+  });
+
+  it('UUID を潰す', () => {
+    expect(redactFreeText('id=550e8400-e29b-41d4-a716-446655440000')).toBe('id=[redacted-uuid]');
+  });
+
+  it('メールアドレスを潰す', () => {
+    expect(redactFreeText('contact kouiso@ritmo.co.jp for access')).toBe('contact [redacted-email] for access');
+  });
+
+  it('32文字以上の英数トークンを潰す', () => {
+    const token = 'a'.repeat(40);
+    expect(redactFreeText(`token=${token}`)).toBe('token=[redacted-token]');
+  });
+
+  it('300字を超えたら切り詰める', () => {
+    // 英数字だと LONG_TOKEN_PATTERN に丸ごと食われて短くなってしまうため、
+    // 他のパターンに一切マッチしない文字（日本語の繰り返し）で長さだけを検証する。
+    const long = 'あ'.repeat(400);
+    const result = redactFreeText(long);
+    expect(result.length).toBeLessThanOrEqual(301);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('該当しない文字列はそのまま', () => {
+    expect(redactFreeText('plain error message')).toBe('plain error message');
+  });
+});
+
+describe('scrubBreadcrumb', () => {
+  it('history breadcrumb の to/from をルート名に丸める（罠4）', () => {
+    const result = scrubBreadcrumb({
+      category: 'navigation',
+      data: { to: '/view/技術スキルシート.md', from: '/view' },
+    });
+    expect(result.data?.to).toBe('/[route:view-sheet]');
+    expect(result.data?.from).toBe('/[route:view-index]');
+  });
+
+  it('http breadcrumb の url を GitHub のファイルパスごと丸める（罠3の二重化）', () => {
+    const result = scrubBreadcrumb({
+      category: 'http',
+      data: { url: 'https://api.github.com/repos/kouiso/private/contents/技術スキルシート.md?ref=main' },
+    });
+    expect(result.data?.url).toBe('/[route:other]');
+  });
+
+  it('message も redactFreeText を通す', () => {
+    const result = scrubBreadcrumb({ category: 'console', message: 'Failed to load sheet: 案件A社.md' });
+    expect(result.message).toBe('Failed to load sheet: [redacted.md]');
+  });
+
+  it('元のオブジェクトを変更しない', () => {
+    const original = { category: 'navigation', data: { to: '/view/x.md' } };
+    scrubBreadcrumb(original);
+    expect(original.data.to).toBe('/view/x.md');
+  });
+});
+
+describe('scrubSentryEvent', () => {
+  it('request.url をルート名に丸め、query/cookie/header を落とす（罠1の防御深化）', () => {
+    const result = scrubSentryEvent({
+      request: {
+        url: 'https://skillsheet.example/view/技術スキルシート.md?foo=bar',
+        query_string: 'foo=bar',
+        cookies: 'session=abc',
+        headers: { cookie: 'session=abc' },
+      },
+    });
+    expect(result.request?.url).toBe('/[route:view-sheet]');
+    expect(result.request?.query_string).toBeUndefined();
+    expect(result.request?.cookies).toBeUndefined();
+    expect(result.request?.headers).toBeUndefined();
+  });
+
+  it('contexts.nextjs.request_path をルート名に丸める（罠1: raw path + query string 対策）', () => {
+    const result = scrubSentryEvent({
+      contexts: { nextjs: { request_path: '/view/技術スキルシート.md?token=abc' } },
+    });
+    expect(result.contexts?.nextjs?.request_path).toBe('/[route:view-sheet]');
+  });
+
+  it('exception.values[].value を redactFreeText する', () => {
+    const result = scrubSentryEvent({
+      exception: { values: [{ type: 'Error', value: 'Failed to load sheet: 技術スキルシート.md' }] },
+    });
+    expect(result.exception?.values?.[0].value).toBe('Failed to load sheet: [redacted.md]');
+  });
+
+  it('user は常に落とす（setUser を呼んでいなくても防御）', () => {
+    const result = scrubSentryEvent({ user: { id: 'abc', email: 'kouiso@ritmo.co.jp' } });
+    expect(result.user).toBeUndefined();
+  });
+
+  it('breadcrumbs も丸ごと scrub する', () => {
+    const result = scrubSentryEvent({
+      breadcrumbs: [{ category: 'navigation', data: { to: '/view/x.md' } }],
+    });
+    expect(result.breadcrumbs?.[0].data?.to).toBe('/[route:view-sheet]');
+  });
+
+  it('該当フィールドが無いイベントはそのまま通す', () => {
+    const result = scrubSentryEvent({ message: 'plain' });
+    expect(result.message).toBe('plain');
+  });
+});

--- a/src/lib/observability/scrub.test.ts
+++ b/src/lib/observability/scrub.test.ts
@@ -73,6 +73,14 @@ describe('redactFreeText', () => {
   it('該当しない文字列はそのまま', () => {
     expect(redactFreeText('plain error message')).toBe('plain error message');
   });
+
+  it('絶対 URL を経由しない相対パスのクエリ文字列（閲覧コード等）も落とす', () => {
+    expect(redactFreeText('fetch failed: /view/a.md?viewer_code=1234')).toBe('fetch failed: /[route:view-sheet]');
+  });
+
+  it('既知ルートに一致しない "/" は無関係な文字列として壊さない', () => {
+    expect(redactFreeText('3/4 done, review and/or approve')).toBe('3/4 done, review and/or approve');
+  });
 });
 
 describe('scrubBreadcrumb', () => {

--- a/src/lib/observability/scrub.test.ts
+++ b/src/lib/observability/scrub.test.ts
@@ -56,6 +56,20 @@ describe('redactFreeText', () => {
     expect(result.endsWith('…')).toBe(true);
   });
 
+  it('Drizzle の DrizzleQueryError（params 以降に職務経歴書の本文が入りうる）を潰す', () => {
+    const message =
+      'Failed query: update "blocks" set "content" = $1 where "id" = $2\nparams: 案件A社の機密プロジェクト詳細,42';
+    expect(redactFreeText(message)).toBe(
+      'Failed query: update "blocks" set "content" = $1 where "id" = $2\nparams: [redacted]',
+    );
+  });
+
+  it('URL をルート名 placeholder に丸める（クエリ文字列の閲覧コード等ごと落とす）', () => {
+    expect(redactFreeText('fetch failed: https://skillsheet.example/view/a.md?viewer_code=1234')).toBe(
+      'fetch failed: /[route:view-sheet]',
+    );
+  });
+
   it('該当しない文字列はそのまま', () => {
     expect(redactFreeText('plain error message')).toBe('plain error message');
   });

--- a/src/lib/observability/scrub.test.ts
+++ b/src/lib/observability/scrub.test.ts
@@ -111,12 +111,14 @@ describe('scrubSentryEvent', () => {
     const result = scrubSentryEvent({
       contexts: { nextjs: { request_path: '/view/技術スキルシート.md?token=abc' } },
     });
-    expect(result.contexts?.nextjs?.request_path).toBe('/[route:view-sheet]');
+    expect((result.contexts?.nextjs as { request_path?: string } | undefined)?.request_path).toBe(
+      '/[route:view-sheet]',
+    );
   });
 
   it('exception.values[].value を redactFreeText する', () => {
     const result = scrubSentryEvent({
-      exception: { values: [{ type: 'Error', value: 'Failed to load sheet: 技術スキルシート.md' }] },
+      exception: { values: [{ value: 'Failed to load sheet: 技術スキルシート.md' }] },
     });
     expect(result.exception?.values?.[0].value).toBe('Failed to load sheet: [redacted.md]');
   });

--- a/src/lib/observability/scrub.ts
+++ b/src/lib/observability/scrub.ts
@@ -56,15 +56,24 @@ const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{1
 const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/gu;
 // 32文字以上の英数字/ハイフン/ドット/アンダースコア連続はトークン・ハッシュ・署名とみなす。
 const LONG_TOKEN_PATTERN = /[A-Za-z0-9_.-]{32,}/gu;
+// http(s) URL はクエリ文字列（閲覧コード等）や動的セグメント（シート名）を運びうるので、
+// ルート名 enum の placeholder に丸める（ファイル名 replace 等より先に、まるごと1回で処理する）。
+const URL_PATTERN = /https?:\/\/[^\s"'<>)]+/giu;
+// Drizzle の `DrizzleQueryError` は `Failed query: <sql>\nparams: <値>` という形式で、
+// params 以降に職務経歴書の本文（会社名・案件名等）がそのまま入る。SQL 本体はプレースホルダ
+// （$1, $2 ...）だけで実データを持たないため、params 以降だけを丸ごと落とす。
+const DRIZZLE_PARAMS_PATTERN = /\bparams:[\s\S]*$/u;
 const MAX_LENGTH = 300;
 
 /**
- * 自由記述文字列（エラーメッセージ等）からファイル名・UUID・メールアドレス・長いトークンを
- * 潰し、300字で切る。イベントの enum フィールドではなく、Sentry の message/value 等
- * SDK が自動で埋める自由記述部にだけ使う最終防衛line。
+ * 自由記述文字列（エラーメッセージ等）から DB クエリパラメータ・URL・ファイル名・UUID・
+ * メールアドレス・長いトークンを潰し、300字で切る。イベントの enum フィールドではなく、
+ * Sentry の message/value 等 SDK が自動で埋める自由記述部にだけ使う最終防衛line。
  */
 export function redactFreeText(input: string): string {
   const redacted = input
+    .replace(DRIZZLE_PARAMS_PATTERN, 'params: [redacted]')
+    .replace(URL_PATTERN, (url) => toRoutePlaceholder(url))
     .replace(MARKDOWN_FILENAME_PATTERN, '[redacted.md]')
     .replace(UUID_PATTERN, '[redacted-uuid]')
     .replace(EMAIL_PATTERN, '[redacted-email]')
@@ -106,6 +115,25 @@ function toRoutePlaceholder(rawUrl: string): string {
   return `/[route:${toRouteName(rawUrl)}]`;
 }
 
+const ROUTE_LIKE_KEYS = new Set(['to', 'from', 'url']);
+
+/**
+ * breadcrumb.data の値を再帰的に潰す。XHR/fetch breadcrumb 等はネストした object/array で
+ * 実データ（URL・レスポンス本文の断片）を運びうるため、トップレベルの文字列だけでは足りない。
+ */
+function scrubValue(key: string, value: unknown): unknown {
+  if (typeof value === 'string') {
+    return ROUTE_LIKE_KEYS.has(key) ? toRoutePlaceholder(value) : redactFreeText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => scrubValue(key, v));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, scrubValue(k, v)]));
+  }
+  return value;
+}
+
 /**
  * サーバー breadcrumb（GitHub の URL・シートファイル名を含みうる）とクライアント
  * breadcrumb（history の to/from）の両方に効く最終防衛line。個別の integration 設定
@@ -117,19 +145,7 @@ export function scrubBreadcrumb(breadcrumb: ScrubbableBreadcrumb): ScrubbableBre
     next.message = redactFreeText(next.message);
   }
   if (next.data && typeof next.data === 'object') {
-    const data: Record<string, unknown> = { ...next.data };
-    for (const key of ['to', 'from', 'url'] as const) {
-      const value = data[key];
-      if (typeof value === 'string') {
-        data[key] = toRoutePlaceholder(value);
-      }
-    }
-    for (const [key, value] of Object.entries(data)) {
-      if (typeof value === 'string' && key !== 'to' && key !== 'from' && key !== 'url') {
-        data[key] = redactFreeText(value);
-      }
-    }
-    next.data = data;
+    next.data = Object.fromEntries(Object.entries(next.data).map(([k, v]) => [k, scrubValue(k, v)]));
   }
   return next;
 }

--- a/src/lib/observability/scrub.ts
+++ b/src/lib/observability/scrub.ts
@@ -1,0 +1,183 @@
+/**
+ * SDK 非依存の純関数群。Sentry / PostHog どちらの型にも依存しない
+ * （テストがベンダー SDK 無しで完結し、将来ベンダーを替えても流用できる）。
+ */
+
+const KNOWN_ROUTES: ReadonlyArray<{ name: RouteName; test: (path: string) => boolean }> = [
+  { name: 'home', test: (p) => p === '/' },
+  { name: 'view-db-sheet', test: (p) => /^\/view\/db\/[^/]+\/?$/u.test(p) },
+  { name: 'view-db-index', test: (p) => /^\/view\/db\/?$/u.test(p) },
+  { name: 'view-sheet', test: (p) => /^\/view\/[^/]+\/?$/u.test(p) },
+  { name: 'view-index', test: (p) => /^\/view\/?$/u.test(p) },
+  { name: 'viewer-auth', test: (p) => /^\/viewer-auth\/?$/u.test(p) },
+  { name: 'login', test: (p) => /^\/login\/?$/u.test(p) },
+  { name: 'builder-preview', test: (p) => /^\/builder\/preview\/?$/u.test(p) },
+  { name: 'builder', test: (p) => /^\/builder\/?$/u.test(p) },
+  { name: 'api-auth', test: (p) => /^\/api\/auth(\/.*)?$/u.test(p) },
+  { name: 'api-logout', test: (p) => /^\/api\/logout\/?$/u.test(p) },
+  { name: 'api-revalidate', test: (p) => /^\/api\/revalidate\/?$/u.test(p) },
+  { name: 'api-trpc', test: (p) => /^\/api\/trpc(\/.*)?$/u.test(p) },
+];
+
+export type RouteName =
+  | 'home'
+  | 'view-index'
+  | 'view-sheet'
+  | 'view-db-index'
+  | 'view-db-sheet'
+  | 'viewer-auth'
+  | 'login'
+  | 'builder'
+  | 'builder-preview'
+  | 'api-auth'
+  | 'api-logout'
+  | 'api-revalidate'
+  | 'api-trpc'
+  | 'other';
+
+/**
+ * パスを既知ルートの enum に丸める。既知ルートへのマッピングのみを持ち、
+ * 未知のパスは無条件で `'other'` にする（除外パターンの正規表現だと、
+ * 想定していないパス — まさにシート名を含む動的セグメント — がそのまま漏れる）。
+ */
+export function toRouteName(pathname: string): RouteName {
+  let path: string;
+  try {
+    path = pathname.startsWith('/') ? pathname : new URL(pathname).pathname;
+  } catch {
+    return 'other';
+  }
+  const match = KNOWN_ROUTES.find((r) => r.test(path));
+  return match?.name ?? 'other';
+}
+
+const MARKDOWN_FILENAME_PATTERN = /[^\s/]+\.md\b/giu;
+const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/giu;
+const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/gu;
+// 32文字以上の英数字/ハイフン/ドット/アンダースコア連続はトークン・ハッシュ・署名とみなす。
+const LONG_TOKEN_PATTERN = /[A-Za-z0-9_.-]{32,}/gu;
+const MAX_LENGTH = 300;
+
+/**
+ * 自由記述文字列（エラーメッセージ等）からファイル名・UUID・メールアドレス・長いトークンを
+ * 潰し、300字で切る。イベントの enum フィールドではなく、Sentry の message/value 等
+ * SDK が自動で埋める自由記述部にだけ使う最終防衛line。
+ */
+export function redactFreeText(input: string): string {
+  const redacted = input
+    .replace(MARKDOWN_FILENAME_PATTERN, '[redacted.md]')
+    .replace(UUID_PATTERN, '[redacted-uuid]')
+    .replace(EMAIL_PATTERN, '[redacted-email]')
+    .replace(LONG_TOKEN_PATTERN, '[redacted-token]');
+  return redacted.length > MAX_LENGTH ? `${redacted.slice(0, MAX_LENGTH)}…` : redacted;
+}
+
+/**
+ * Sentry の実 Event 型を import せず、必要なフィールドだけの構造的部分型で受ける。
+ * `@sentry/nextjs` を追加する前（step1）でもコンパイルできるようにするため。
+ * 実際の `Sentry.Event` はこの部分型のスーパーセットなので、そのまま渡せる。
+ */
+export interface ScrubbableSentryEvent {
+  message?: string;
+  request?: {
+    url?: string;
+    query_string?: unknown;
+    cookies?: unknown;
+    headers?: unknown;
+  };
+  contexts?: {
+    nextjs?: { request_path?: string; [key: string]: unknown };
+    [key: string]: unknown;
+  };
+  exception?: {
+    values?: Array<{ value?: string; [key: string]: unknown }>;
+  };
+  user?: unknown;
+  breadcrumbs?: ScrubbableBreadcrumb[];
+  [key: string]: unknown;
+}
+
+export interface ScrubbableBreadcrumb {
+  category?: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function toRoutePlaceholder(rawUrl: string): string {
+  return `/[route:${toRouteName(rawUrl)}]`;
+}
+
+/**
+ * サーバー breadcrumb（GitHub の URL・シートファイル名を含みうる）とクライアント
+ * breadcrumb（history の to/from）の両方に効く最終防衛line。個別の integration 設定
+ * （httpIntegration({breadcrumbs:false}) 等）が主防御で、これは二重化。
+ */
+export function scrubBreadcrumb<T extends ScrubbableBreadcrumb>(breadcrumb: T): T {
+  const next: T = { ...breadcrumb };
+  if (typeof next.message === 'string') {
+    next.message = redactFreeText(next.message);
+  }
+  if (next.data && typeof next.data === 'object') {
+    const data: Record<string, unknown> = { ...next.data };
+    for (const key of ['to', 'from', 'url'] as const) {
+      const value = data[key];
+      if (typeof value === 'string') {
+        data[key] = toRoutePlaceholder(value);
+      }
+    }
+    for (const [key, value] of Object.entries(data)) {
+      if (typeof value === 'string' && key !== 'to' && key !== 'from' && key !== 'url') {
+        data[key] = redactFreeText(value);
+      }
+    }
+    next.data = data;
+  }
+  return next;
+}
+
+/**
+ * PII の最終防衛line。個々の integration 設定・breadcrumb 無効化が主防御で、
+ * これは「それでも漏れたら」を潰す二重化。request のユーザー識別情報は丸ごと落とす。
+ */
+export function scrubSentryEvent<T extends ScrubbableSentryEvent>(event: T): T {
+  const next: T = { ...event };
+
+  if (typeof next.message === 'string') {
+    next.message = redactFreeText(next.message);
+  }
+
+  if (next.request) {
+    const { url } = next.request;
+    next.request = {
+      url: typeof url === 'string' ? toRoutePlaceholder(url) : undefined,
+      // query string・cookie・header は識別情報の塊なので丸ごと落とす。
+    };
+  }
+
+  if (next.contexts?.nextjs?.request_path) {
+    next.contexts = {
+      ...next.contexts,
+      nextjs: { ...next.contexts.nextjs, request_path: toRoutePlaceholder(next.contexts.nextjs.request_path) },
+    };
+  }
+
+  if (next.exception?.values) {
+    next.exception = {
+      ...next.exception,
+      values: next.exception.values.map((v) =>
+        typeof v.value === 'string' ? { ...v, value: redactFreeText(v.value) } : v,
+      ),
+    };
+  }
+
+  if ('user' in next) {
+    next.user = undefined;
+  }
+
+  if (next.breadcrumbs) {
+    next.breadcrumbs = next.breadcrumbs.map(scrubBreadcrumb);
+  }
+
+  return next;
+}

--- a/src/lib/observability/scrub.ts
+++ b/src/lib/observability/scrub.ts
@@ -59,6 +59,12 @@ const LONG_TOKEN_PATTERN = /[A-Za-z0-9_.-]{32,}/gu;
 // http(s) URL はクエリ文字列（閲覧コード等）や動的セグメント（シート名）を運びうるので、
 // ルート名 enum の placeholder に丸める（ファイル名 replace 等より先に、まるごと1回で処理する）。
 const URL_PATTERN = /https?:\/\/[^\s"'<>)]+/giu;
+// 絶対 URL を経由しない相対パス（fetch failed: /view/a.md?viewer_code=1234 等）も
+// クエリ文字列を運びうる。既知ルートの接頭辞に一致する場合のみルート名 enum に丸める
+// （任意の "/" を丸めると "3/4" のような無関係な文字列まで壊すため、既知ルートに限定する）。
+// 直前が単語文字だと絶対 URL のパス部分（ドメイン直後の "/"）を二重処理してしまうため除外する。
+const RELATIVE_ROUTE_PATTERN =
+  /(?<![\w-])\/(?:view\/db|view|viewer-auth|login|builder\/preview|builder|api\/auth|api\/logout|api\/revalidate|api\/trpc)(?:\/[^\s?#"'<>)]*)?(?:\?[^\s#"'<>)]*)?(?:#[^\s"'<>)]*)?/gu;
 // Drizzle の `DrizzleQueryError` は `Failed query: <sql>\nparams: <値>` という形式で、
 // params 以降に職務経歴書の本文（会社名・案件名等）がそのまま入る。SQL 本体はプレースホルダ
 // （$1, $2 ...）だけで実データを持たないため、params 以降だけを丸ごと落とす。
@@ -74,6 +80,7 @@ export function redactFreeText(input: string): string {
   const redacted = input
     .replace(DRIZZLE_PARAMS_PATTERN, 'params: [redacted]')
     .replace(URL_PATTERN, (url) => toRoutePlaceholder(url))
+    .replace(RELATIVE_ROUTE_PATTERN, (route) => toRoutePlaceholder(route.split(/[?#]/, 1)[0]))
     .replace(MARKDOWN_FILENAME_PATTERN, '[redacted.md]')
     .replace(UUID_PATTERN, '[redacted-uuid]')
     .replace(EMAIL_PATTERN, '[redacted-email]')

--- a/src/lib/observability/scrub.ts
+++ b/src/lib/observability/scrub.ts
@@ -63,8 +63,11 @@ const URL_PATTERN = /https?:\/\/[^\s"'<>)]+/giu;
 // クエリ文字列を運びうる。既知ルートの接頭辞に一致する場合のみルート名 enum に丸める
 // （任意の "/" を丸めると "3/4" のような無関係な文字列まで壊すため、既知ルートに限定する）。
 // 直前が単語文字だと絶対 URL のパス部分（ドメイン直後の "/"）を二重処理してしまうため除外する。
+// 候補は長いものを先に並べ、接頭辞の直後に境界（/ ? # 空白 引用符 括弧 末尾）を要求する。
+// 順序だけに頼ると `view|viewer-auth` の順で `/viewer-auth?code=...` が `/view` で確定して
+// 後続の `er-auth?code=...` がそのまま残っていた（レビュー指摘）。
 const RELATIVE_ROUTE_PATTERN =
-  /(?<![\w-])\/(?:view\/db|view|viewer-auth|login|builder\/preview|builder|api\/auth|api\/logout|api\/revalidate|api\/trpc)(?:\/[^\s?#"'<>)]*)?(?:\?[^\s#"'<>)]*)?(?:#[^\s"'<>)]*)?/gu;
+  /(?<![\w-])\/(?:view\/db|viewer-auth|view|builder\/preview|builder|login|api\/auth|api\/logout|api\/revalidate|api\/trpc)(?=[/?#\s"'<>)]|$)(?:\/[^\s?#"'<>)]*)?(?:\?[^\s#"'<>)]*)?(?:#[^\s"'<>)]*)?/gu;
 // Drizzle の `DrizzleQueryError` は `Failed query: <sql>\nparams: <値>` という形式で、
 // params 以降に職務経歴書の本文（会社名・案件名等）がそのまま入る。SQL 本体はプレースホルダ
 // （$1, $2 ...）だけで実データを持たないため、params 以降だけを丸ごと落とす。
@@ -95,6 +98,12 @@ export function redactFreeText(input: string): string {
  */
 export interface ScrubbableSentryEvent {
   message?: string;
+  /**
+   * サーバーでは httpIntegration が isolation scope に `GET /view/<生パス>` を setTransactionName し、
+   * クライアントでは browserTracingIntegration が pageload の pathname を入れる。どちらも
+   * error event の `transaction` に転記される（scope データは type !== 'transaction' の event にも乗る）。
+   */
+  transaction?: string;
   request?: {
     url?: string;
     query_string?: unknown;
@@ -120,6 +129,17 @@ export interface ScrubbableBreadcrumb {
 
 function toRoutePlaceholder(rawUrl: string): string {
   return `/[route:${toRouteName(rawUrl)}]`;
+}
+
+/**
+ * `transaction` は `GET /view/x.md`（サーバー、HTTP メソッド付き）と `/view/x.md`（クライアント）の
+ * 2形式で来る。メソッドは残し、パス部分だけをルート名に丸める。Sentry が `/view/[path]` に
+ * parameterize 済みの値も `toRouteName` で `view-sheet` に落ちるので、区別せず同じ処理を通す。
+ */
+function scrubTransactionName(transaction: string): string {
+  const spaceAt = transaction.indexOf(' ');
+  if (spaceAt === -1) return toRoutePlaceholder(transaction);
+  return `${transaction.slice(0, spaceAt)} ${toRoutePlaceholder(transaction.slice(spaceAt + 1))}`;
 }
 
 const ROUTE_LIKE_KEYS = new Set(['to', 'from', 'url']);
@@ -166,6 +186,10 @@ export function scrubSentryEvent(event: ScrubbableSentryEvent): ScrubbableSentry
 
   if (typeof next.message === 'string') {
     next.message = redactFreeText(next.message);
+  }
+
+  if (typeof next.transaction === 'string') {
+    next.transaction = scrubTransactionName(next.transaction);
   }
 
   if (next.request) {

--- a/src/lib/observability/scrub.ts
+++ b/src/lib/observability/scrub.ts
@@ -85,23 +85,21 @@ export interface ScrubbableSentryEvent {
     cookies?: unknown;
     headers?: unknown;
   };
-  contexts?: {
-    nextjs?: { request_path?: string; [key: string]: unknown };
-    [key: string]: unknown;
-  };
+  // 実 Sentry の Contexts 型は「全プロパティ任意の辞書型」で `nextjs` を静的に知らないため、
+  // 構造的部分型としてそのまま渡すと TS の weak-type チェックに弾かれる。辞書として受け、
+  // 中の読み書きだけ nextjs の形を仮定する（scrubSentryEvent 内でのみ行う）。
+  contexts?: Record<string, unknown>;
   exception?: {
-    values?: Array<{ value?: string; [key: string]: unknown }>;
+    values?: Array<{ value?: string }>;
   };
   user?: unknown;
   breadcrumbs?: ScrubbableBreadcrumb[];
-  [key: string]: unknown;
 }
 
 export interface ScrubbableBreadcrumb {
   category?: string;
   message?: string;
   data?: Record<string, unknown>;
-  [key: string]: unknown;
 }
 
 function toRoutePlaceholder(rawUrl: string): string {
@@ -113,8 +111,8 @@ function toRoutePlaceholder(rawUrl: string): string {
  * breadcrumb（history の to/from）の両方に効く最終防衛line。個別の integration 設定
  * （httpIntegration({breadcrumbs:false}) 等）が主防御で、これは二重化。
  */
-export function scrubBreadcrumb<T extends ScrubbableBreadcrumb>(breadcrumb: T): T {
-  const next: T = { ...breadcrumb };
+export function scrubBreadcrumb(breadcrumb: ScrubbableBreadcrumb): ScrubbableBreadcrumb {
+  const next: ScrubbableBreadcrumb = { ...breadcrumb };
   if (typeof next.message === 'string') {
     next.message = redactFreeText(next.message);
   }
@@ -140,8 +138,8 @@ export function scrubBreadcrumb<T extends ScrubbableBreadcrumb>(breadcrumb: T): 
  * PII の最終防衛line。個々の integration 設定・breadcrumb 無効化が主防御で、
  * これは「それでも漏れたら」を潰す二重化。request のユーザー識別情報は丸ごと落とす。
  */
-export function scrubSentryEvent<T extends ScrubbableSentryEvent>(event: T): T {
-  const next: T = { ...event };
+export function scrubSentryEvent(event: ScrubbableSentryEvent): ScrubbableSentryEvent {
+  const next: ScrubbableSentryEvent = { ...event };
 
   if (typeof next.message === 'string') {
     next.message = redactFreeText(next.message);
@@ -155,10 +153,11 @@ export function scrubSentryEvent<T extends ScrubbableSentryEvent>(event: T): T {
     };
   }
 
-  if (next.contexts?.nextjs?.request_path) {
+  const nextjsContext = next.contexts?.nextjs as { request_path?: string } | undefined;
+  if (typeof nextjsContext?.request_path === 'string') {
     next.contexts = {
       ...next.contexts,
-      nextjs: { ...next.contexts.nextjs, request_path: toRoutePlaceholder(next.contexts.nextjs.request_path) },
+      nextjs: { ...nextjsContext, request_path: toRoutePlaceholder(nextjsContext.request_path) },
     };
   }
 

--- a/src/lib/observability/sentry-options.client.ts
+++ b/src/lib/observability/sentry-options.client.ts
@@ -1,0 +1,19 @@
+import * as Sentry from '@sentry/nextjs';
+
+import type { SentryIntegration } from './sentry-options';
+
+/**
+ * クライアント専用ファイル。`Sentry.breadcrumbsIntegration` はブラウザビルドの輸出であり、
+ * サーバービルドには存在しない。`sentry.server.config.ts` から誤って import すると
+ * Turbopack のビルドが壊れるので、client 専用ファイルとして分離してある。
+ *
+ * クライアントの `history` breadcrumb（既定 true）は `data.to`/`data.from` に
+ * `/view/技術スキルシート.md` のような実パスをそのまま記録する（罠4）。console・dom も切る。
+ * fetch/xhr/sentry は残す — その `data.url` は `beforeBreadcrumb` の `scrubBreadcrumb` が
+ * 二重化として route enum に丸めるので、直前の通信が分かる情報としての価値は保ちつつ安全。
+ */
+export function buildClientIntegrations(defaultIntegrations: SentryIntegration[]): SentryIntegration[] {
+  return defaultIntegrations.map((i) =>
+    i.name === 'Breadcrumbs' ? Sentry.breadcrumbsIntegration({ console: false, dom: false, history: false }) : i,
+  );
+}

--- a/src/lib/observability/sentry-options.server.ts
+++ b/src/lib/observability/sentry-options.server.ts
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/nextjs';
+
+import type { SentryIntegration } from './sentry-options';
+
+/**
+ * サーバー専用ファイル。`Sentry.httpIntegration` は @sentry/node の輸出であり、
+ * クライアントビルドには存在しない。この関数を `instrumentation-client.ts` から
+ * 誤って import すると Turbopack のビルドが壊れる（実際に一度壊した）ので、
+ * server 専用ファイルとして分離してある。
+ *
+ * サーバー側 console→breadcrumb は `breadcrumbsIntegration`（ブラウザ専用）とは別の
+ * default-on integration（`consoleIntegration`、名前は `"Console"`）。ここで名前指定して外す。
+ * `httpIntegration` の breadcrumbs は既定 true — GitHub API の URL（ファイル名を含む）が
+ * そのまま breadcrumb に乗るのを防ぐため false にする（罠3）。
+ */
+export function buildServerIntegrations(defaultIntegrations: SentryIntegration[]): SentryIntegration[] {
+  return defaultIntegrations
+    .filter((i) => i.name !== 'Console')
+    .map((i) => (i.name === 'Http' ? Sentry.httpIntegration({ breadcrumbs: false }) : i));
+}

--- a/src/lib/observability/sentry-options.ts
+++ b/src/lib/observability/sentry-options.ts
@@ -1,0 +1,46 @@
+import type * as Sentry from '@sentry/nextjs';
+
+import { scrubBreadcrumb, scrubSentryEvent } from './scrub';
+
+/**
+ * '@sentry/nextjs' は `Integration` 型を独立してエクスポートしていないため、
+ * 唯一それを返す公開 API（getDefaultIntegrations）の戻り値から要素型を取り出す。
+ * `getDefaultIntegrations` はクライアント・サーバー双方のビルドに存在するので、
+ * この型エイリアスは（型のみの参照なので）どちらのバンドルからでも安全に import できる。
+ */
+export type SentryIntegration = ReturnType<typeof Sentry.getDefaultIntegrations>[number];
+
+/**
+ * プロセス（サーバーレスインスタンス）あたりの送信上限。設定不備を `onRequestError` の
+ * ラップ側で落としてもなお何かの理由で連投が起きた場合の、最後のサーキットブレーカー。
+ * コールドスタートごとにリセットされる（モジュールスコープの変数なので）。
+ */
+const MAX_EVENTS_PER_PROCESS = 20;
+let sentEventCount = 0;
+
+/**
+ * サーバー用・クライアント用どちらの `Sentry.init` にも共通で渡すオプション。
+ * ランタイム固有の named integration（httpIntegration / breadcrumbsIntegration）は
+ * ここに置かない — 置いた瞬間、この値をクライアントバンドルへも取り込む都合上、
+ * Turbopack がクライアントビルドに存在しないサーバー専用 export を要求してビルドが壊れる
+ * （実際に一度壊してから ./sentry-options.server.ts / ./sentry-options.client.ts に分けた）。
+ *
+ * `dataCollection` オプションのキーは、ここにも各ランタイムの `Sentry.init` にも
+ * **絶対に書かない**。公式ドキュメント曰く、未指定のカテゴリは指定した瞬間により許可的な既定へ
+ * 倒れる（`{}` を渡すだけで cookie・user・IP・request body が軒並み ON になる）。
+ * ここは「書かないこと」自体が設計なので、キーを書き足したくなったら先に理由を書くこと。
+ */
+export const SHARED_SENTRY_OPTIONS = {
+  tracesSampleRate: 0,
+  beforeBreadcrumb(breadcrumb: Sentry.Breadcrumb) {
+    // scrub.ts は SDK 型に依存しない構造的部分型で動く（テストが SDK 無しで完結する）ため、
+    // ここで実 SDK 型との境界を1回だけ明示的にまたぐ。timestamp/level/type 等
+    // ScrubbableBreadcrumb が知らないフィールドは元の値のまま残す。
+    return { ...breadcrumb, ...scrubBreadcrumb(breadcrumb) } as Sentry.Breadcrumb;
+  },
+  beforeSend(event: Sentry.ErrorEvent) {
+    if (sentEventCount >= MAX_EVENTS_PER_PROCESS) return null;
+    sentEventCount += 1;
+    return { ...event, ...scrubSentryEvent(event) } as Sentry.ErrorEvent;
+  },
+} satisfies Partial<Sentry.NodeOptions & Sentry.BrowserOptions>;

--- a/src/server/auth-gate.ts
+++ b/src/server/auth-gate.ts
@@ -2,6 +2,7 @@ import { headers } from 'next/headers';
 import { cache } from 'react';
 
 import { getAuth } from '@/lib/auth';
+import { reportDegradation } from '@/server/report-error';
 
 /**
  * 編集者（オーナー）認可の単一チェックポイント（DAL）。
@@ -34,6 +35,9 @@ async function resolveEditorUserId(requestHeaders?: Headers): Promise<string | n
     return userId;
   } catch (err) {
     console.error('Better Auth session check failed:', err);
+    // セッション確認が例外で落ちると、本物のオーナーも黙って編集者から降格する
+    // （fail-safe だが気づけないと「保存できない」で問い合わせが来るまで放置される）。
+    reportDegradation('Better Auth session check failed; editor status downgraded', { scope: 'auth-gate' });
     return null;
   }
 }

--- a/src/server/known-config-error.test.ts
+++ b/src/server/known-config-error.test.ts
@@ -1,0 +1,39 @@
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+
+import { MISSING_SERVER_ENV_PREFIX } from '@/lib/env';
+
+import {
+  isKnownConfigError,
+  REVALIDATE_SECRET_MISSING_MESSAGE,
+  SESSION_SECRET_MISSING_MESSAGE,
+  VIEWER_AUTH_NOT_CONFIGURED_MESSAGE,
+} from './known-config-error';
+
+describe('isKnownConfigError', () => {
+  it.each([
+    ['assertServerEnv の欠落', new Error(`${MISSING_SERVER_ENV_PREFIX}: DATABASE_URL。`)],
+    ['classifyConfigError が拾う DB 未設定', new Error('DATABASE_URL is not set')],
+    ['classifyConfigError が拾う GitHub 未設定', new Error('Missing required GitHub env vars: GITHUB_TOKEN')],
+    ['SESSION_SECRET 未設定', new Error(SESSION_SECRET_MISSING_MESSAGE)],
+    [
+      'VIEWER_CODE 未設定（TRPCError 経由）',
+      new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: VIEWER_AUTH_NOT_CONFIGURED_MESSAGE }),
+    ],
+    [
+      'REVALIDATE_SECRET 未設定（TRPCError 経由）',
+      new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: REVALIDATE_SECRET_MISSING_MESSAGE }),
+    ],
+  ])('%s は設定不備として扱う', (_label, error) => {
+    expect(isKnownConfigError(error)).toBe(true);
+  });
+
+  it('未知のエラーは設定不備ではない', () => {
+    expect(isKnownConfigError(new Error('something unexpected'))).toBe(false);
+  });
+
+  it('Error でない値は設定不備ではない', () => {
+    expect(isKnownConfigError('SESSION_SECRET is not set')).toBe(false);
+    expect(isKnownConfigError(undefined)).toBe(false);
+  });
+});

--- a/src/server/known-config-error.ts
+++ b/src/server/known-config-error.ts
@@ -1,0 +1,41 @@
+import { MISSING_SERVER_ENV_PREFIX } from '@/lib/env';
+import { classifyConfigError } from '@/util/is-config-error';
+
+/**
+ * 「待っても直らない設定不備」の判定を1か所に集める。
+ *
+ * `instrumentation.ts` の `onRequestError` と `src/server/report-error.ts` が同じ判定を持っていたが、
+ * 2か所に分かれていたため片方だけが SESSION_SECRET / VIEWER_CODE / REVALIDATE_SECRET の文言を
+ * 知る状態になっていた（レビュー指摘）。次の設定不備文言を足すときは、このファイルだけを直す。
+ *
+ * 設定不備を Sentry へ送らない理由: 環境変数が1つ欠けた状態で本番にクローラが来ると
+ * 全リクエストが同じ原因で落ち続け、5,000 件/月の無料枠を1日で溶かす。対処は環境変数の
+ * 設定であって障害対応ではないので、`app/global-error.tsx` が warning レベルで1回だけ拾う。
+ */
+
+// route handler は `assertServerEnv()` を通さないため、VIEWER_CODE / SESSION_SECRET の欠落は
+// auth.login やセッション署名の中で初めて個別のエラーとして顕在化する。文言の正本はここに置き、
+// 投げる側（session.ts / trpc/router/auth.ts / trpc/router/maintenance.ts）がここから import する
+// （逆向きに import すると report-error.ts → auth.ts → viewer-rate-limit.ts → report-error.ts の循環になる）。
+export const SESSION_SECRET_MISSING_MESSAGE = 'SESSION_SECRET is not set';
+export const VIEWER_AUTH_NOT_CONFIGURED_MESSAGE = 'viewer authentication is not configured';
+// `maintenance.revalidate` が投げる、GitHub/DB 系とは別系統の「任意環境変数が未設定」エラー。
+// REVALIDATE_SECRET は REQUIRED_SERVER_ENV に無い任意変数なので env.ts 側の判定を素通りする。
+export const REVALIDATE_SECRET_MISSING_MESSAGE = 'REVALIDATE_SECRET is not configured';
+
+const KNOWN_CONFIG_ERROR_MESSAGES: ReadonlySet<string> = new Set([
+  REVALIDATE_SECRET_MISSING_MESSAGE,
+  SESSION_SECRET_MISSING_MESSAGE,
+  VIEWER_AUTH_NOT_CONFIGURED_MESSAGE,
+]);
+
+/**
+ * `classifyConfigError()`（GitHub/DB 系）、`assertServerEnv()` の欠落メッセージ、
+ * 個別 route の設定不備メッセージの3系統すべてを見る。片方だけだと env 起因の
+ * 全リクエスト失敗が無料枠を溶かす。
+ */
+export function isKnownConfigError(error: unknown): boolean {
+  if (classifyConfigError(error) !== null) return true;
+  if (!(error instanceof Error)) return false;
+  return error.message.startsWith(MISSING_SERVER_ENV_PREFIX) || KNOWN_CONFIG_ERROR_MESSAGES.has(error.message);
+}

--- a/src/server/report-error.test.ts
+++ b/src/server/report-error.test.ts
@@ -1,10 +1,13 @@
 import { TRPCError } from '@trpc/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import * as config from '@/lib/observability/config';
+
 import { reportDegradation, reportTRPCError } from './report-error';
 
 const captureMessageMock = vi.fn();
-vi.mock('@sentry/nextjs', () => ({ captureMessage: captureMessageMock, captureException: vi.fn() }));
+const captureExceptionMock = vi.fn();
+vi.mock('@sentry/nextjs', () => ({ captureMessage: captureMessageMock, captureException: captureExceptionMock }));
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -49,6 +52,50 @@ describe('reportTRPCError', () => {
     const error = new Error('unexpected');
     reportTRPCError({ error, scope: 'test', logArgs: ['test: unexpected error:', error] });
     expect(spy).toHaveBeenCalledWith('test: unexpected error:', error);
+  });
+});
+
+describe('reportTRPCError — Sentry 送信の抑制（isSentryEnabled をモックして検証）', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    captureExceptionMock.mockClear();
+  });
+
+  it('VIEWER_CODE 未設定（auth.login）は Sentry へ送らない', async () => {
+    vi.spyOn(config, 'isSentryEnabled').mockReturnValue(true);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'viewer authentication is not configured' });
+    reportTRPCError({ error, scope: 'test', logArgs: ['x', error] });
+    await tick();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('SESSION_SECRET 未設定は Sentry へ送らない', async () => {
+    vi.spyOn(config, 'isSentryEnabled').mockReturnValue(true);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'SESSION_SECRET is not set' });
+    reportTRPCError({ error, scope: 'test', logArgs: ['x', error] });
+    await tick();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('TOO_MANY_REQUESTS はログするが Sentry へは送らない（攻撃者による無料枠消費を防ぐ）', async () => {
+    vi.spyOn(config, 'isSentryEnabled').mockReturnValue(true);
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new TRPCError({ code: 'TOO_MANY_REQUESTS', message: 'too many requests' });
+    reportTRPCError({ error, scope: 'test', logArgs: ['x', error] });
+    await tick();
+    expect(spy).toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('未知のエラーは通常どおり Sentry へ送る（抑制条件を広げすぎていないかの回帰防止）', async () => {
+    vi.spyOn(config, 'isSentryEnabled').mockReturnValue(true);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('something unexpected');
+    reportTRPCError({ error, scope: 'test', logArgs: ['x', error] });
+    await tick();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/server/report-error.test.ts
+++ b/src/server/report-error.test.ts
@@ -1,0 +1,54 @@
+import { TRPCError } from '@trpc/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { reportDegradation, reportTRPCError } from './report-error';
+
+/**
+ * `isSentryEnabled()` は NODE_ENV=test で常に false（config.test.ts で確認済み）なので、
+ * ここでは「Sentry へ実際に送るかどうか」ではなく「console.error を呼ぶ/呼ばない」だけを見る。
+ * Sentry 側の実送信保証は動作確認手順（DevTools 目視・手順4）で行う — 単体テストでは
+ * `NEXT_PUBLIC_*` のビルド時インライン化を再現できないため代替できない。
+ */
+describe('reportTRPCError', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(['UNAUTHORIZED', 'NOT_FOUND', 'CONFLICT'])('%s は想定内なので console.error を呼ばない', (code) => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    reportTRPCError({
+      error: new TRPCError({ code: code as never, message: 'x' }),
+      scope: 'test',
+      logArgs: ['test: unexpected error:', new Error('x')],
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('FORBIDDEN は CSRF 試行の唯一のシグナルなので console.error を呼ぶ', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new TRPCError({ code: 'FORBIDDEN', message: 'cross-origin' });
+    reportTRPCError({ error, scope: 'test', logArgs: ['test: unexpected error:', error] });
+    expect(spy).toHaveBeenCalledWith('test: unexpected error:', error);
+  });
+
+  it('logArgs をそのまま console.error に渡す（既存ログ文言を一字一句維持する）', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('boom');
+    reportTRPCError({ error, scope: 'test', logArgs: ['POST /api/auth: unexpected error:', error] });
+    expect(spy).toHaveBeenCalledWith('POST /api/auth: unexpected error:', error);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('TRPCError でない例外は常にログする', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('unexpected');
+    reportTRPCError({ error, scope: 'test', logArgs: ['test: unexpected error:', error] });
+    expect(spy).toHaveBeenCalledWith('test: unexpected error:', error);
+  });
+});
+
+describe('reportDegradation', () => {
+  it('NODE_ENV=test では Sentry 無効なので例外を投げず何もしない', () => {
+    expect(() => reportDegradation('degraded', { scope: 'test' })).not.toThrow();
+  });
+});

--- a/src/server/report-error.test.ts
+++ b/src/server/report-error.test.ts
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { reportDegradation, reportTRPCError } from './report-error';
 
+const captureMessageMock = vi.fn();
+vi.mock('@sentry/nextjs', () => ({ captureMessage: captureMessageMock, captureException: vi.fn() }));
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 /**
  * `isSentryEnabled()` は NODE_ENV=test で常に false（config.test.ts で確認済み）なので、
  * ここでは「Sentry へ実際に送るかどうか」ではなく「console.error を呼ぶ/呼ばない」だけを見る。
@@ -48,7 +53,13 @@ describe('reportTRPCError', () => {
 });
 
 describe('reportDegradation', () => {
-  it('NODE_ENV=test では Sentry 無効なので例外を投げず何もしない', () => {
-    expect(() => reportDegradation('degraded', { scope: 'test' })).not.toThrow();
+  afterEach(() => {
+    captureMessageMock.mockClear();
+  });
+
+  it('NODE_ENV=test では Sentry 無効なので通信も発生しない', async () => {
+    reportDegradation('degraded', { scope: 'test' });
+    await tick();
+    expect(captureMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/src/server/report-error.ts
+++ b/src/server/report-error.ts
@@ -1,10 +1,40 @@
 import { TRPCError } from '@trpc/server';
+import { after } from 'next/server';
 
 import { MISSING_SERVER_ENV_PREFIX } from '@/lib/env';
 import { isSentryEnabled } from '@/lib/observability/config';
 import { classifyConfigError } from '@/util/is-config-error';
 
+import { SESSION_SECRET_MISSING_MESSAGE } from './session';
 import { shouldLogTRPCError } from './trpc/log-error';
+
+// src/server/trpc/router/auth.ts の VIEWER_AUTH_NOT_CONFIGURED_MESSAGE と同じ文字列。
+// auth.ts はレート制限（viewer-rate-limit.ts）経由でこのファイルを import するため、
+// 直接 import すると循環参照になる（レビュー指摘対応で文字列比較のみ追加する形にした）。
+// 変更する場合は両方を必ず一緒に直すこと。
+const VIEWER_AUTH_NOT_CONFIGURED_MESSAGE = 'viewer authentication is not configured';
+
+// tRPC のレート制限応答（総当たり防御が意図通り機能している状態）。攻撃者がロック後も
+// 送り続けるだけで Sentry の無料枠（20 件）を溶かせてしまうため、例外送信からは除外する
+// （レビュー指摘）。console.error 自体は shouldLogTRPCError 側の判定で維持し、
+// サーバー側の攻撃ログは失わない。
+const RATE_LIMIT_CODES: ReadonlySet<string> = new Set(['TOO_MANY_REQUESTS']);
+
+/**
+ * Sentry 送信だけをリクエストの生存期間内に留める。`after()` はレスポンス返却後も
+ * この Promise が解決するまでサーバーレス実行環境を維持するため、応答直後に
+ * インスタンスが凍結/終了して検出コードが未実行のまま送信が消える事故を防ぐ
+ * （レビュー指摘: 元の fire-and-forget では captureException が呼ばれる前に切れうる）。
+ * リクエストスコープ外（単体テスト等）で呼ばれた場合は `after()`自体が同期 throw するため、
+ * 元の fire-and-forget にフォールバックする。
+ */
+function reportAsync(work: () => Promise<void>): void {
+  try {
+    after(work);
+  } catch {
+    void work();
+  }
+}
 
 /**
  * `@sentry/nextjs` は動的 import にする（トップレベル import しない）。
@@ -31,6 +61,16 @@ async function loadSentry() {
 // 判定を素通りする）。
 const REVALIDATE_SECRET_MISSING_MESSAGE = 'REVALIDATE_SECRET is not configured';
 
+// route handler は assertServerEnv() を通さないため、VIEWER_CODE/SESSION_SECRET 欠落は
+// 個別のエラーとして auth.login / セッション署名の中で初めて顕在化する。ここで見ないと
+// 該当変数が1つ欠けた状態で /api/trpc/auth.login への通常アクセスのたびに Sentry へ送られる
+// （レビュー指摘）。
+const KNOWN_CONFIG_ERROR_MESSAGES: ReadonlySet<string> = new Set([
+  REVALIDATE_SECRET_MISSING_MESSAGE,
+  SESSION_SECRET_MISSING_MESSAGE,
+  VIEWER_AUTH_NOT_CONFIGURED_MESSAGE,
+]);
+
 /**
  * 「待っても直らない設定不備」の判定。`classifyConfigError()`（GitHub/DB系）と
  * `assertServerEnv()` の欠落メッセージ（別の文言体系）の両方を見る必要がある
@@ -39,7 +79,7 @@ const REVALIDATE_SECRET_MISSING_MESSAGE = 'REVALIDATE_SECRET is not configured';
 function isKnownConfigError(error: unknown): boolean {
   if (classifyConfigError(error) !== null) return true;
   if (!(error instanceof Error)) return false;
-  return error.message.startsWith(MISSING_SERVER_ENV_PREFIX) || error.message === REVALIDATE_SECRET_MISSING_MESSAGE;
+  return error.message.startsWith(MISSING_SERVER_ENV_PREFIX) || KNOWN_CONFIG_ERROR_MESSAGES.has(error.message);
 }
 
 /**
@@ -59,12 +99,14 @@ export function reportTRPCError(options: {
 
   console.error(...options.logArgs);
 
-  if (isSentryEnabled() && !isKnownConfigError(options.error)) {
-    void loadSentry()
-      .then((Sentry) => {
-        Sentry.captureException(options.error, { tags: { scope: options.scope } });
-      })
-      .catch(() => undefined);
+  if (isSentryEnabled() && !isKnownConfigError(options.error) && !RATE_LIMIT_CODES.has(code)) {
+    reportAsync(() =>
+      loadSentry()
+        .then((Sentry) => {
+          Sentry.captureException(options.error, { tags: { scope: options.scope } });
+        })
+        .catch(() => undefined),
+    );
   }
 }
 
@@ -86,9 +128,11 @@ export function reportDegradation(message: string, context: { scope: string }): 
   const last = degradationLastReportedAt.get(key);
   if (last !== undefined && now - last < DEGRADATION_COOLDOWN_MS) return;
   degradationLastReportedAt.set(key, now);
-  void loadSentry()
-    .then((Sentry) => {
-      Sentry.captureMessage(message, { level: 'warning', tags: { scope: context.scope } });
-    })
-    .catch(() => undefined);
+  reportAsync(() =>
+    loadSentry()
+      .then((Sentry) => {
+        Sentry.captureMessage(message, { level: 'warning', tags: { scope: context.scope } });
+      })
+      .catch(() => undefined),
+  );
 }

--- a/src/server/report-error.ts
+++ b/src/server/report-error.ts
@@ -1,18 +1,10 @@
 import { TRPCError } from '@trpc/server';
 import { after } from 'next/server';
 
-import { MISSING_SERVER_ENV_PREFIX } from '@/lib/env';
 import { isSentryEnabled } from '@/lib/observability/config';
-import { classifyConfigError } from '@/util/is-config-error';
 
-import { SESSION_SECRET_MISSING_MESSAGE } from './session';
+import { isKnownConfigError } from './known-config-error';
 import { shouldLogTRPCError } from './trpc/log-error';
-
-// src/server/trpc/router/auth.ts の VIEWER_AUTH_NOT_CONFIGURED_MESSAGE と同じ文字列。
-// auth.ts はレート制限（viewer-rate-limit.ts）経由でこのファイルを import するため、
-// 直接 import すると循環参照になる（レビュー指摘対応で文字列比較のみ追加する形にした）。
-// 変更する場合は両方を必ず一緒に直すこと。
-const VIEWER_AUTH_NOT_CONFIGURED_MESSAGE = 'viewer authentication is not configured';
 
 // tRPC のレート制限応答（総当たり防御が意図通り機能している状態）。攻撃者がロック後も
 // 送り続けるだけで Sentry の無料枠（20 件）を溶かせてしまうため、例外送信からは除外する
@@ -54,40 +46,11 @@ async function loadSentry() {
   return import('@sentry/nextjs');
 }
 
-// `maintenance.revalidate` が投げる、GitHub/DB 系とは別系統の「任意環境変数が未設定」エラー。
-// `classifyConfigError()` と `MISSING_SERVER_ENV_PREFIX` のどちらの文言にもマッチしないため、
-// これを個別に見ないと /api/revalidate への誤 secret での呼び出しのたびに Sentry へ送られ続ける
-// （レビュー指摘: REVALIDATE_SECRET は REQUIRED_SERVER_ENV に無い任意変数なので env.ts 側の
-// 判定を素通りする）。
-const REVALIDATE_SECRET_MISSING_MESSAGE = 'REVALIDATE_SECRET is not configured';
-
-// route handler は assertServerEnv() を通さないため、VIEWER_CODE/SESSION_SECRET 欠落は
-// 個別のエラーとして auth.login / セッション署名の中で初めて顕在化する。ここで見ないと
-// 該当変数が1つ欠けた状態で /api/trpc/auth.login への通常アクセスのたびに Sentry へ送られる
-// （レビュー指摘）。
-const KNOWN_CONFIG_ERROR_MESSAGES: ReadonlySet<string> = new Set([
-  REVALIDATE_SECRET_MISSING_MESSAGE,
-  SESSION_SECRET_MISSING_MESSAGE,
-  VIEWER_AUTH_NOT_CONFIGURED_MESSAGE,
-]);
-
-/**
- * 「待っても直らない設定不備」の判定。`classifyConfigError()`（GitHub/DB系）と
- * `assertServerEnv()` の欠落メッセージ（別の文言体系）の両方を見る必要がある
- * （片方だけだと env 起因の全リクエスト失敗が無料枠を1日で溶かす）。
- */
-function isKnownConfigError(error: unknown): boolean {
-  if (classifyConfigError(error) !== null) return true;
-  if (!(error instanceof Error)) return false;
-  return error.message.startsWith(MISSING_SERVER_ENV_PREFIX) || KNOWN_CONFIG_ERROR_MESSAGES.has(error.message);
-}
-
 /**
  * tRPC の想定外エラーを、ログと Sentry 送信の同じ分岐から出す（ズレようがない形にする）。
  * `logArgs` は既存のログ行を一字一句そのまま維持するために呼び出し側が組み立てる
  * （3ファイルが異なる文言で厳密比較するテストを持つため、ここで文言を統一しない）。
- * 設定不備は報告しない — 環境変数が1つ欠けた状態で全リクエストが落ちると Sentry の
- * 無料枠を溶かす。設定不備自体は `app/global-error.tsx` が warning レベルで別途拾う。
+ * 設定不備は報告しない（判定は `./known-config-error.ts`。`instrumentation.ts` と同じ関数を使う）。
  */
 export function reportTRPCError(options: {
   error: unknown;

--- a/src/server/report-error.ts
+++ b/src/server/report-error.ts
@@ -1,0 +1,70 @@
+import { TRPCError } from '@trpc/server';
+
+import { MISSING_SERVER_ENV_PREFIX } from '@/lib/env';
+import { isSentryEnabled } from '@/lib/observability/config';
+import { classifyConfigError } from '@/util/is-config-error';
+
+import { shouldLogTRPCError } from './trpc/log-error';
+
+/**
+ * `@sentry/nextjs` は動的 import にする（トップレベル import しない）。
+ *
+ * 理由は2つ:
+ * 1. `isSentryEnabled()` が false（キー未設定・ローカル・テスト）のときに実 SDK を
+ *    一切ロードしない。実測で、トップレベル import すると vitest（jsdom）配下で
+ *    `@sentry/server-utils` 経由の `@apm-js-collab/code-transformer-bundler-plugins` が
+ *    `import.meta.url` を file スキームと決め打ちして即座に throw し、
+ *    `app/api/**` の既存テストが軒並み壊れた（Vite の変換後 URL は file スキームではない）。
+ * 2. バンドラ層をまたいで Sentry ハンドルを共有できるかは実証済みでない
+ *    （`src/lib/observability/capture.ts` の globalThis レジストリに頼らない理由も同じ）。
+ *    SDK 自身が自前のグローバルキャリアでクライアントを解決するため、ここでは
+ *    `@sentry/nextjs` を直接（ただし動的に） import する。
+ */
+async function loadSentry() {
+  return import('@sentry/nextjs');
+}
+
+/**
+ * 「待っても直らない設定不備」の判定。`classifyConfigError()`（GitHub/DB系）と
+ * `assertServerEnv()` の欠落メッセージ（別の文言体系）の両方を見る必要がある
+ * （片方だけだと env 起因の全リクエスト失敗が無料枠を1日で溶かす）。
+ */
+function isKnownConfigError(error: unknown): boolean {
+  if (classifyConfigError(error) !== null) return true;
+  return error instanceof Error && error.message.startsWith(MISSING_SERVER_ENV_PREFIX);
+}
+
+/**
+ * tRPC の想定外エラーを、ログと Sentry 送信の同じ分岐から出す（ズレようがない形にする）。
+ * `logArgs` は既存のログ行を一字一句そのまま維持するために呼び出し側が組み立てる
+ * （3ファイルが異なる文言で厳密比較するテストを持つため、ここで文言を統一しない）。
+ * 設定不備は報告しない — 環境変数が1つ欠けた状態で全リクエストが落ちると Sentry の
+ * 無料枠を溶かす。設定不備自体は `app/global-error.tsx` が warning レベルで別途拾う。
+ */
+export function reportTRPCError(options: {
+  error: unknown;
+  scope: string;
+  logArgs: readonly [message: string, error: unknown];
+}): void {
+  const code = options.error instanceof TRPCError ? options.error.code : 'INTERNAL_SERVER_ERROR';
+  if (!shouldLogTRPCError(code)) return;
+
+  console.error(...options.logArgs);
+
+  if (isSentryEnabled() && !isKnownConfigError(options.error)) {
+    void loadSentry().then((Sentry) => {
+      Sentry.captureException(options.error, { tags: { scope: options.scope } });
+    });
+  }
+}
+
+/**
+ * セキュリティの劣化（編集者が黙って降格・総当たり防御が fail open）を warning レベルで送る。
+ * バグ報告ではなく「守りが弱くなっている」信号なので、error レベルにはしない。
+ */
+export function reportDegradation(message: string, context: { scope: string }): void {
+  if (!isSentryEnabled()) return;
+  void loadSentry().then((Sentry) => {
+    Sentry.captureMessage(message, { level: 'warning', tags: { scope: context.scope } });
+  });
+}

--- a/src/server/report-error.ts
+++ b/src/server/report-error.ts
@@ -24,6 +24,13 @@ async function loadSentry() {
   return import('@sentry/nextjs');
 }
 
+// `maintenance.revalidate` が投げる、GitHub/DB 系とは別系統の「任意環境変数が未設定」エラー。
+// `classifyConfigError()` と `MISSING_SERVER_ENV_PREFIX` のどちらの文言にもマッチしないため、
+// これを個別に見ないと /api/revalidate への誤 secret での呼び出しのたびに Sentry へ送られ続ける
+// （レビュー指摘: REVALIDATE_SECRET は REQUIRED_SERVER_ENV に無い任意変数なので env.ts 側の
+// 判定を素通りする）。
+const REVALIDATE_SECRET_MISSING_MESSAGE = 'REVALIDATE_SECRET is not configured';
+
 /**
  * 「待っても直らない設定不備」の判定。`classifyConfigError()`（GitHub/DB系）と
  * `assertServerEnv()` の欠落メッセージ（別の文言体系）の両方を見る必要がある
@@ -31,7 +38,8 @@ async function loadSentry() {
  */
 function isKnownConfigError(error: unknown): boolean {
   if (classifyConfigError(error) !== null) return true;
-  return error instanceof Error && error.message.startsWith(MISSING_SERVER_ENV_PREFIX);
+  if (!(error instanceof Error)) return false;
+  return error.message.startsWith(MISSING_SERVER_ENV_PREFIX) || error.message === REVALIDATE_SECRET_MISSING_MESSAGE;
 }
 
 /**
@@ -52,19 +60,35 @@ export function reportTRPCError(options: {
   console.error(...options.logArgs);
 
   if (isSentryEnabled() && !isKnownConfigError(options.error)) {
-    void loadSentry().then((Sentry) => {
-      Sentry.captureException(options.error, { tags: { scope: options.scope } });
-    });
+    void loadSentry()
+      .then((Sentry) => {
+        Sentry.captureException(options.error, { tags: { scope: options.scope } });
+      })
+      .catch(() => undefined);
   }
 }
+
+// scope+message のペアごとに、直近いつ送ったか。DB 障害時の劣化通知は「起きた」の1回だけで
+// 十分で、直りもしない状態を毎リクエスト送ると障害中ほど Sentry の無料枠を早く溶かす
+// （レビュー指摘: viewer-rate-limit.ts の check/reserve/clear がリクエストごとに呼ぶ）。
+const degradationLastReportedAt = new Map<string, number>();
+const DEGRADATION_COOLDOWN_MS = 5 * 60 * 1000;
 
 /**
  * セキュリティの劣化（編集者が黙って降格・総当たり防御が fail open）を warning レベルで送る。
  * バグ報告ではなく「守りが弱くなっている」信号なので、error レベルにはしない。
+ * 同じ scope+message は `DEGRADATION_COOLDOWN_MS` の間に1回しか送らない。
  */
 export function reportDegradation(message: string, context: { scope: string }): void {
   if (!isSentryEnabled()) return;
-  void loadSentry().then((Sentry) => {
-    Sentry.captureMessage(message, { level: 'warning', tags: { scope: context.scope } });
-  });
+  const key = `${context.scope}:${message}`;
+  const now = Date.now();
+  const last = degradationLastReportedAt.get(key);
+  if (last !== undefined && now - last < DEGRADATION_COOLDOWN_MS) return;
+  degradationLastReportedAt.set(key, now);
+  void loadSentry()
+    .then((Sentry) => {
+      Sentry.captureMessage(message, { level: 'warning', tags: { scope: context.scope } });
+    })
+    .catch(() => undefined);
 }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -15,9 +15,14 @@ interface SessionPayload {
   exp: number;
 }
 
+// report-error.ts の isKnownConfigError() が「待っても直らない設定不備」として
+// 個別に見分けるために import する（レビュー指摘: 未設定のまま個別に見ないと
+// SESSION_SECRET が1つ欠けた状態で全リクエストが Sentry へ送られ続ける）。
+export const SESSION_SECRET_MISSING_MESSAGE = 'SESSION_SECRET is not set';
+
 function getSecret(): Buffer {
   const secret = process.env.SESSION_SECRET;
-  if (!secret) throw new Error('SESSION_SECRET is not set');
+  if (!secret) throw new Error(SESSION_SECRET_MISSING_MESSAGE);
   return Buffer.from(secret, 'utf-8');
 }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -7,6 +7,8 @@ import 'server-only';
 import { Buffer } from 'node:buffer';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
+import { SESSION_SECRET_MISSING_MESSAGE } from './known-config-error';
+
 const SESSION_DURATION_SECONDS = 7 * 24 * 60 * 60;
 const SESSION_COOKIE_NAME = 'session';
 
@@ -14,11 +16,6 @@ interface SessionPayload {
   iat: number;
   exp: number;
 }
-
-// report-error.ts の isKnownConfigError() が「待っても直らない設定不備」として
-// 個別に見分けるために import する（レビュー指摘: 未設定のまま個別に見ないと
-// SESSION_SECRET が1つ欠けた状態で全リクエストが Sentry へ送られ続ける）。
-export const SESSION_SECRET_MISSING_MESSAGE = 'SESSION_SECRET is not set';
 
 function getSecret(): Buffer {
   const secret = process.env.SESSION_SECRET;

--- a/src/server/trpc/route-error.ts
+++ b/src/server/trpc/route-error.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { NextResponse } from 'next/server';
 
-import { shouldLogTRPCError } from './log-error';
+import { reportTRPCError } from '@/server/report-error';
 
 /** TRPC のコード → 返す HTTP ステータスと本文。ルートごとに違う部分だけを渡す。 */
 export type RouteErrorMap = Partial<Record<TRPCError['code'], { status: number; message: string }>>;
@@ -11,7 +11,8 @@ export type RouteErrorMap = Partial<Record<TRPCError['code'], { status: number; 
  * 「TRPCError → HTTP レスポンス」変換をここに集約する。
  *
  * ログを出す条件（想定内の 4xx は出さない）を各ルートに書き写していたため、
- * 片方だけ直すとログ方針が食い違う。判定は shouldLogTRPCError の1か所に寄せる。
+ * 片方だけ直すとログ方針が食い違う。判定は reportTRPCError（内部で shouldLogTRPCError を使う）
+ * の1か所に寄せる。マップ済みコードの早期 return 順は変えない（変えると 403 が急に流れ出す）。
  */
 export function trpcErrorToResponse(
   error: unknown,
@@ -21,8 +22,6 @@ export function trpcErrorToResponse(
     const mapped = options.map[error.code];
     if (mapped) return NextResponse.json({ error: mapped.message }, { status: mapped.status });
   }
-  if (!(error instanceof TRPCError) || shouldLogTRPCError(error.code)) {
-    console.error(`${options.label}: unexpected error:`, error);
-  }
+  reportTRPCError({ error, scope: options.label, logArgs: [`${options.label}: unexpected error:`, error] });
   return NextResponse.json({ error: options.fallbackMessage }, { status: 500 });
 }

--- a/src/server/trpc/router/auth.ts
+++ b/src/server/trpc/router/auth.ts
@@ -2,13 +2,12 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 import { TRPCError } from '@trpc/server';
 import { clientKeyFromHeaders } from '@/db/viewer-rate-limit';
 
+import { VIEWER_AUTH_NOT_CONFIGURED_MESSAGE } from '@/server/known-config-error';
 import { appendExpiredSessionCookie, appendSessionCookie } from '@/server/session';
 import { clearViewerLoginRateLimit, reserveViewerLoginAttemptBoth } from '@/server/viewer-rate-limit';
 
 import { publicProcedure, router } from '../init';
 import { viewerLoginInputSchema } from '../schema';
-
-export const VIEWER_AUTH_NOT_CONFIGURED_MESSAGE = 'viewer authentication is not configured';
 
 export function isSameOriginRequest(request: Request): boolean {
   const origin = request.headers.get('origin');

--- a/src/server/trpc/router/maintenance.ts
+++ b/src/server/trpc/router/maintenance.ts
@@ -3,6 +3,8 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 import { TRPCError } from '@trpc/server';
 import { revalidateTag } from 'next/cache';
 
+import { REVALIDATE_SECRET_MISSING_MESSAGE } from '@/server/known-config-error';
+
 import { publicProcedure, router } from '../init';
 
 function safeEqual(a: string, b: string): boolean {
@@ -24,7 +26,7 @@ export const maintenanceRouter = router({
   revalidate: publicProcedure.mutation(({ ctx }) => {
     const secret = process.env.REVALIDATE_SECRET;
     if (!secret) {
-      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'REVALIDATE_SECRET is not configured' });
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: REVALIDATE_SECRET_MISSING_MESSAGE });
     }
 
     const provided = getProvidedSecret(ctx.request);

--- a/src/server/viewer-rate-limit.ts
+++ b/src/server/viewer-rate-limit.ts
@@ -8,6 +8,7 @@ import {
   reserveViewerLoginAttempt,
   WINDOW_MS,
 } from '@/db/viewer-rate-limit';
+import { reportDegradation } from '@/server/report-error';
 
 /**
  * 閲覧コードの総当たり対策を、プロセス内カウンタと DB カウンタの二段で行う。
@@ -97,6 +98,11 @@ export async function checkViewerLoginRateLimit(key: string, now = Date.now()): 
   } catch (err) {
     // DB に届かないだけで閲覧を止めない。プロセス内の判定は生かす。
     console.warn('viewer rate limit: DB check failed, falling back to in-process counter', err);
+    // プロセス内カウンタは serverless インスタンスごとに別なので、DB が使えない間は
+    // 総当たり防御が事実上 fail open する（水平スケールで並列試行され放題になる）。
+    reportDegradation('viewer rate limit: DB check failed, brute-force defense degraded to in-process only', {
+      scope: 'viewer-rate-limit',
+    });
     return inMemory;
   }
 }
@@ -116,6 +122,9 @@ export async function reserveViewerLoginAttemptBoth(key: string, now = Date.now(
     return strictest(inMemory, inDb);
   } catch (err) {
     console.warn('viewer rate limit: DB reserve failed, falling back to in-process counter', err);
+    reportDegradation('viewer rate limit: DB reserve failed, brute-force defense degraded to in-process only', {
+      scope: 'viewer-rate-limit',
+    });
     return inMemory;
   }
 }
@@ -126,6 +135,9 @@ export async function clearViewerLoginRateLimit(key: string): Promise<void> {
     await clearViewerLoginFailures(key);
   } catch (err) {
     console.warn('viewer rate limit: DB clear failed', err);
+    // 正しい相手の記録を消し損ねるだけ（fail open ではない）だが、繰り返すとロック済みの
+    // 通知が来ないまま正規ユーザーが締め出され続ける事故になるので観測しておく。
+    reportDegradation('viewer rate limit: DB clear failed after successful login', { scope: 'viewer-rate-limit' });
   }
 }
 


### PR DESCRIPTION

## Issue リンク / Link to Issue

refs #316（コード側の完了条件はこの PR で満たす。Sentry org / PostHog project の作成と Vercel への環境変数登録は局長の手作業なので、#316 はその2項目のために開けたままにする）

### 概要

障害監視のSentryと利用状況計測のPostHogを導入した。

今まで本番のエラーはconsole.errorにしか残らず、誰も気づけなかった。
誰がスキルシートを開いて最後まで読んでPDFを落としたかも分からなかった。

キー未設定時は自動で無効になる。ローカルとCIでは常に無効。

### 見て欲しいポイント

- [ ] 監視の窓口を`src/lib/observability/`に集約した。アプリコードから
      Sentry・PostHogのSDKを直接呼べないよう、lintで機械的に禁止している
      （`scripts/check-telemetry-imports.mjs`）。
- [ ] 個人情報を送らない設計。URLやパスは実際の値ではなく種類（ルート名）に丸めている
      （`src/lib/observability/scrub.ts`）。cookie・header・query stringは
      すべて落とす。`event.transaction`（httpIntegration / browserTracing が入れる生パス）も丸める。
- [ ] 環境変数が1つ欠けた状態で本番にクローラが来ても、無料枠を溶かさない設計にした。
      設定不備の判定は `src/server/known-config-error.ts` の1か所に集約し、
      `instrumentation.ts` と `report-error.ts` が同じ関数を使う。
      詳しい理由は`doc/observability.md`に書いた。

### 見なくてもよいポイント

- [ ] `src/lib/observability/sentry-options.server.ts`と`sentry-options.client.ts`の
      分割。サーバー用とクライアント用でSentryの機能が違うため分けただけで、
      中身は薄い。
- [ ] `pnpm.overrides.browserslist`（e883d81）と `fast-uri`（0d47ab5）は #316 とは別目的で、CI の依存脆弱性監査（Dependency audit）を通すための override。この PR で依存を追加したタイミングで監査に引っかかったため同梱した。

### その他(あれば)

Sentryの組織作成とPostHogのアカウント作成はGoogleログインが必要で、
自動化した操作がbot判定で弾かれたため、局長の手元での作業待ち（#316 に残す）。
キー未設定時に通信ゼロ・`window.posthog`/`window.Sentry` が undefined のままなことはブラウザで確認済み。
キー設定時に実際に届くことの確認は、org 作成後の preview デプロイで行う（#316）。

`.env.enc`（SOPS + age）はローカル開発用の値だけを入れる運用。公開リポジトリの履歴に恒久的に残るため、鍵漏洩時の対処（全値ローテーション）を SETUP.md に明記した。

---

### PR チェックポイント

- [x] タイトルに タスク管理ツール のチケット番号が入っているか（細かい hotfix 以外）
- [ ] 複数の変更が 1 つの PR に入り込んでいないか（browserslist / fast-uri override と SOPS 導入が同梱。理由は上記）
- [x] 開発環境修正(環境変数の追加・ライブラリのインストール等)がある場合は周知しているか（SETUP.md / .env.example / doc/observability.md）
- [ ] AdminXXX or OwnerXXX の修正時、横展開でもう一方の同機能も修正しているか（該当なし）

### レビュー観点

- [x] 想定通りに動作するか
- [x] より良い書き方はないか？
- [x] より良い設計はないか？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数・コンポーネントの粒度は適切か？
- [ ] その他(具体的に記述をしてください)

## Summary by CodeRabbit

- **新機能**
  - Sentry／PostHogによるエラー監視・利用状況計測に対応しました。
  - シート閲覧、表示切り替え、読了度、PDF出力、認証結果を計測できるようになりました。
  - PDF出力の成功・失敗や処理時間、失敗理由を記録します。
  - サーバー・クライアントの障害を状況に応じて報告します。

- **改善**
  - 監視データからURL、個人情報、機密情報を除去します。
  - 設定不備や一時的な障害の重複報告を抑制します。

- **ドキュメント**
  - 監視サービスの設定、暗号化された環境設定、障害対応手順を追加しました。
